### PR TITLE
feat: add reusable Button component with variants (#124)

### DIFF
--- a/frontend/src/components/Button.css
+++ b/frontend/src/components/Button.css
@@ -1,0 +1,94 @@
+.btn {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 0.6em 1.2em;
+  font-size: 1em;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 0.25s, opacity 0.25s, background-color 0.25s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5em;
+}
+
+/* Variants */
+.btn-primary {
+  background-color: #646cff;
+  color: #fff;
+  border-color: #646cff;
+}
+.btn-primary:hover:not(:disabled) {
+  background-color: #535bf2;
+  border-color: #535bf2;
+}
+
+.btn-secondary {
+  background-color: #1a1a1a;
+  color: rgba(255, 255, 255, 0.87);
+  border-color: #646cff;
+}
+.btn-secondary:hover:not(:disabled) {
+  background-color: #2a2a2a;
+}
+
+.btn-danger {
+  background-color: #e53e3e;
+  color: #fff;
+  border-color: #e53e3e;
+}
+.btn-danger:hover:not(:disabled) {
+  background-color: #c53030;
+  border-color: #c53030;
+}
+
+.btn-ghost {
+  background-color: transparent;
+  color: #646cff;
+  border-color: transparent;
+}
+.btn-ghost:hover:not(:disabled) {
+  background-color: rgba(100, 108, 255, 0.1);
+}
+
+/* Sizes */
+.btn-sm {
+  font-size: 0.8em;
+  padding: 0.4em 0.8em;
+}
+
+.btn-md {
+  font-size: 1em;
+  padding: 0.6em 1.2em;
+}
+
+.btn-lg {
+  font-size: 1.2em;
+  padding: 0.8em 1.6em;
+}
+
+/* States */
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-loading {
+  cursor: wait;
+  opacity: 0.8;
+}
+
+/* Spinner */
+.btn-spinner {
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,0 +1,47 @@
+import './Button.css';
+
+type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost';
+type ButtonSize = 'sm' | 'md' | 'lg';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  loading?: boolean;
+  icon?: React.ReactNode;
+  iconPosition?: 'left' | 'right';
+}
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  loading = false,
+  disabled = false,
+  icon,
+  iconPosition = 'left',
+  children,
+  className = '',
+  ...rest
+}: ButtonProps) {
+  const classes = [
+    'btn',
+    `btn-${variant}`,
+    `btn-${size}`,
+    loading ? 'btn-loading' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button
+      className={classes}
+      disabled={disabled || loading}
+      {...rest}
+    >
+      {loading && <span className="btn-spinner" aria-hidden="true" />}
+      {!loading && icon && iconPosition === 'left' && icon}
+      {children}
+      {!loading && icon && iconPosition === 'right' && icon}
+    </button>
+  );
+}


### PR DESCRIPTION
Closes #124

---


Summary
Created a reusable Button component with full variant, size, state, and icon support as specified in the issue.

Changes
- `frontend/src/components/Button.tsx` — Button component with all required features
- `frontend/src/components/Button.css` — Component styles matching existing project CSS conventions

Features implemented
- Variants: primary, secondary, danger, ghost
- Sizes: sm, md, lg
- Loading state with animated spinner
- Disabled state
- Icon support with left or right positioning
- Fully typed with TypeScript — extends native button HTML attributes

Usage
```tsx
<Button variant="primary">Save</Button>
<Button variant="secondary">Cancel</Button>
<Button variant="danger">Delete</Button>
<Button variant="ghost">Skip</Button>
<Button loading>Saving...</Button>
<Button disabled>Disabled</Button>
<Button size="sm" icon={<Icon />}>Small</Button>
<Button size="lg">Large</Button>
```


