### PR TITLE
feat: add calculate_current_cycle helper with unit tests

### DIFF
--- a/.kiro/specs/calculate-current-cycle/.config.kiro
+++ b/.kiro/specs/calculate-current-cycle/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "8a07b67d-14fa-4d73-88db-0542ca0c0581", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/calculate-current-cycle/design.md
+++ b/.kiro/specs/calculate-current-cycle/design.md
@@ -1,0 +1,193 @@
+# Design Document: calculate_current_cycle
+
+## Overview
+
+This feature adds a `calculate_current_cycle` pure helper function to `contracts/stellar-save/src/helpers.rs`. The function determines the current cycle index for a savings group by computing how many full `cycle_duration` windows have elapsed since `started_at`, capping the result at `max_members - 1`.
+
+It is called internally by contribution validation, payout scheduling, and cycle advancement logic to avoid duplicating cycle-calculation arithmetic across the contract.
+
+Key design decisions:
+- **Pure helper, no state mutation**: the function only reads from storage and the ledger clock.
+- **Placed in `helpers.rs`**: consistent with the existing `is_cycle_deadline_passed` helper that lives there.
+- **Returns `Result<u32, StellarSaveError>`**: typed errors let callers handle failures without panicking.
+- **`u64` arithmetic throughout**: avoids signed-integer overflow; cast to `u32` only after the cap is applied.
+
+---
+
+## Architecture
+
+The function sits entirely within the existing `helpers` module. No new modules, traits, or storage keys are introduced.
+
+```mermaid
+flowchart TD
+    Caller["Contract operation\n(contribution / payout / cycle advance)"]
+    Helper["helpers::calculate_current_cycle(env, group_id)"]
+    Storage["Persistent storage\nStorageKeyBuilder::group_data(group_id)"]
+    Ledger["env.ledger().timestamp()"]
+
+    Caller -->|calls| Helper
+    Helper -->|reads| Storage
+    Helper -->|reads| Ledger
+    Helper -->|Ok(cycle) / Err| Caller
+```
+
+---
+
+## Components and Interfaces
+
+### Function Signature
+
+```rust
+/// Calculates the current cycle number for a savings group.
+///
+/// # Arguments
+/// * `env`      - Soroban environment (storage + ledger access)
+/// * `group_id` - ID of the group to query
+///
+/// # Returns
+/// * `Ok(0)`                        - group not yet started, or current_time < started_at
+/// * `Ok(n)` where n ≤ max_members-1 - number of complete cycles elapsed, capped
+/// * `Err(StellarSaveError::GroupNotFound)` - group_id not in storage
+pub fn calculate_current_cycle(env: &Env, group_id: u64) -> Result<u32, StellarSaveError>
+```
+
+### Placement
+
+File: `contracts/stellar-save/src/helpers.rs`
+
+The function is a free function (not a method on `StellarSaveContract`) consistent with `format_group_id` and `is_cycle_deadline_passed` already in that file.
+
+### Interaction with Existing Code
+
+| Existing symbol | How it is used |
+|---|---|
+| `StorageKeyBuilder::group_data(group_id)` | Load the `Group` struct |
+| `Group.started` | Early-return `Ok(0)` if group not started |
+| `Group.started_at` | Base timestamp for elapsed calculation |
+| `Group.cycle_duration` | Divisor for integer division |
+| `Group.max_members` | Cap: result ≤ `max_members - 1` |
+| `StellarSaveError::GroupNotFound` | Returned when group absent from storage |
+| `env.ledger().timestamp()` | Current on-chain time |
+
+---
+
+## Data Models
+
+No new data structures are introduced. The function reads the existing `Group` struct:
+
+```rust
+pub struct Group {
+    pub started: bool,
+    pub started_at: u64,       // Unix timestamp (seconds) of activation
+    pub cycle_duration: u64,   // Length of one cycle in seconds
+    pub max_members: u32,      // Total number of cycles == total members
+    // ... other fields unchanged
+}
+```
+
+### Computation Model
+
+```
+elapsed_seconds  = current_time - started_at          (u64 subtraction, guarded by current_time >= started_at)
+cycles_elapsed   = elapsed_seconds / cycle_duration   (u64 integer division, truncates toward zero)
+capped_cycles    = min(cycles_elapsed, max_members - 1 as u64)
+result           = capped_cycles as u32               (safe: value ≤ max_members - 1 ≤ u32::MAX)
+```
+
+Edge cases handled before the computation:
+1. Group not in storage → `Err(GroupNotFound)`
+2. `group.started == false` → `Ok(0)`
+3. `current_time < started_at` → `Ok(0)` (clock skew guard)
+
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: GroupNotFound for unknown group_id
+
+*For any* `group_id` that has not been stored in persistent storage, `calculate_current_cycle` must return `Err(StellarSaveError::GroupNotFound)`.
+
+**Validates: Requirements 1.2, 5.1**
+
+---
+
+### Property 2: Unstarted group always returns cycle 0
+
+*For any* `Group` whose `started` field is `false` (regardless of other fields), `calculate_current_cycle` must return `Ok(0)`.
+
+**Validates: Requirements 1.3**
+
+---
+
+### Property 3: Cycle count correctness formula
+
+*For any* started group with `current_time >= started_at`, the returned cycle number must equal `min(floor((current_time - started_at) / cycle_duration), max_members - 1)` cast to `u32`. This subsumes the cap requirement and the integer-truncation requirement.
+
+**Validates: Requirements 2.2, 3.1, 3.3, 4.2, 6.3**
+
+---
+
+### Property 4: Result is always a valid cycle index
+
+*For any* started group and any `current_time >= started_at`, the returned value `n` must satisfy `0 <= n <= max_members - 1`. This invariant holds independently of the exact formula and can be checked without recomputing the formula.
+
+**Validates: Requirements 4.4**
+
+---
+
+### Property 5: Determinism — same inputs produce same result
+
+*For any* group and ledger timestamp, calling `calculate_current_cycle` twice with identical inputs must return identical results. The function has no side effects that could cause divergence.
+
+**Validates: Requirements 6.6**
+
+---
+
+## Error Handling
+
+| Condition | Return value | Notes |
+|---|---|---|
+| `group_id` not in storage | `Err(StellarSaveError::GroupNotFound)` | Propagated from `.ok_or(...)` on storage get |
+| `group.started == false` | `Ok(0)` | Early return before any arithmetic |
+| `current_time < started_at` | `Ok(0)` | Clock-skew guard; no panic |
+| Normal operation | `Ok(n)` where `0 <= n <= max_members - 1` | Integer division + cap |
+
+The function never panics. All arithmetic is on `u64` values (no overflow possible for realistic timestamps and durations), and the cast to `u32` is safe because the value is capped at `max_members - 1` which fits in `u32`.
+
+---
+
+## Testing Strategy
+
+### Unit Tests (in `helpers.rs` `#[cfg(test)]` block)
+
+Unit tests cover specific examples and edge cases:
+
+1. Non-existent `group_id` → `Err(GroupNotFound)`
+2. Group with `started = false` → `Ok(0)`
+3. Query at exactly `started_at` (zero elapsed) → `Ok(0)`
+4. Query at `started_at + cycle_duration * N` for N = 1, 2, 3 → `Ok(N)`
+5. Query at `started_at + cycle_duration * N - 1` (one second before boundary) → `Ok(N-1)` (no partial cycle)
+6. Query far in the future (elapsed >> max_members cycles) → `Ok(max_members - 1)` (cap)
+
+### Property-Based Tests
+
+Property-based testing library: **`proptest`** (already available in the Rust ecosystem; add to `[dev-dependencies]` in `contracts/stellar-save/Cargo.toml`).
+
+Each property test runs a minimum of **100 iterations**.
+
+| Property | Test description | Tag |
+|---|---|---|
+| P1: GroupNotFound | Generate random `u64` group_ids, verify `Err(GroupNotFound)` | `Feature: calculate-current-cycle, Property 1: GroupNotFound for unknown group_id` |
+| P2: Unstarted returns 0 | Generate random `Group` with `started=false`, verify `Ok(0)` | `Feature: calculate-current-cycle, Property 2: Unstarted group always returns cycle 0` |
+| P3: Correctness formula | Generate random started groups + timestamps ≥ `started_at`, verify formula | `Feature: calculate-current-cycle, Property 3: Cycle count correctness formula` |
+| P4: Bounds invariant | Generate random started groups + timestamps ≥ `started_at`, verify `0 <= n <= max_members-1` | `Feature: calculate-current-cycle, Property 4: Result is always a valid cycle index` |
+| P5: Determinism | Call twice with same inputs, verify identical results | `Feature: calculate-current-cycle, Property 5: Determinism — same inputs produce same result` |
+
+Each property test must include a comment referencing its design property using the tag format above.
+
+### Dual Testing Rationale
+
+Unit tests catch concrete bugs at known boundary values (e.g., off-by-one at cycle boundaries). Property tests verify the general formula holds across the full input space, including large timestamps, large `cycle_duration` values, and `max_members` at its extremes. Together they provide comprehensive coverage without redundancy.

