### PR TITLE
Add GroupBadge component with status icons and color coding

### DIFF
--- a/frontend/src/components/GroupBadge.css
+++ b/frontend/src/components/GroupBadge.css
@@ -1,0 +1,8 @@
+.group-badge {
+  text-transform: capitalize;
+  letter-spacing: 0.01em;
+}
+
+.group-badge .group-badge-icon {
+  flex-shrink: 0;
+}

--- a/frontend/src/components/GroupBadge.tsx
+++ b/frontend/src/components/GroupBadge.tsx
@@ -1,0 +1,112 @@
+import { Badge } from './Badge';
+import './GroupBadge.css';
+
+export type GroupBadgeStatus = 'active' | 'pending' | 'complete' | 'completed';
+
+interface GroupBadgeProps {
+  status: GroupBadgeStatus;
+  className?: string;
+  showIcon?: boolean;
+}
+
+type NormalizedStatus = 'active' | 'pending' | 'complete';
+
+function normalizeStatus(status: GroupBadgeStatus): NormalizedStatus {
+  if (status === 'completed') {
+    return 'complete';
+  }
+
+  return status;
+}
+
+function getStatusVariant(status: NormalizedStatus): 'success' | 'warning' | 'info' {
+  switch (status) {
+    case 'active':
+      return 'success';
+    case 'pending':
+      return 'warning';
+    case 'complete':
+      return 'info';
+    default:
+      return 'info';
+  }
+}
+
+function getStatusLabel(status: GroupBadgeStatus): string {
+  switch (status) {
+    case 'active':
+      return 'active';
+    case 'pending':
+      return 'pending';
+    case 'complete':
+      return 'complete';
+    case 'completed':
+      return 'completed';
+    default:
+      return 'completed';
+  }
+}
+
+function getStatusIcon(status: NormalizedStatus): React.ReactNode {
+  switch (status) {
+    case 'active':
+      return (
+        <svg
+          className="group-badge-icon"
+          viewBox="0 0 16 16"
+          width="12"
+          height="12"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" strokeWidth="1.5" />
+          <path d="M5.5 8.1L7.2 9.8L10.8 6.2" fill="none" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      );
+    case 'pending':
+      return (
+        <svg
+          className="group-badge-icon"
+          viewBox="0 0 16 16"
+          width="12"
+          height="12"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" strokeWidth="1.5" />
+          <path d="M8 4.5V8L10.5 9.5" fill="none" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      );
+    case 'complete':
+      return (
+        <svg
+          className="group-badge-icon"
+          viewBox="0 0 16 16"
+          width="12"
+          height="12"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" strokeWidth="1.5" />
+          <path d="M5.5 8.2L7.2 9.8L10.8 6.1" fill="none" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      );
+    default:
+      return null;
+  }
+}
+
+export function GroupBadge({ status, className = '', showIcon = true }: GroupBadgeProps) {
+  const normalizedStatus = normalizeStatus(status);
+
+  return (
+    <Badge
+      variant={getStatusVariant(normalizedStatus)}
+      size="sm"
+      className={['group-badge', className].filter(Boolean).join(' ')}
+      icon={showIcon ? getStatusIcon(normalizedStatus) : undefined}
+    >
+      {getStatusLabel(status)}
+    </Badge>
+  );
+}

--- a/frontend/src/components/GroupCard.tsx
+++ b/frontend/src/components/GroupCard.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import { buildRoute } from '../routing/constants';
 import './GroupCard.css';
 import { Button } from './Button';
-import { Badge } from './Badge';
+import { GroupBadge } from './GroupBadge';
 
 interface GroupCardProps {
   groupId?: string;
@@ -10,7 +10,7 @@ interface GroupCardProps {
   memberCount: number;
   contributionAmount: number;
   currency?: string;
-  status?: 'active' | 'completed' | 'pending';
+  status?: 'active' | 'completed' | 'pending' | 'complete';
   onClick?: () => void;
   onViewDetails?: () => void;
   onJoin?: () => void;
@@ -39,26 +39,11 @@ export function GroupCard({
     onClick?.();
   };
 
-  const getStatusVariant = () => {
-    switch (status) {
-      case 'active':
-        return 'success';
-      case 'completed':
-        return 'info';
-      case 'pending':
-        return 'warning';
-      default:
-        return 'primary';
-    }
-  };
-
   const cardContent = (
     <>
       <div className="group-card-header">
         <h3 className="group-card-title">{groupName}</h3>
-        <Badge variant={getStatusVariant()} size="sm">
-          {status}
-        </Badge>
+        <GroupBadge status={status} />
       </div>
 
       <div className="group-card-body">

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,5 +1,7 @@
 export { Avatar } from "./Avatar";
 export { Badge } from "./Badge";
+export { GroupBadge } from "./GroupBadge";
+export type { GroupBadgeStatus } from "./GroupBadge";
 export { Tooltip } from "./Tooltip";
 export { Dropdown } from "./Dropdown";
 export { EmptyState } from "./EmptyState/EmptyState";

--- a/frontend/src/test/GroupBadge.test.tsx
+++ b/frontend/src/test/GroupBadge.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GroupBadge } from '../components/GroupBadge';
+
+describe('GroupBadge', () => {
+  it('renders active status with success styling and icon', () => {
+    render(<GroupBadge status="active" />);
+
+    const badgeText = screen.getByText('active');
+    const badge = badgeText.closest('.badge');
+
+    expect(badge).toHaveClass('badge-success');
+    expect(badge).toHaveClass('badge-sm');
+    expect(badge).toHaveClass('group-badge');
+    expect(badge?.querySelector('.group-badge-icon')).toBeInTheDocument();
+  });
+
+  it('renders pending status with warning styling', () => {
+    render(<GroupBadge status="pending" />);
+
+    const badge = screen.getByText('pending').closest('.badge');
+    expect(badge).toHaveClass('badge-warning');
+  });
+
+  it('renders complete status with info styling', () => {
+    render(<GroupBadge status="complete" />);
+
+    const badge = screen.getByText('complete').closest('.badge');
+    expect(badge).toHaveClass('badge-info');
+  });
+
+  it('supports completed alias with complete styling', () => {
+    render(<GroupBadge status="completed" />);
+
+    const badge = screen.getByText('completed').closest('.badge');
+    expect(badge).toHaveClass('badge-info');
+  });
+
+  it('supports icon toggle', () => {
+    render(<GroupBadge status="active" showIcon={false} />);
+
+    const badge = screen.getByText('active').closest('.badge');
+    expect(badge?.querySelector('.group-badge-icon')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes Xoulomon/Stellar-Save#276

## Summary
- Added reusable `GroupBadge` component for group status display.
- Supports statuses: `active`, `pending`, `complete` (plus `completed` alias).
- Added status-based color coding and icons.
- Kept badge compact using small size.
- Integrated `GroupBadge` into `GroupCard`.
- Added unit tests for status rendering, styling, alias handling, and icon toggle.

## Validation
- `npm run test -- GroupBadge.test.tsx` passed.
-Targeted lint on changed files passed (full project lint/build currently has unrelated pre-existing issues).
