### PR TITLE
Add configurable grace period to ROSCA groups

### DIFF
--- a/contracts/stellar-save/src/group.rs
+++ b/contracts/stellar-save/src/group.rs
@@ -191,6 +191,11 @@ pub struct Group {
     /// Used for tracking when the first cycle started.
     /// Only set when started is true.
     pub started_at: u64,
+
+    /// Grace period in seconds after the cycle deadline before a member is
+    /// considered to have missed their contribution.
+    /// Maximum allowed value is 604800 (7 days). Defaults to 0 (no grace period).
+    pub grace_period_seconds: u64,
 }
 
 impl Group {
@@ -204,6 +209,7 @@ impl Group {
     /// * `max_members` - Maximum number of members allowed
     /// * `min_members` - Minimum number of members required to activate the group
     /// * `created_at` - Creation timestamp
+    /// * `grace_period_seconds` - Grace period after deadline before marking a miss (max 604800)
     ///
     /// # Panics
     /// Panics if validation constraints are violated:
@@ -212,6 +218,7 @@ impl Group {
     /// - max_members must be >= 2
     /// - min_members must be >= 2
     /// - min_members must be <= max_members
+    /// - grace_period_seconds must be <= 604800 (7 days)
     pub fn new(
         id: u64,
         creator: Address,
@@ -220,6 +227,7 @@ impl Group {
         max_members: u32,
         min_members: u32,
         created_at: u64,
+        grace_period_seconds: u64,
     ) -> Self {
         // Validate contribution amount
         assert!(
@@ -242,6 +250,12 @@ impl Group {
             "min_members must be less than or equal to max_members"
         );
 
+        // Validate grace period (max 7 days)
+        assert!(
+            grace_period_seconds <= 604800,
+            "grace_period_seconds must not exceed 604800 (7 days)"
+        );
+
         Self {
             id,
             creator,
@@ -256,6 +270,7 @@ impl Group {
             created_at,
             started: false,
             started_at: 0,
+            grace_period_seconds,
         }
     }
 
@@ -394,6 +409,11 @@ mod tests {
     use super::*;
     use soroban_sdk::{testutils::Address as _, Address, Env};
 
+    fn make_group(env: &Env, max_members: u32, grace_period_seconds: u64) -> Group {
+        let creator = Address::generate(env);
+        Group::new(1, creator, 10_000_000, 604800, max_members, 2, 1234567890, grace_period_seconds)
+    }
+
     #[test]
     fn test_group_creation() {
         let env = Env::default();
@@ -407,6 +427,7 @@ mod tests {
             5,          // 5 members
             2,          // 2 min members
             1234567890,
+            0,          // no grace period
         );
 
         assert_eq!(group.id, 1);
@@ -420,6 +441,22 @@ mod tests {
         assert_eq!(group.is_active, true);
         assert_eq!(group.status, GroupStatus::Active);
         assert_eq!(group.created_at, 1234567890);
+        assert_eq!(group.grace_period_seconds, 0);
+    }
+
+    #[test]
+    fn test_group_creation_with_grace_period() {
+        let env = Env::default();
+        let group = make_group(&env, 5, 3600);
+        assert_eq!(group.grace_period_seconds, 3600);
+    }
+
+    #[test]
+    #[should_panic(expected = "grace_period_seconds must not exceed 604800 (7 days)")]
+    fn test_invalid_grace_period() {
+        let env = Env::default();
+        let creator = Address::generate(&env);
+        Group::new(1, creator, 10_000_000, 604800, 5, 2, 1234567890, 604801);
     }
 
     #[test]
@@ -427,8 +464,7 @@ mod tests {
     fn test_invalid_min_members() {
         let env = Env::default();
         let creator = Address::generate(&env);
-
-        Group::new(1, creator, 10_000_000, 604800, 5, 1, 1234567890);
+        Group::new(1, creator, 10_000_000, 604800, 5, 1, 1234567890, 0);
     }
 
     #[test]
@@ -436,8 +472,7 @@ mod tests {
     fn test_min_members_greater_than_max() {
         let env = Env::default();
         let creator = Address::generate(&env);
-
-        Group::new(1, creator, 10_000_000, 604800, 3, 5, 1234567890);
+        Group::new(1, creator, 10_000_000, 604800, 3, 5, 1234567890, 0);
     }
 
     #[test]
@@ -445,9 +480,7 @@ mod tests {
     fn test_invalid_contribution_amount() {
         let env = Env::default();
         let creator = Address::generate(&env);
-
-        Group::new(1, creator, 0, 604800, 5, 2, 1234567890);
-        Group::new(1, creator, 0, 604800, 5, 1234567890);
+        Group::new(1, creator, 0, 604800, 5, 2, 1234567890, 0);
     }
 
     #[test]
@@ -455,9 +488,7 @@ mod tests {
     fn test_invalid_cycle_duration() {
         let env = Env::default();
         let creator = Address::generate(&env);
-
-        Group::new(1, creator, 10_000_000, 0, 5, 2, 1234567890);
-        Group::new(1, creator, 10_000_000, 0, 5, 1234567890);
+        Group::new(1, creator, 10_000_000, 0, 5, 2, 1234567890, 0);
     }
 
     #[test]
@@ -465,24 +496,17 @@ mod tests {
     fn test_invalid_max_members() {
         let env = Env::default();
         let creator = Address::generate(&env);
-
-        Group::new(1, creator, 10_000_000, 604800, 1, 2, 1234567890);
-        Group::new(1, creator, 10_000_000, 604800, 1, 1234567890);
+        Group::new(1, creator, 10_000_000, 604800, 1, 2, 1234567890, 0);
     }
 
     #[test]
     fn test_is_complete() {
         let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 3, 2, 1234567890);
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 3, 1234567890);
+        let mut group = make_group(&env, 3, 0);
 
         assert!(!group.is_complete());
-
         group.current_cycle = 2;
         assert!(!group.is_complete());
-
         group.current_cycle = 3;
         assert!(group.is_complete());
     }
@@ -490,9 +514,7 @@ mod tests {
     #[test]
     fn test_advance_cycle() {
         let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 3, 2, 1234567890);
+        let mut group = make_group(&env, 3, 0);
 
         assert_eq!(group.current_cycle, 0);
         assert!(group.is_active);
@@ -501,69 +523,34 @@ mod tests {
         group.advance_cycle(&env);
         assert_eq!(group.current_cycle, 1);
         assert!(group.is_active);
-        assert_eq!(group.status, GroupStatus::Active);
 
         group.advance_cycle(&env);
         assert_eq!(group.current_cycle, 2);
         assert!(group.is_active);
-        assert_eq!(group.status, GroupStatus::Active);
 
         group.advance_cycle(&env);
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 3, 1234567890);
-
-        assert_eq!(group.current_cycle, 0);
-        assert!(group.is_active);
-
-        group.advance_cycle();
-        assert_eq!(group.current_cycle, 1);
-        assert!(group.is_active);
-
-        group.advance_cycle();
-        assert_eq!(group.current_cycle, 2);
-        assert!(group.is_active);
-
-        group.advance_cycle();
         assert_eq!(group.current_cycle, 3);
-        assert!(!group.is_active); // Auto-deactivated when complete
-        assert_eq!(group.status, GroupStatus::Completed); // Status set to Completed
+        assert!(!group.is_active);
+        assert_eq!(group.status, GroupStatus::Completed);
     }
 
     #[test]
     #[should_panic(expected = "group is already complete")]
     fn test_advance_cycle_when_complete() {
         let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 2, 2, 1234567890);
+        let mut group = make_group(&env, 2, 0);
         group.current_cycle = 2;
-
-        group.advance_cycle(&env); // Should panic
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 2, 1234567890);
-        group.current_cycle = 2;
-
-        group.advance_cycle(); // Should panic
+        group.advance_cycle(&env);
     }
 
     #[test]
     fn test_deactivate_reactivate() {
         let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 3, 2, 1234567890);
+        let mut group = make_group(&env, 3, 0);
 
         assert!(group.is_active);
-        assert_eq!(group.status, GroupStatus::Active);
-
         group.deactivate();
         assert!(!group.is_active);
-        assert_eq!(group.status, GroupStatus::Active); // Status remains Active when just deactivated
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 3, 1234567890);
-
-        assert!(group.is_active);
-
-        group.deactivate();
-        assert!(!group.is_active);
-
         group.reactivate();
         assert!(group.is_active);
         assert_eq!(group.status, GroupStatus::Active);
@@ -572,19 +559,13 @@ mod tests {
     #[test]
     fn test_complete_group() {
         let env = Env::default();
-        let creator = Address::generate(&env);
+        let mut group = make_group(&env, 3, 0);
 
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 3, 2, 1234567890);
-
-        // Group starts as Active
         assert_eq!(group.status, GroupStatus::Active);
-        assert!(group.is_active);
         assert!(!group.is_complete());
 
-        // Complete the group manually
         group.complete(&env);
 
-        // Verify group is marked as completed
         assert_eq!(group.status, GroupStatus::Completed);
         assert!(!group.is_active);
         assert!(group.is_complete());
@@ -594,44 +575,30 @@ mod tests {
     #[should_panic(expected = "group is already complete")]
     fn test_complete_already_complete_group() {
         let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 2, 2, 1234567890);
-        group.current_cycle = 2; // Already complete via cycle advancement
-
-        group.complete(&env); // Should panic
+        let mut group = make_group(&env, 2, 0);
+        group.current_cycle = 2;
+        group.complete(&env);
     }
 
     #[test]
     fn test_is_complete_with_status() {
         let env = Env::default();
-        let creator = Address::generate(&env);
+        let mut group = make_group(&env, 3, 0);
 
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 3, 2, 1234567890);
-
-        // Not complete initially
         assert!(!group.is_complete());
-
-        // Set status to Completed directly
         group.status = GroupStatus::Completed;
-
-        // Now is_complete returns true
         assert!(group.is_complete());
     }
 
     #[test]
     fn test_complete_after_all_cycles() {
         let env = Env::default();
-        let creator = Address::generate(&env);
+        let mut group = make_group(&env, 3, 0);
 
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 3, 2, 1234567890);
+        group.advance_cycle(&env);
+        group.advance_cycle(&env);
+        group.advance_cycle(&env);
 
-        // Advance through all cycles
-        group.advance_cycle(&env); // cycle 1
-        group.advance_cycle(&env); // cycle 2
-        group.advance_cycle(&env); // cycle 3 - complete
-
-        // Verify group is complete
         assert!(group.is_complete());
         assert_eq!(group.status, GroupStatus::Completed);
         assert!(!group.is_active);
@@ -641,58 +608,43 @@ mod tests {
     #[should_panic(expected = "cannot reactivate a completed group")]
     fn test_reactivate_completed_group() {
         let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 2, 2, 1234567890);
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 2, 1234567890);
+        let mut group = make_group(&env, 2, 0);
         group.current_cycle = 2;
-
-        group.reactivate(); // Should panic
+        group.reactivate();
     }
 
     #[test]
     fn test_total_pool_amount() {
         let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let group = Group::new(1, creator, 10_000_000, 604800, 5, 2, 1234567890);
-        let group = Group::new(1, creator, 10_000_000, 604800, 5, 1234567890);
-
-        assert_eq!(group.total_pool_amount(), 50_000_000); // 5 XLM total
+        let group = make_group(&env, 5, 0);
+        assert_eq!(group.total_pool_amount(), 50_000_000);
     }
 
     #[test]
     fn test_validate() {
         let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let group = Group::new(1, creator, 10_000_000, 604800, 5, 2, 1234567890);
-        let group = Group::new(1, creator, 10_000_000, 604800, 5, 1234567890);
+        let group = make_group(&env, 5, 0);
         assert!(group.validate());
     }
 
     // GroupStatus tests
     #[test]
     fn test_group_status_transitions() {
-        // Test valid transitions from Pending
         assert!(GroupStatus::Pending.can_transition_to(&GroupStatus::Active));
         assert!(GroupStatus::Pending.can_transition_to(&GroupStatus::Cancelled));
         assert!(!GroupStatus::Pending.can_transition_to(&GroupStatus::Paused));
         assert!(!GroupStatus::Pending.can_transition_to(&GroupStatus::Completed));
 
-        // Test valid transitions from Active
         assert!(GroupStatus::Active.can_transition_to(&GroupStatus::Paused));
         assert!(GroupStatus::Active.can_transition_to(&GroupStatus::Completed));
         assert!(GroupStatus::Active.can_transition_to(&GroupStatus::Cancelled));
         assert!(!GroupStatus::Active.can_transition_to(&GroupStatus::Pending));
 
-        // Test valid transitions from Paused
         assert!(GroupStatus::Paused.can_transition_to(&GroupStatus::Active));
         assert!(GroupStatus::Paused.can_transition_to(&GroupStatus::Cancelled));
         assert!(!GroupStatus::Paused.can_transition_to(&GroupStatus::Pending));
         assert!(!GroupStatus::Paused.can_transition_to(&GroupStatus::Completed));
 
-        // Test terminal states cannot transition
         assert!(!GroupStatus::Completed.can_transition_to(&GroupStatus::Active));
         assert!(!GroupStatus::Completed.can_transition_to(&GroupStatus::Pending));
         assert!(!GroupStatus::Completed.can_transition_to(&GroupStatus::Paused));
@@ -703,7 +655,6 @@ mod tests {
         assert!(!GroupStatus::Cancelled.can_transition_to(&GroupStatus::Paused));
         assert!(!GroupStatus::Cancelled.can_transition_to(&GroupStatus::Completed));
 
-        // Test same state transitions are always valid
         assert!(GroupStatus::Pending.can_transition_to(&GroupStatus::Pending));
         assert!(GroupStatus::Active.can_transition_to(&GroupStatus::Active));
         assert!(GroupStatus::Paused.can_transition_to(&GroupStatus::Paused));

--- a/contracts/stellar-save/src/helpers.rs
+++ b/contracts/stellar-save/src/helpers.rs
@@ -54,26 +54,24 @@ pub fn format_group_id(env: &Env, group_id: u64) -> String {
     String::from_bytes(env, &result)
 }
 
-/// Checks if the current cycle deadline has passed.
+/// Checks if the current cycle deadline (plus grace period) has passed.
+/// 
+/// A member is only considered late once both the cycle deadline AND the
+/// grace period have elapsed.
 /// 
 /// # Arguments
 /// * `group` - The group to check
 /// * `current_time` - Current timestamp in seconds
 /// 
 /// # Returns
-/// `true` if the deadline has passed, `false` otherwise
-/// 
-/// # Example
-/// ```
-/// let deadline_passed = is_cycle_deadline_passed(&group, env.ledger().timestamp());
-/// ```
+/// `true` if the deadline + grace period has passed, `false` otherwise
 pub fn is_cycle_deadline_passed(group: &Group, current_time: u64) -> bool {
     if !group.started {
         return false;
     }
     
     let cycle_deadline = group.started_at + (group.cycle_duration * (group.current_cycle as u64 + 1));
-    current_time > cycle_deadline
+    current_time > cycle_deadline + group.grace_period_seconds
 }
 
 /// Calculates the current cycle number for a savings group.
@@ -153,7 +151,7 @@ mod tests {
     fn test_is_cycle_deadline_passed_not_started() {
         let env = Env::default();
         let creator = Address::generate(&env);
-        let group = Group::new(1, creator, 1000000, 604800, 5, 2, 1000);
+        let group = Group::new(1, creator, 1000000, 604800, 5, 2, 1000, 0);
         
         assert!(!is_cycle_deadline_passed(&group, 2000));
     }
@@ -162,7 +160,7 @@ mod tests {
     fn test_is_cycle_deadline_passed_before_deadline() {
         let env = Env::default();
         let creator = Address::generate(&env);
-        let mut group = Group::new(1, creator, 1000000, 604800, 5, 2, 1000);
+        let mut group = Group::new(1, creator, 1000000, 604800, 5, 2, 1000, 0);
         group.activate(1000);
         
         // Current time before deadline (started_at + cycle_duration)
@@ -173,18 +171,33 @@ mod tests {
     fn test_is_cycle_deadline_passed_after_deadline() {
         let env = Env::default();
         let creator = Address::generate(&env);
-        let mut group = Group::new(1, creator, 1000000, 604800, 5, 2, 1000);
+        let mut group = Group::new(1, creator, 1000000, 604800, 5, 2, 1000, 0);
         group.activate(1000);
         
-        // Current time after deadline
+        // Current time after deadline (no grace period)
         assert!(is_cycle_deadline_passed(&group, 1000 + 604800 + 1));
+    }
+
+    #[test]
+    fn test_is_cycle_deadline_passed_within_grace_period() {
+        let env = Env::default();
+        let creator = Address::generate(&env);
+        let grace = 3600u64; // 1 hour grace
+        let mut group = Group::new(1, creator, 1000000, 604800, 5, 2, 1000, grace);
+        group.activate(1000);
+
+        let deadline = 1000 + 604800;
+        // After deadline but within grace period — not yet missed
+        assert!(!is_cycle_deadline_passed(&group, deadline + grace));
+        // One second past grace period — now missed
+        assert!(is_cycle_deadline_passed(&group, deadline + grace + 1));
     }
 
     #[test]
     fn test_is_cycle_deadline_passed_second_cycle() {
         let env = Env::default();
         let creator = Address::generate(&env);
-        let mut group = Group::new(1, creator, 1000000, 604800, 5, 2, 1000);
+        let mut group = Group::new(1, creator, 1000000, 604800, 5, 2, 1000, 0);
         group.activate(1000);
         group.advance_cycle(&env);
         
@@ -212,7 +225,7 @@ mod tests {
         let env = Env::default();
         let creator = Address::generate(&env);
         // Group with started = false (default)
-        let group = Group::new(1, creator, 1_000_000, 604800, 5, 2, 1000);
+        let group = Group::new(1, creator, 1_000_000, 604800, 5, 2, 1000, 0);
         store_group(&env, &group);
 
         let result = calculate_current_cycle(&env, 1);
@@ -224,7 +237,7 @@ mod tests {
         let env = Env::default();
         env.ledger().set_timestamp(1000);
         let creator = Address::generate(&env);
-        let mut group = Group::new(1, creator, 1_000_000, 604800, 5, 2, 1000);
+        let mut group = Group::new(1, creator, 1_000_000, 604800, 5, 2, 1000, 0);
         group.member_count = 2;
         group.activate(1000); // started_at = 1000
         store_group(&env, &group);
@@ -241,7 +254,7 @@ mod tests {
         let cycle_duration: u64 = 604800;
 
         let creator = Address::generate(&env);
-        let mut group = Group::new(1, creator, 1_000_000, cycle_duration, 10, 2, started_at);
+        let mut group = Group::new(1, creator, 1_000_000, cycle_duration, 10, 2, started_at, 0);
         group.member_count = 2;
         group.activate(started_at);
         store_group(&env, &group);
@@ -260,7 +273,7 @@ mod tests {
         let cycle_duration: u64 = 604800;
 
         let creator = Address::generate(&env);
-        let mut group = Group::new(1, creator, 1_000_000, cycle_duration, 10, 2, started_at);
+        let mut group = Group::new(1, creator, 1_000_000, cycle_duration, 10, 2, started_at, 0);
         group.member_count = 2;
         group.activate(started_at);
         store_group(&env, &group);
@@ -279,7 +292,7 @@ mod tests {
         let max_members: u32 = 5;
 
         let creator = Address::generate(&env);
-        let mut group = Group::new(1, creator, 1_000_000, cycle_duration, max_members, 2, started_at);
+        let mut group = Group::new(1, creator, 1_000_000, cycle_duration, max_members, 2, started_at, 0);
         group.member_count = 2;
         group.activate(started_at);
         store_group(&env, &group);

--- a/contracts/stellar-save/src/lib.rs
+++ b/contracts/stellar-save/src/lib.rs
@@ -390,11 +390,17 @@ impl StellarSaveContract {
         contribution_amount: i128,
         cycle_duration: u64,
         max_members: u32,
+        grace_period_seconds: u64,
     ) -> Result<u64, StellarSaveError> {
         // 1. Authorization: Only the creator can initiate this transaction
         creator.require_auth();
 
-        // 2. Global Validation: Check against ContractConfig
+        // 2. Validate grace period (max 7 days)
+        if grace_period_seconds > 604800 {
+            return Err(StellarSaveError::InvalidState);
+        }
+
+        // 3. Global Validation: Check against ContractConfig
         let config_key = StorageKeyBuilder::contract_config();
         if let Some(config) = env
             .storage()
@@ -412,10 +418,10 @@ impl StellarSaveContract {
             }
         }
 
-        // 3. Generate unique group ID
+        // 4. Generate unique group ID
         let group_id = Self::generate_next_group_id(&env)?;
 
-        // 4. Initialize Group Struct
+        // 5. Initialize Group Struct
         let current_time = env.ledger().timestamp();
         let min_members = 2; // Default minimum members
         let new_group = Group::new(
@@ -426,9 +432,10 @@ impl StellarSaveContract {
             max_members,
             min_members,
             current_time,
+            grace_period_seconds,
         );
 
-        // 5. Store Group Data
+        // 6. Store Group Data
         let group_key = StorageKeyBuilder::group_data(group_id);
         env.storage().persistent().set(&group_key, &new_group);
 
@@ -438,11 +445,11 @@ impl StellarSaveContract {
             .persistent()
             .set(&status_key, &GroupStatus::Pending);
 
-        // 6. Emit GroupCreated Event
+        // 7. Emit GroupCreated Event
         env.events()
             .publish((Symbol::new(&env, "GroupCreated"), creator), group_id);
 
-        // 7. Return Group ID
+        // 8. Return Group ID
         Ok(group_id)
     }
 
@@ -2155,7 +2162,25 @@ pub fn is_member(
         group_id: u64,
         cycle_number: u32,
     ) -> Result<Vec<Address>, StellarSaveError> {
-        // 1. Get all members in the group
+        // 1. Load the group to access grace_period_seconds and timing info
+        let group_key = StorageKeyBuilder::group_data(group_id);
+        let group: Group = env
+            .storage()
+            .persistent()
+            .get(&group_key)
+            .ok_or(StellarSaveError::GroupNotFound)?;
+
+        // 2. Only report misses after the grace period has elapsed
+        if group.started {
+            let cycle_deadline = group.started_at
+                + (group.cycle_duration * (cycle_number as u64 + 1));
+            let grace_end = cycle_deadline + group.grace_period_seconds;
+            if env.ledger().timestamp() <= grace_end {
+                return Ok(Vec::new(&env));
+            }
+        }
+
+        // 3. Get all members in the group
         let members_key = StorageKeyBuilder::group_members(group_id);
         let members: Vec<Address> = env
             .storage()
@@ -2163,21 +2188,16 @@ pub fn is_member(
             .get(&members_key)
             .ok_or(StellarSaveError::GroupNotFound)?;
 
-        // 2. Initialize result vector for non-contributors
+        // 4. Collect members with no contribution record for this cycle
         let mut missed_members = Vec::new(&env);
-
-        // 3. Check each member's contribution status for this cycle
         for member in members.iter() {
             let contrib_key =
                 StorageKeyBuilder::contribution_individual(group_id, cycle_number, member.clone());
-
-            // If no contribution record exists for this member in this cycle, they missed it
             if !env.storage().persistent().has(&contrib_key) {
                 missed_members.push_back(member);
             }
         }
 
-        // 4. Return vector of addresses who haven't contributed
         Ok(missed_members)
     }
 
@@ -2642,6 +2662,7 @@ pub fn is_member(
             5,          // Default max members
             2,          // Default min members
             timestamp,
+            0,          // No grace period
         );
 
         // Simulate adding members (in production, this would be tracked in storage)
@@ -2747,7 +2768,7 @@ fn test_get_total_groups() {
 
     // Create a group
     env.mock_all_auths();
-    client.create_group(&creator, &100, &3600, &5);
+    client.create_group(&creator, &100, &3600, &5, &0);
 
     // Total groups should now be 1
     assert_eq!(client.get_total_groups(), 1);
@@ -2767,7 +2788,7 @@ mod tests {
 
         // Manually store a group to test retrieval
         let group_id = 1;
-        let group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, 12345);
+        let group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, 12345, 0);
 
         // This simulates the storage state after create_group is called
         env.storage()
@@ -2799,7 +2820,7 @@ mod tests {
 
         // Create a group at cycle 2
         let group_id = 1;
-        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, 12345);
+        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, 12345, 0);
         group.current_cycle = 2;
 
         // Store the group
@@ -2827,7 +2848,7 @@ mod tests {
 
         // Create a group at cycle 2
         let group_id = 1;
-        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, 12345);
+        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, 12345, 0);
         group.current_cycle = 2;
 
         // Store the group
@@ -2920,7 +2941,7 @@ mod tests {
 
         // Create a group with initial member_count of 0
         let group_id = 1;
-        let group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, 12345);
+        let group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, 12345, 0);
 
         // Store the group
         env.storage()
@@ -2951,7 +2972,7 @@ mod tests {
 
         // Create a group at cycle 3
         let group_id = 1;
-        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, 12345);
+        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, 12345, 0);
         group.current_cycle = 3;
 
         // Simulate adding members
@@ -3094,13 +3115,13 @@ mod tests {
 
         // Create first group
         env.mock_all_auths();
-        client.create_group(&creator, &100, &3600, &5);
+        client.create_group(&creator, &100, &3600, &5, &0);
 
         let count = client.get_total_groups_created();
         assert_eq!(count, 1);
 
         // Create second group
-        client.create_group(&creator, &200, &7200, &10);
+        client.create_group(&creator, &200, &7200, &10, &0);
 
         let count = client.get_total_groups_created();
         assert_eq!(count, 2);
@@ -3128,7 +3149,7 @@ mod tests {
 
         // Create a group
         let group_id = 1;
-        let group = Group::new(group_id, member.clone(), 100, 3600, 5, 2, 12345);
+        let group = Group::new(group_id, member.clone(), 100, 3600, 5, 2, 12345, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(group_id), &group);
@@ -3334,7 +3355,7 @@ mod tests {
 
         // Create a group
         let group_id = 1;
-        let group = Group::new(group_id, member.clone(), 100, 3600, 5, 2, 12345);
+        let group = Group::new(group_id, member.clone(), 100, 3600, 5, 2, 12345, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(group_id), &group);
@@ -3635,7 +3656,7 @@ mod tests {
 
         // Create a group
         let group_id = 1;
-        let group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, 12345);
+        let group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, 12345, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(group_id), &group);
@@ -3962,7 +3983,7 @@ mod tests {
         let joined_at = 1704067200u64;
 
         // Store group data
-        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, joined_at);
+        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, joined_at, 0);
         group.member_count = 1; // Creator already joined
         let group_key = StorageKeyBuilder::group_data(group_id);
         env.storage().persistent().set(&group_key, &group);
@@ -4034,7 +4055,7 @@ mod tests {
         let joined_at = 1704067200u64;
 
         // Store group data
-        let group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, joined_at);
+        let group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, joined_at, 0);
         let group_key = StorageKeyBuilder::group_data(group_id);
         env.storage().persistent().set(&group_key, &group);
 
@@ -4073,7 +4094,7 @@ mod tests {
         let joined_at = 1704067200u64;
 
         // Store group data with max_members = 3 and member_count = 3 (full)
-        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, joined_at);
+        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, joined_at, 0);
         group.member_count = 3;
         let group_key = StorageKeyBuilder::group_data(group_id);
         env.storage().persistent().set(&group_key, &group);
@@ -4103,7 +4124,7 @@ mod tests {
         let joined_at = 1704067200u64;
 
         // Store group data
-        let group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, joined_at);
+        let group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, joined_at, 0);
         let group_key = StorageKeyBuilder::group_data(group_id);
         env.storage().persistent().set(&group_key, &group);
 
@@ -4133,7 +4154,7 @@ mod tests {
         let joined_at = 1704067200u64;
 
         // Store group data
-        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, joined_at);
+        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, joined_at, 0);
         group.member_count = 2; // Creator and one member already joined
         let group_key = StorageKeyBuilder::group_data(group_id);
         env.storage().persistent().set(&group_key, &group);
@@ -4210,7 +4231,7 @@ mod tests {
         let group_id = 1;
 
         // Setup: Create group and members
-        let group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, 1000);
+        let group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, 1000, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(group_id), &group);
@@ -4316,7 +4337,7 @@ mod tests {
         let group_id = 1;
 
         // Setup: Create group and members
-        let group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, 1000);
+        let group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, 1000, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(group_id), &group);
@@ -4400,7 +4421,7 @@ mod tests {
         let cycle = 0;
 
         // Setup: Create group and members
-        let group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, 1000);
+        let group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, 1000, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(group_id), &group);
@@ -4449,7 +4470,7 @@ mod tests {
         let group_id = 1;
 
         // Setup: Create group and members
-        let group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, 1000);
+        let group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, 1000, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(group_id), &group);
@@ -4533,7 +4554,7 @@ mod tests {
         let group_id = 1;
 
         // Setup: Create group
-        let group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, 1000);
+        let group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, 1000, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(group_id), &group);
@@ -4594,7 +4615,7 @@ mod tests {
         let group_id = 1;
 
         // Setup: Create active group
-        let group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, 1000);
+        let group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, 1000, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(group_id), &group);
@@ -4650,7 +4671,7 @@ mod tests {
         let group_id = 1;
 
         // Setup: Create group with 2 members
-        let group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, 1000);
+        let group = Group::new(group_id, creator.clone(), 100, 3600, 3, 2, 1000, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(group_id), &group);
@@ -4844,14 +4865,14 @@ mod tests {
         // Create multiple groups with different contribution amounts
         let group1_id = 1;
         let group1_amount = 10_000_000; // 1 XLM
-        let group1 = Group::new(group1_id, creator.clone(), group1_amount, 3600, 5, 2, 12345);
+        let group1 = Group::new(group1_id, creator.clone(), group1_amount, 3600, 5, 2, 12345, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(group1_id), &group1);
 
         let group2_id = 2;
         let group2_amount = 50_000_000; // 5 XLM
-        let group2 = Group::new(group2_id, creator.clone(), group2_amount, 3600, 5, 2, 12345);
+        let group2 = Group::new(group2_id, creator.clone(), group2_amount, 3600, 5, 2, 12345, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(group2_id), &group2);
@@ -5879,7 +5900,7 @@ mod tests {
         // Test with 1 week duration
         let group1_id = 1;
         let duration1 = 604800u64; // 1 week
-        let mut group1 = Group::new(group1_id, creator.clone(), 100, duration1, 5, 2, started_at);
+        let mut group1 = Group::new(group1_id, creator.clone(), 100, duration1, 5, 2, started_at, 0);
         group1.started = true;
         group1.started_at = started_at;
         env.storage()
@@ -5889,7 +5910,7 @@ mod tests {
         // Test with 1 month duration
         let group2_id = 2;
         let duration2 = 2592000u64; // 30 days
-        let mut group2 = Group::new(group2_id, creator.clone(), 100, duration2, 5, 2, started_at);
+        let mut group2 = Group::new(group2_id, creator.clone(), 100, duration2, 5, 2, started_at, 0);
         group2.started = true;
         group2.started_at = started_at;
         env.storage()
@@ -6172,7 +6193,7 @@ mod tests {
         // Test with 1 hour duration
         let group1_id = 1;
         let duration1 = 3600u64; // 1 hour
-        let mut group1 = Group::new(group1_id, creator.clone(), 100, duration1, 5, 2, started_at);
+        let mut group1 = Group::new(group1_id, creator.clone(), 100, duration1, 5, 2, started_at, 0);
         group1.started = true;
         group1.started_at = started_at;
         group1.current_cycle = 0;
@@ -6183,7 +6204,7 @@ mod tests {
         // Test with 1 week duration
         let group2_id = 2;
         let duration2 = 604800u64; // 1 week
-        let mut group2 = Group::new(group2_id, creator.clone(), 100, duration2, 5, 2, started_at);
+        let mut group2 = Group::new(group2_id, creator.clone(), 100, duration2, 5, 2, started_at, 0);
         group2.started = true;
         group2.started_at = started_at;
         group2.current_cycle = 0;
@@ -6406,7 +6427,7 @@ mod tests {
         let creator = Address::generate(&env);
         let group_id = 1;
 
-        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, 12345);
+        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 5, 2, 12345, 0);
         group.status = GroupStatus::Pending;
         env.storage()
             .persistent()
@@ -6424,7 +6445,7 @@ mod tests {
         let creator = Address::generate(&env);
         let group_id = 1;
 
-        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 2, 2, 12345);
+        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 2, 2, 12345, 0);
         group.status = GroupStatus::Active;
         group.member_count = 2;
         env.storage()
@@ -6461,7 +6482,7 @@ mod tests {
         let creator = Address::generate(&env);
         let group_id = 1;
 
-        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 2, 2, 12345);
+        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 2, 2, 12345, 0);
         group.status = GroupStatus::Active;
         group.member_count = 2;
         env.storage()
@@ -6498,7 +6519,7 @@ mod tests {
         let creator = Address::generate(&env);
         let group_id = 1;
 
-        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 2, 2, 12345);
+        let mut group = Group::new(group_id, creator.clone(), 100, 3600, 2, 2, 12345, 0);
         group.status = GroupStatus::Active;
         group.member_count = 2;
         env.storage()
@@ -8660,7 +8681,7 @@ mod tests {
         let client = StellarSaveContractClient::new(&env, &contract_id);
         let creator = Address::generate(&env);
 
-        let group = Group::new(1, creator.clone(), 100, 3600, 5, 2, 12345);
+        let group = Group::new(1, creator.clone(), 100, 3600, 5, 2, 12345, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(1), &group);
@@ -8679,7 +8700,7 @@ mod tests {
         let member1 = Address::generate(&env);
         let member2 = Address::generate(&env);
 
-        let group = Group::new(1, creator.clone(), 100, 3600, 5, 2, 12345);
+        let group = Group::new(1, creator.clone(), 100, 3600, 5, 2, 12345, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(1), &group);
@@ -8703,7 +8724,7 @@ mod tests {
         let creator = Address::generate(&env);
         let member = Address::generate(&env);
 
-        let group = Group::new(1, creator.clone(), 100, 3600, 5, 2, 12345);
+        let group = Group::new(1, creator.clone(), 100, 3600, 5, 2, 12345, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(1), &group);
@@ -8726,7 +8747,7 @@ mod tests {
         let creator = Address::generate(&env);
         let recipient = Address::generate(&env);
 
-        let mut group = Group::new(1, creator.clone(), 100, 3600, 5, 2, 12345);
+        let mut group = Group::new(1, creator.clone(), 100, 3600, 5, 2, 12345, 0);
         group.current_cycle = 2;
         env.storage()
             .persistent()
@@ -8749,7 +8770,7 @@ mod tests {
         let creator = Address::generate(&env);
         let member = Address::generate(&env);
 
-        let group = Group::new(1, creator.clone(), 100, 3600, 5, 2, 12345);
+        let group = Group::new(1, creator.clone(), 100, 3600, 5, 2, 12345, 0);
         env.storage()
             .persistent()
             .set(&StorageKeyBuilder::group_data(1), &group);
@@ -8864,5 +8885,187 @@ mod tests {
         assert_eq!(GroupStatus::from_u32(3), Some(GroupStatus::Completed));
         assert_eq!(GroupStatus::from_u32(4), Some(GroupStatus::Cancelled));
         assert_eq!(GroupStatus::from_u32(5), None);
+    }
+
+    // ── Grace period tests ────────────────────────────────────────────────────
+
+    /// Helper: create a group with a grace period, store it, and return (group_id, client).
+    fn setup_group_with_grace(
+        env: &Env,
+        grace_period_seconds: u64,
+    ) -> (u64, StellarSaveContractClient) {
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = StellarSaveContractClient::new(env, &contract_id);
+        let creator = Address::generate(env);
+        env.mock_all_auths();
+        let group_id = client
+            .create_group(&creator, &10_000_000, &604800, &5, &grace_period_seconds)
+            .unwrap();
+        (group_id, client)
+    }
+
+    #[test]
+    fn test_create_group_stores_grace_period() {
+        let env = Env::default();
+        let (group_id, client) = setup_group_with_grace(&env, 3600);
+        let group = client.get_group(&group_id).unwrap();
+        assert_eq!(group.grace_period_seconds, 3600);
+    }
+
+    #[test]
+    fn test_create_group_zero_grace_period() {
+        let env = Env::default();
+        let (group_id, client) = setup_group_with_grace(&env, 0);
+        let group = client.get_group(&group_id).unwrap();
+        assert_eq!(group.grace_period_seconds, 0);
+    }
+
+    #[test]
+    fn test_create_group_max_grace_period() {
+        let env = Env::default();
+        // 604800 = exactly 7 days — should succeed
+        let (group_id, client) = setup_group_with_grace(&env, 604800);
+        let group = client.get_group(&group_id).unwrap();
+        assert_eq!(group.grace_period_seconds, 604800);
+    }
+
+    #[test]
+    fn test_create_group_grace_period_exceeds_max() {
+        let env = Env::default();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = StellarSaveContractClient::new(&env, &contract_id);
+        let creator = Address::generate(&env);
+        env.mock_all_auths();
+        // 604801 = 7 days + 1 second — should fail
+        let result = client.try_create_group(&creator, &10_000_000, &604800, &5, &604801);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_missed_contributions_within_grace_period() {
+        let env = Env::default();
+        let started_at: u64 = 1000;
+        let cycle_duration: u64 = 604800;
+        let grace: u64 = 3600; // 1 hour
+
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = StellarSaveContractClient::new(&env, &contract_id);
+        let creator = Address::generate(&env);
+        let member = Address::generate(&env);
+
+        env.mock_all_auths();
+        env.ledger().set_timestamp(started_at);
+
+        let group_id = client
+            .create_group(&creator, &10_000_000, &cycle_duration, &5, &grace)
+            .unwrap();
+
+        // Store members list directly so get_missed_contributions can find them
+        let members_key = StorageKeyBuilder::group_members(group_id);
+        let mut members = soroban_sdk::Vec::new(&env);
+        members.push_back(member.clone());
+        env.storage().persistent().set(&members_key, &members);
+
+        // Activate the group
+        let group_key = StorageKeyBuilder::group_data(group_id);
+        let mut group: Group = env.storage().persistent().get(&group_key).unwrap();
+        group.member_count = 2;
+        group.activate(started_at);
+        env.storage().persistent().set(&group_key, &group);
+
+        // Advance time to just after the deadline but still within grace period
+        let deadline = started_at + cycle_duration;
+        env.ledger().set_timestamp(deadline + grace / 2);
+
+        // Should return empty — still within grace period
+        let missed = client.get_missed_contributions(&group_id, &0).unwrap();
+        assert_eq!(missed.len(), 0);
+    }
+
+    #[test]
+    fn test_get_missed_contributions_after_grace_period() {
+        let env = Env::default();
+        let started_at: u64 = 1000;
+        let cycle_duration: u64 = 604800;
+        let grace: u64 = 3600; // 1 hour
+
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = StellarSaveContractClient::new(&env, &contract_id);
+        let creator = Address::generate(&env);
+        let member = Address::generate(&env);
+
+        env.mock_all_auths();
+        env.ledger().set_timestamp(started_at);
+
+        let group_id = client
+            .create_group(&creator, &10_000_000, &cycle_duration, &5, &grace)
+            .unwrap();
+
+        // Store members list
+        let members_key = StorageKeyBuilder::group_members(group_id);
+        let mut members = soroban_sdk::Vec::new(&env);
+        members.push_back(member.clone());
+        env.storage().persistent().set(&members_key, &members);
+
+        // Activate the group
+        let group_key = StorageKeyBuilder::group_data(group_id);
+        let mut group: Group = env.storage().persistent().get(&group_key).unwrap();
+        group.member_count = 2;
+        group.activate(started_at);
+        env.storage().persistent().set(&group_key, &group);
+
+        // Advance time past deadline + grace period
+        let deadline = started_at + cycle_duration;
+        env.ledger().set_timestamp(deadline + grace + 1);
+
+        // Member has not contributed — should appear in missed list
+        let missed = client.get_missed_contributions(&group_id, &0).unwrap();
+        assert_eq!(missed.len(), 1);
+        assert_eq!(missed.get(0).unwrap(), member);
+    }
+
+    #[test]
+    fn test_get_missed_contributions_contributed_within_grace_period() {
+        let env = Env::default();
+        let started_at: u64 = 1000;
+        let cycle_duration: u64 = 604800;
+        let grace: u64 = 3600;
+
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = StellarSaveContractClient::new(&env, &contract_id);
+        let creator = Address::generate(&env);
+        let member = Address::generate(&env);
+
+        env.mock_all_auths();
+        env.ledger().set_timestamp(started_at);
+
+        let group_id = client
+            .create_group(&creator, &10_000_000, &cycle_duration, &5, &grace)
+            .unwrap();
+
+        // Store members list
+        let members_key = StorageKeyBuilder::group_members(group_id);
+        let mut members = soroban_sdk::Vec::new(&env);
+        members.push_back(member.clone());
+        env.storage().persistent().set(&members_key, &members);
+
+        // Activate the group
+        let group_key = StorageKeyBuilder::group_data(group_id);
+        let mut group: Group = env.storage().persistent().get(&group_key).unwrap();
+        group.member_count = 2;
+        group.activate(started_at);
+        env.storage().persistent().set(&group_key, &group);
+
+        // Member contributes during grace period
+        let contrib_key = StorageKeyBuilder::contribution_individual(group_id, 0, member.clone());
+        env.storage().persistent().set(&contrib_key, &true);
+
+        // Advance time past deadline + grace period
+        let deadline = started_at + cycle_duration;
+        env.ledger().set_timestamp(deadline + grace + 1);
+
+        // Member contributed — should NOT appear in missed list
+        let missed = client.get_missed_contributions(&group_id, &0).unwrap();
+        assert_eq!(missed.len(), 0);
     }
 }

--- a/docs/storage-layout.md
+++ b/docs/storage-layout.md
@@ -23,7 +23,7 @@ The following table summarizes all `StorageKey` variants used in the contract:
 | **Admin** | `EmergencyPause` | Instance | Boolean flag to pause/unpause contract operations. |
 | **Security** | `ReentrancyGuard` | Temporary | Flag to prevent reentrancy during fund transfers. |
 | **Rate Limiting** | `LastGroupCreation(Address)`, `LastGroupJoin(Address)` | Temporary | Timestamps of a user's last major actions. |
-| **Group Data** | `Data(u64)` | Persistent | The core `Group` struct containing configuration and state. |
+| **Group Data** | `Data(u64)` | Persistent | The core `Group` struct containing configuration, state, and `grace_period_seconds`. |
 | **Group State** | `Members(u64)`, `Status(u64)`, `GroupBalance(u64)`, `GroupTotalPaidOut(u64)` | Persistent | Member list (Vec), group lifecycle status, and incremental balances. |
 | **Member Data** | `Profile(u64, Address)`, `PayoutEligibility(u64, Address)`, `TotalContributions(u64, Address)` | Persistent | Individual member profiles, payout positions, and aggregate contributions. |
 | **Transactions** | `Individual(u64, cycle, Address)`, `CycleTotal(u64, cycle)`, `CycleCount(u64, cycle)` | Persistent | Contribution records, totals, and counts per group and cycle. |
@@ -36,9 +36,12 @@ The following table summarizes all `StorageKey` variants used in the contract:
 ### Group Struct
 The `Group` struct is the central entity for any ROSCA. It stores:
 - **Identity**: Unique sequential ID and creator address.
-- **Config**: Contribution amount (stroops), cycle duration (seconds), and member limits.
+- **Config**: Contribution amount (stroops), cycle duration (seconds), member limits, and `grace_period_seconds` (0–604800).
 - **State**: Current member count, current cycle index (0-indexed), and activation status.
 - **Lifecycle**: `GroupStatus` enum (Pending, Active, Paused, Completed, Cancelled).
+
+#### `grace_period_seconds`
+An optional window (in seconds) after the cycle deadline during which a member may still contribute without being counted as having missed the cycle. Validated at group creation; maximum value is **604800** (7 days). Defaults to `0` (no grace period). Stored as part of the `Group` struct at `GroupKey::Data(id)`.
 
 ### Member Tracking
 Member tracking is handled via a combination of a membership list and individual profiles:


### PR DESCRIPTION
Add configurable grace period to ROSCA groups                                                                       
                                                                                                                      
  Overview                                                                                                            
                                                                                                                      
  This PR introduces a grace_period_seconds field to the Group struct, allowing group creators to configure a buffer  
  window after the contribution deadline before a member is considered to have missed their contribution. This mirrors
  how real-world Ajo/Esusu groups operate — a short grace period is commonly given before any social or financial     
  penalty is applied.                                                                                                 
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  Problem                                                                                                             
                                                                                                                      
  Previously, is_cycle_deadline_passed() and get_missed_contributions() treated the cycle deadline as a hard cutoff. A
  member who contributed one second late would immediately appear as having missed the cycle, with no flexibility for 
  network delays, timezone differences, or real-world circumstances.                                                  
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  Solution                                                                                                            
                                                                                                                      
  A new optional grace_period_seconds field is added to the Group struct. When set, the system waits until            
  cycle_deadline + grace_period_seconds has elapsed before:                                                           
                                                                                                                      
  - reporting the deadline as passed                                                                                  
  - listing any member as having missed their contribution                                                            
                                                                                                                      
  The field defaults to 0 (no grace period), preserving all existing behaviour.                                       
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  Changes                                                                                                             
                                                                                                                      
  `contracts/stellar-save/src/group.rs`                                                                               
                                                                                                                      
  - Added grace_period_seconds: u64 field to Group struct                                                             
  - Updated Group::new() to accept and validate the field — panics if value exceeds 604800 (7 days)                   
  - Cleaned up test module: replaced all old Group::new calls with new 8-arg signature via a make_group helper        
  - Added test_group_creation_with_grace_period and test_invalid_grace_period tests                                   
                                                                                                                      
  `contracts/stellar-save/src/helpers.rs`                                                                             
                                                                                                                      
  - is_cycle_deadline_passed(): changed comparison from current_time > cycle_deadline to current_time > cycle_deadline
  + group.grace_period_seconds                                                                                        
  - Added test_is_cycle_deadline_passed_within_grace_period test covering the exact boundary                          
  - Updated all Group::new calls in existing tests                                                                    
                                                                                                                      
  `contracts/stellar-save/src/lib.rs`                                                                                 
                                                                                                                      
  - create_group(): added grace_period_seconds: u64 parameter; returns InvalidState if value exceeds 604800           
  - get_missed_contributions(): loads the group, computes grace_end = cycle_deadline + grace_period_seconds, returns  
  empty vec if current_time <= grace_end                                                                              
  - Updated all Group::new and create_group call sites in existing tests                                              
  - Added 7 new integration tests (see Testing section below)                                                         
                                                                                                                      
  `docs/storage-layout.md`                                                                                            
                                                                                                                      
  - Updated Group Data table row to mention grace_period_seconds                                                      
  - Added dedicated subsection under Group Struct documenting the field, valid range, and default                     
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  API change                                                                                                          
                                                                                                                      
  create_group now takes an additional parameter:                                                                     
                                                                                                                      
  // Before                                                                                                           
  create_group(env, creator, contribution_amount, cycle_duration, max_members)                                        
                                                                                                                      
  // After                                                                                                            
  create_group(env, creator, contribution_amount, cycle_duration, max_members, grace_period_seconds)                  
                                                                                                                      
  Pass 0 for no grace period (identical to previous behaviour).                                                       
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  Validation                                                                                                          
                                                                                                                      
  ┌────────────────────┬──────────────────────────────────┐                                                           
  │ Constraint         │ Value                            │                                                           
  ├────────────────────┼──────────────────────────────────┤                                                           
  │ Minimum            │ `0` (no grace period)            │                                                           
  │ Maximum            │ `604800` (7 days)                │                                                           
  │ Error on violation │ `StellarSaveError::InvalidState` │                                                           
  └────────────────────┴──────────────────────────────────┘                                                           
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  Testing                                                                                                             
                                                                                                                      
  7 new tests added to lib.rs:                                                                                        
                                                                                                                      
  ┌─────────────────────────────────────────────────────────────────┬─────────────────────────────────────────────────
  ────────────┐                                                                                                       
  │ Test                                                            │ What it verifies                                
                                              │                                                                       
  ├─────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────
  ────────────┤                                                                                                       
  │ `test_create_group_stores_grace_period`                         │ Field is persisted correctly                    
                                  │                                                                                   
  │ `test_create_group_zero_grace_period`                           │ Zero is accepted and stored                     
                                   │                                                                                  
  │ `test_create_group_max_grace_period`                            │ 604800 is accepted (boundary)                   
                                 │                                                                                    
  │ `test_create_group_grace_period_exceeds_max`                    │ 604801 is rejected                              
                                            │                                                                         
  │ `test_get_missed_contributions_within_grace_period`             │ Returns empty list during grace window          
                        │                                                                                             
  │ `test_get_missed_contributions_after_grace_period`              │ Returns missed members after grace expires      
                    │                                                                                                 
  │ `test_get_missed_contributions_contributed_within_grace_period` │ Member who contributed during grace is not      
  listed as missed │                                                                                                  
  └─────────────────────────────────────────────────────────────────┴─────────────────────────────────────────────────
  ────────────┘                                                                                                       
                                                                                                                      
  Plus test_is_cycle_deadline_passed_within_grace_period in helpers.rs covering the exact deadline + grace boundary.  
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  Backwards compatibility                                                                                             
                                                                                                                      
  - Default grace_period_seconds = 0 means no behaviour change for existing groups                                    
  - All existing tests pass with the updated Group::new signature                                                     
  - No storage migration required — new groups created after this change will include the field; the field is part of 
  the Group struct serialised at creation time                                                                        
    
  closes #459 