--- a/.kiro/specs/calculate-current-cycle/requirements.md
+++ b/.kiro/specs/calculate-current-cycle/requirements.md
@@ -1,0 +1,95 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds a `calculate_current_cycle` helper function to the Stellar-Save Soroban smart contract. The function determines the current cycle number for a savings group based on the time elapsed since the group was started. It reads the group's `started_at` timestamp and `cycle_duration` from storage, retrieves the current ledger timestamp, and computes how many full cycles have elapsed. This is a pure helper used internally by other contract operations (e.g., contribution validation, payout scheduling) to avoid duplicating cycle-calculation logic.
+
+## Glossary
+
+- **Helper**: A Rust function in `helpers.rs` that performs a reusable computation without directly mutating contract state.
+- **Cycle**: A fixed time window during which all group members are expected to contribute. Indexed from 0.
+- **Cycle_Duration**: The length of one cycle in seconds, stored on the `Group` struct as `cycle_duration: u64`.
+- **Started_At**: The Unix timestamp (seconds) at which the group was activated, stored on the `Group` struct as `started_at: u64`.
+- **Current_Time**: The current ledger timestamp in seconds, obtained via `env.ledger().timestamp()`.
+- **Elapsed_Seconds**: The difference `current_time - started_at` in seconds.
+- **Cycle_Calculator**: The helper function `calculate_current_cycle` being specified here.
+- **Group**: The `Group` struct defined in `group.rs`, loaded from persistent storage via `StorageKeyBuilder::group_data(group_id)`.
+- **StellarSaveError**: The contract error enum defined in `error.rs`.
+
+---
+
+## Requirements
+
+### Requirement 1: Retrieve Group Start Time
+
+**User Story:** As a contract developer, I want the helper to load the group's start time from storage, so that cycle calculations are always based on authoritative on-chain data.
+
+#### Acceptance Criteria
+
+1. WHEN `calculate_current_cycle` is called with a valid `group_id`, THE `Cycle_Calculator` SHALL load the `Group` struct from persistent storage using `StorageKeyBuilder::group_data(group_id)`.
+2. IF the `group_id` does not exist in storage, THEN THE `Cycle_Calculator` SHALL return `Err(StellarSaveError::GroupNotFound)`.
+3. IF the `Group` has `started` set to `false`, THEN THE `Cycle_Calculator` SHALL return `Ok(0)` indicating no cycles have elapsed.
+
+---
+
+### Requirement 2: Retrieve Current Ledger Time
+
+**User Story:** As a contract developer, I want the helper to use the current ledger timestamp, so that cycle calculations reflect the actual on-chain time.
+
+#### Acceptance Criteria
+
+1. THE `Cycle_Calculator` SHALL obtain the current time by calling `env.ledger().timestamp()`.
+2. WHILE the group is started and `current_time >= started_at`, THE `Cycle_Calculator` SHALL compute `elapsed_seconds = current_time - started_at`.
+3. IF `current_time < started_at`, THEN THE `Cycle_Calculator` SHALL return `Ok(0)` to handle any clock skew or edge cases without panicking.
+
+---
+
+### Requirement 3: Calculate Cycles Elapsed
+
+**User Story:** As a contract developer, I want the helper to compute the number of complete cycles elapsed, so that the contract can determine which cycle is currently active.
+
+#### Acceptance Criteria
+
+1. WHEN `elapsed_seconds` and `cycle_duration` are both available, THE `Cycle_Calculator` SHALL compute `cycles_elapsed = elapsed_seconds / cycle_duration` using integer division.
+2. THE `Cycle_Calculator` SHALL perform the division using `u64` arithmetic to avoid signed-integer overflow.
+3. THE `Cycle_Calculator` SHALL NOT count a partial cycle as a completed cycle (integer division truncates toward zero).
+
+---
+
+### Requirement 4: Return Cycle Number
+
+**User Story:** As a contract developer, I want the helper to return the current cycle number capped at the group's maximum, so that callers always receive a valid, bounded cycle index.
+
+#### Acceptance Criteria
+
+1. THE `Cycle_Calculator` SHALL return the cycle number as `Ok(u32)`.
+2. WHEN `cycles_elapsed` exceeds `group.max_members - 1`, THE `Cycle_Calculator` SHALL return `Ok(group.max_members - 1)` to cap the result at the last valid cycle index.
+3. THE `Cycle_Calculator` SHALL cast `cycles_elapsed` from `u64` to `u32` only after applying the cap, preventing truncation errors on large elapsed values.
+4. FOR ALL started groups where `current_time >= started_at`, the returned cycle number SHALL satisfy `0 <= result <= group.max_members - 1`.
+
+---
+
+### Requirement 5: Error Handling
+
+**User Story:** As a contract developer, I want the helper to return typed errors for all failure conditions, so that callers can handle failures without panicking.
+
+#### Acceptance Criteria
+
+1. IF the group is not found in storage, THEN THE `Cycle_Calculator` SHALL return `Err(StellarSaveError::GroupNotFound)`.
+2. THE `Cycle_Calculator` SHALL NOT panic under any valid input combination.
+3. THE `Cycle_Calculator` SHALL return `Result<u32, StellarSaveError>` as its return type.
+
+---
+
+### Requirement 6: Tests
+
+**User Story:** As a contract developer, I want unit tests for `calculate_current_cycle`, so that correctness is verified and regressions are caught.
+
+#### Acceptance Criteria
+
+1. THE test suite SHALL include a test verifying that calling `calculate_current_cycle` with a non-existent `group_id` returns `Err(StellarSaveError::GroupNotFound)`.
+2. THE test suite SHALL include a test verifying that a group that has not been started returns `Ok(0)`.
+3. THE test suite SHALL include a test verifying that a group started at time `T` with `cycle_duration` `D`, queried at time `T + D * N`, returns `Ok(N)` for representative values of `N`.
+4. THE test suite SHALL include a test verifying that the returned cycle is capped at `max_members - 1` when more cycles have elapsed than the group has members.
+5. THE test suite SHALL include a test verifying that querying at exactly `started_at` (zero elapsed seconds) returns `Ok(0)`.
+6. FOR ALL valid started groups, parsing the cycle number and re-computing it from the same inputs SHALL produce the same result (idempotence / determinism property).

--- a/.kiro/specs/calculate-current-cycle/tasks.md
+++ b/.kiro/specs/calculate-current-cycle/tasks.md
@@ -1,0 +1,66 @@
+# Implementation Plan: calculate_current_cycle
+
+## Overview
+
+Add a pure `calculate_current_cycle` helper function to `contracts/stellar-save/src/helpers.rs`. The function reads a `Group` from persistent storage and the current ledger timestamp, then returns the capped cycle index as `Result<u32, StellarSaveError>`.
+
+## Tasks
+
+- [x] 1. Implement `calculate_current_cycle` in `helpers.rs`
+  - Add the function after `is_cycle_deadline_passed` in `contracts/stellar-save/src/helpers.rs`
+  - Import `StellarSaveError` and `StorageKeyBuilder` at the top of the file (they are already available via `crate::`)
+  - Implement the four-step logic: load group → early-return if not started or clock skew → integer division → cap and cast
+  - Signature: `pub fn calculate_current_cycle(env: &Env, group_id: u64) -> Result<u32, StellarSaveError>`
+  - _Requirements: 1.1, 1.2, 1.3, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 4.1, 4.2, 4.3, 5.1, 5.2, 5.3_
+
+- [x] 2. Write unit tests for `calculate_current_cycle`
+  - Add tests inside the existing `#[cfg(test)] mod tests` block in `helpers.rs`
+  - [x] 2.1 Test: non-existent `group_id` returns `Err(GroupNotFound)`
+    - _Requirements: 1.2, 5.1, 6.1_
+  - [x] 2.2 Test: group with `started = false` returns `Ok(0)`
+    - _Requirements: 1.3, 6.2_
+  - [x] 2.3 Test: query at exactly `started_at` (zero elapsed) returns `Ok(0)`
+    - _Requirements: 2.2, 6.5_
+  - [x] 2.4 Test: query at `started_at + cycle_duration * N` returns `Ok(N)` for N = 1, 2, 3
+    - _Requirements: 3.1, 3.3, 6.3_
+  - [x] 2.5 Test: query at `started_at + cycle_duration * N - 1` returns `Ok(N-1)` (no partial cycle)
+    - _Requirements: 3.3, 6.3_
+  - [x] 2.6 Test: query far in the future returns `Ok(max_members - 1)` (cap)
+    - _Requirements: 4.2, 4.4, 6.4_
+
+- [x] 3. Checkpoint — Ensure all unit tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 4. Write property-based tests using `proptest`
+  - Add a `proptest!` block inside the `#[cfg(test)] mod tests` block in `helpers.rs`
+  - `proptest` is already listed in `[dev-dependencies]` in `contracts/stellar-save/Cargo.toml`
+  - [ ]* 4.1 Write property test for Property 1: GroupNotFound for unknown group_id
+    - Generate random `u64` group_ids that have not been stored; assert `Err(GroupNotFound)`
+    - **Property 1: GroupNotFound for unknown group_id**
+    - **Validates: Requirements 1.2, 5.1**
+  - [ ]* 4.2 Write property test for Property 2: Unstarted group always returns cycle 0
+    - Generate random `Group` values with `started = false`; assert `Ok(0)`
+    - **Property 2: Unstarted group always returns cycle 0**
+    - **Validates: Requirements 1.3**
+  - [ ]* 4.3 Write property test for Property 3: Cycle count correctness formula
+    - Generate random started groups and `current_time >= started_at`; assert result equals `min(floor((current_time - started_at) / cycle_duration), max_members - 1) as u32`
+    - **Property 3: Cycle count correctness formula**
+    - **Validates: Requirements 2.2, 3.1, 3.3, 4.2, 6.3**
+  - [ ]* 4.4 Write property test for Property 4: Result is always a valid cycle index
+    - Generate random started groups and `current_time >= started_at`; assert `0 <= n <= max_members - 1`
+    - **Property 4: Result is always a valid cycle index**
+    - **Validates: Requirements 4.4**
+  - [ ]* 4.5 Write property test for Property 5: Determinism — same inputs produce same result
+    - Call `calculate_current_cycle` twice with identical env state and inputs; assert results are equal
+    - **Property 5: Determinism — same inputs produce same result**
+    - **Validates: Requirements 6.6**
+
+- [x] 5. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- `proptest` is already in `[dev-dependencies]` — no Cargo.toml changes needed
+- All arithmetic stays in `u64`; the `u32` cast happens only after the cap is applied
+- The function is a free function (not a method on `StellarSaveContract`), consistent with `format_group_id` and `is_cycle_deadline_passed`

--- a/contracts/stellar-save/src/helpers.rs
+++ b/contracts/stellar-save/src/helpers.rs
@@ -1,7 +1,7 @@
 //! Helper utilities for formatting and display
 
 use soroban_sdk::{String, Env, Bytes};
-use crate::Group;
+use crate::{Group, StellarSaveError, StorageKeyBuilder};
 
 /// Formats a group ID for display with a "GROUP-" prefix.
 /// 
@@ -74,6 +74,45 @@ pub fn is_cycle_deadline_passed(group: &Group, current_time: u64) -> bool {
     
     let cycle_deadline = group.started_at + (group.cycle_duration * (group.current_cycle as u64 + 1));
     current_time > cycle_deadline
+}
+
+/// Calculates the current cycle number for a savings group.
+///
+/// # Arguments
+/// * `env`      - Soroban environment (storage + ledger access)
+/// * `group_id` - ID of the group to query
+///
+/// # Returns
+/// * `Ok(0)`                        - group not yet started, or current_time < started_at
+/// * `Ok(n)` where n ≤ max_members-1 - number of complete cycles elapsed, capped
+/// * `Err(StellarSaveError::GroupNotFound)` - group_id not in storage
+pub fn calculate_current_cycle(env: &Env, group_id: u64) -> Result<u32, StellarSaveError> {
+    // Step 1: Load Group from storage
+    let group_key = StorageKeyBuilder::group_data(group_id);
+    let group = env
+        .storage()
+        .persistent()
+        .get::<_, Group>(&group_key)
+        .ok_or(StellarSaveError::GroupNotFound)?;
+
+    // Step 2: If group has not been started, return cycle 0
+    if !group.started {
+        return Ok(0);
+    }
+
+    // Step 3: Get current ledger time; guard against clock skew
+    let current_time: u64 = env.ledger().timestamp();
+    if current_time < group.started_at {
+        return Ok(0);
+    }
+
+    // Step 4: Compute elapsed cycles, cap at max_members - 1, cast to u32
+    let elapsed: u64 = current_time - group.started_at;
+    let cycles: u64 = elapsed / group.cycle_duration;
+    let cap: u64 = (group.max_members - 1) as u64;
+    let result: u32 = cycles.min(cap) as u32;
+
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -153,5 +192,102 @@ mod tests {
         // Deadline for cycle 1 is started_at + (cycle_duration * 2)
         assert!(!is_cycle_deadline_passed(&group, 1000 + 604800 * 2));
         assert!(is_cycle_deadline_passed(&group, 1000 + 604800 * 2 + 1));
+    }
+
+    // --- calculate_current_cycle tests ---
+
+    fn store_group(env: &Env, group: &Group) {
+        let key = StorageKeyBuilder::group_data(group.id);
+        env.storage().persistent().set(&key, group);
+    }
+
+    #[test]
+    fn test_calculate_current_cycle_group_not_found() {
+        let env = Env::default();
+        let result = calculate_current_cycle(&env, 9999);
+        assert_eq!(result, Err(StellarSaveError::GroupNotFound));
+    }
+
+    #[test]
+    fn test_calculate_current_cycle_not_started() {
+        let env = Env::default();
+        let creator = Address::generate(&env);
+        // Group with started = false (default)
+        let group = Group::new(1, creator, 1_000_000, 604800, 5, 2, 1000);
+        store_group(&env, &group);
+
+        let result = calculate_current_cycle(&env, 1);
+        assert_eq!(result, Ok(0));
+    }
+
+    #[test]
+    fn test_calculate_current_cycle_at_started_at() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1000);
+        let creator = Address::generate(&env);
+        let mut group = Group::new(1, creator, 1_000_000, 604800, 5, 2, 1000);
+        group.member_count = 2;
+        group.activate(1000); // started_at = 1000
+        store_group(&env, &group);
+
+        // current_time == started_at → elapsed = 0 → cycle 0
+        let result = calculate_current_cycle(&env, 1);
+        assert_eq!(result, Ok(0));
+    }
+
+    #[test]
+    fn test_calculate_current_cycle_n_full_cycles() {
+        let env = Env::default();
+        let started_at: u64 = 1000;
+        let cycle_duration: u64 = 604800;
+
+        let creator = Address::generate(&env);
+        let mut group = Group::new(1, creator, 1_000_000, cycle_duration, 10, 2, started_at);
+        group.member_count = 2;
+        group.activate(started_at);
+        store_group(&env, &group);
+
+        for n in 1u64..=5 {
+            env.ledger().set_timestamp(started_at + cycle_duration * n);
+            let result = calculate_current_cycle(&env, 1);
+            assert_eq!(result, Ok(n as u32), "expected cycle {} at time {}", n, started_at + cycle_duration * n);
+        }
+    }
+
+    #[test]
+    fn test_calculate_current_cycle_no_partial_cycle() {
+        let env = Env::default();
+        let started_at: u64 = 1000;
+        let cycle_duration: u64 = 604800;
+
+        let creator = Address::generate(&env);
+        let mut group = Group::new(1, creator, 1_000_000, cycle_duration, 10, 2, started_at);
+        group.member_count = 2;
+        group.activate(started_at);
+        store_group(&env, &group);
+
+        // One second before the second cycle boundary → still cycle 1
+        env.ledger().set_timestamp(started_at + cycle_duration * 2 - 1);
+        let result = calculate_current_cycle(&env, 1);
+        assert_eq!(result, Ok(1));
+    }
+
+    #[test]
+    fn test_calculate_current_cycle_capped_at_max_members_minus_one() {
+        let env = Env::default();
+        let started_at: u64 = 1000;
+        let cycle_duration: u64 = 604800;
+        let max_members: u32 = 5;
+
+        let creator = Address::generate(&env);
+        let mut group = Group::new(1, creator, 1_000_000, cycle_duration, max_members, 2, started_at);
+        group.member_count = 2;
+        group.activate(started_at);
+        store_group(&env, &group);
+
+        // Far in the future: many more cycles than max_members
+        env.ledger().set_timestamp(started_at + cycle_duration * 1000);
+        let result = calculate_current_cycle(&env, 1);
+        assert_eq!(result, Ok(max_members - 1));
     }
 }


### PR DESCRIPTION
feat: Add calculate_current_cycle helper function
Overview
Adds a calculate_current_cycle pure helper function to 
helpers.rs
. The function determines the current cycle index for a savings group based on time elapsed since the group was activated, capping the result at max_members - 1.

Problem
Cycle-number arithmetic was either absent or would need to be duplicated across contribution validation, payout scheduling, and cycle advancement logic. This helper centralizes the calculation in one place.

Solution
A free function in helpers.rs (consistent with is_cycle_deadline_passed) that:

Loads the Group from persistent storage — returns Err(GroupNotFound) if absent
Returns Ok(0) if the group hasn't started
Returns Ok(0) if current_time < started_at (clock skew guard)
Computes floor((current_time - started_at) / cycle_duration) in u64, caps at max_members - 1, casts to u32
Changes
helpers.rs

Added calculate_current_cycle(env: &Env, group_id: u64) -> Result<u32, StellarSaveError>
Added 6 unit tests:
Test	Scenario	Expected
test_calculate_current_cycle_group_not_found	Unknown group_id	Err(GroupNotFound)
test_calculate_current_cycle_not_started	started = false	Ok(0)
test_calculate_current_cycle_at_started_at	Query at exactly started_at	Ok(0)
test_calculate_current_cycle_n_full_cycles	Query at started_at + duration * N for N=1..5	Ok(N)
test_calculate_current_cycle_no_partial_cycle	One second before cycle boundary	Ok(N-1)
test_calculate_current_cycle_capped_at_max_members_minus_one	Far future query	Ok(max_members - 1)
.kiro/specs/calculate-current-cycle/ — spec files added (requirements, design, tasks)

Correctness Properties
GroupNotFound for unknown group_id
Unstarted group always returns Ok(0)
Cycle count correctness: min(floor((current_time - started_at) / cycle_duration), max_members - 1)
Result always satisfies 0 <= n <= max_members - 1
Determinism — same inputs always produce same result
Notes
All arithmetic stays in u64; u32 cast only after cap is applied — no overflow risk
No new storage keys, data types, or dependencies introduced

Closes #263 