### PR TITLE
feat: implement cycle progression logic for rotational savings groups

### DIFF
--- a/contracts/stellar-save/src/cycle_advancement.rs
+++ b/contracts/stellar-save/src/cycle_advancement.rs
@@ -2,288 +2,328 @@ use soroban_sdk::{Address, Env};
 use crate::{
     error::StellarSaveError,
     events::EventEmitter,
-    group::Group,
+    group::{Group, GroupStatus},
     storage::StorageKeyBuilder,
 };
 
-/// Helper function to advance a group to the next cycle after payout.
+// ─── Cycle Calculation ────────────────────────────────────────────────────────
+
+/// Returns the current cycle index (0-indexed) based on elapsed time.
 ///
-/// This function encapsulates the complete logic for transitioning a group
-/// from one cycle to the next after a successful payout. It performs all
-/// necessary validations, updates, and event emissions.
+/// Formula: `floor((now - started_at) / cycle_duration)`
 ///
-/// # Arguments
-/// * `env` - The Soroban environment
-/// * `group` - Mutable reference to the group being advanced
-/// * `group_id` - The ID of the group
-/// * `caller` - The address of the caller (for event emission)
+/// Returns `0` if the group has not started yet or `now < started_at`.
+pub fn get_current_cycle(group: &Group, now: u64) -> u32 {
+    if !group.started || now < group.started_at || group.cycle_duration == 0 {
+        return 0;
+    }
+    let elapsed = now - group.started_at;
+    let cycle = elapsed / group.cycle_duration;
+    // Cap at max_members so we never exceed the group's total cycles
+    (cycle as u32).min(group.max_members)
+}
+
+/// Returns the start timestamp of a given cycle.
 ///
-/// # Returns
-/// * `Ok(())` if the cycle advancement was successful
-/// * `Err(StellarSaveError)` if validation fails
+/// `cycle_start = started_at + (cycle_number * cycle_duration)`
+pub fn get_cycle_start(group: &Group, cycle_number: u32) -> Result<u64, StellarSaveError> {
+    let offset = (cycle_number as u64)
+        .checked_mul(group.cycle_duration)
+        .ok_or(StellarSaveError::Overflow)?;
+    group.started_at.checked_add(offset).ok_or(StellarSaveError::Overflow)
+}
+
+/// Returns the deadline (end timestamp) of a given cycle.
 ///
-/// # Errors
-/// * `CycleNotComplete` - If the cycle is not yet complete (payout not verified)
-/// * `InvalidState` - If the group is not in a valid state for advancement
+/// `deadline = started_at + ((cycle_number + 1) * cycle_duration)`
+pub fn get_cycle_deadline(group: &Group, cycle_number: u32) -> Result<u64, StellarSaveError> {
+    let next = (cycle_number as u64)
+        .checked_add(1)
+        .ok_or(StellarSaveError::Overflow)?;
+    let offset = next
+        .checked_mul(group.cycle_duration)
+        .ok_or(StellarSaveError::Overflow)?;
+    group.started_at.checked_add(offset).ok_or(StellarSaveError::Overflow)
+}
+
+// ─── Deadline Validation ──────────────────────────────────────────────────────
+
+/// Returns `true` when the given cycle's deadline has passed.
 ///
-/// # Side Effects
-/// * Updates group's current_cycle counter
-/// * Updates group's is_active flag if group is now complete
-/// * Persists updated group to storage
-/// * Emits GroupStatusChanged event if group transitions to Completed
-pub fn advance_group_to_next_cycle(
+/// An optional `grace_period` (in seconds) allows minor clock drift.
+pub fn is_cycle_expired(
+    group: &Group,
+    cycle_number: u32,
+    now: u64,
+    grace_period: u64,
+) -> Result<bool, StellarSaveError> {
+    let deadline = get_cycle_deadline(group, cycle_number)?;
+    Ok(now > deadline.saturating_add(grace_period))
+}
+
+// ─── Cycle Transition ─────────────────────────────────────────────────────────
+
+/// Attempts to advance the group to the next cycle.
+///
+/// This is the main entry-point for cycle progression. It:
+/// 1. Validates the group is active and not already complete.
+/// 2. Checks the current cycle's deadline has passed (time-based trigger).
+/// 3. Emits a `CycleEnded` event for the outgoing cycle.
+/// 4. Increments `current_cycle` and persists the updated group.
+/// 5. Emits a `CycleStarted` event for the new cycle (unless group is now complete).
+/// 6. Emits `GroupStatusChanged` / `GroupCompleted` when the final cycle ends.
+///
+/// Idempotent: if `group.current_cycle` already reflects the time-derived cycle
+/// no transition is performed and `Ok(false)` is returned.
+///
+/// Returns `Ok(true)` when a transition occurred, `Ok(false)` when not needed.
+pub fn try_advance_cycle(
     env: &Env,
-    group: &mut Group,
     group_id: u64,
     caller: &Address,
-) -> Result<(), StellarSaveError> {
-    // Task 1: Verify cycle is complete
-    // Check that the group is not already complete
+) -> Result<bool, StellarSaveError> {
+    let group_key = StorageKeyBuilder::group_data(group_id);
+    let mut group: Group = env
+        .storage()
+        .persistent()
+        .get::<_, Group>(&group_key)
+        .ok_or(StellarSaveError::GroupNotFound)?;
+
+    // Must be active and started
+    if group.status != GroupStatus::Active || !group.started {
+        return Err(StellarSaveError::InvalidState);
+    }
+
+    // Already finished all cycles
     if group.is_complete() {
         return Err(StellarSaveError::InvalidState);
     }
 
-    // Task 2: Increment cycle counter
-    group.advance_cycle();
+    let now = env.ledger().timestamp();
+    let time_cycle = get_current_cycle(&group, now);
 
-    // Task 3: Update group storage
-    let group_key = StorageKeyBuilder::group_data(group_id);
-    env.storage().persistent().set(&group_key, group);
+    // Nothing to do — time hasn't moved past the current cycle boundary
+    if time_cycle <= group.current_cycle {
+        return Ok(false);
+    }
 
-    // Task 4: Emit event
-    // Emit GroupStatusChanged event when transitioning to Completed state
-    if group.is_complete() {
-        let old_status = (group.current_cycle - 1) as u32;
-        let new_status = 3u32; // Completed status code
-        let timestamp = env.ledger().timestamp();
+    // Prevent skipping more than one cycle at a time
+    let next_cycle = group.current_cycle + 1;
 
+    // Emit CycleEnded for the cycle we're leaving
+    EventEmitter::emit_cycle_ended(env, group_id, group.current_cycle, now);
+
+    // Advance the cycle counter (group.advance_cycle also handles completion)
+    group.advance_cycle(env);
+
+    // Persist updated group
+    env.storage().persistent().set(&group_key, &group);
+
+    // Emit CycleStarted for the new cycle (only if group is still running)
+    if !group.is_complete() {
+        EventEmitter::emit_cycle_started(env, group_id, next_cycle, now);
+    } else {
+        // Emit GroupStatusChanged → Completed
         EventEmitter::emit_group_status_changed(
             env,
             group_id,
-            old_status,
-            new_status,
+            GroupStatus::Active as u32,
+            GroupStatus::Completed as u32,
             caller.clone(),
-            timestamp,
+            now,
         );
     }
 
-    Ok(())
+    Ok(true)
 }
 
-/// Core logic for advancing a group cycle without storage operations.
-/// This is useful for testing and for scenarios where storage is managed separately.
+/// Pure logic version of cycle advancement (no storage, no events).
 ///
-/// # Arguments
-/// * `group` - Mutable reference to the group being advanced
-///
-/// # Returns
-/// * `Ok(())` if the cycle advancement was successful
-/// * `Err(StellarSaveError)` if validation fails
-///
-/// # Errors
-/// * `InvalidState` - If the group is already complete
-pub fn advance_group_cycle_logic(group: &mut Group) -> Result<(), StellarSaveError> {
-    // Verify cycle is complete
+/// Useful for unit tests and scenarios where storage is managed externally.
+/// Returns `Err(InvalidState)` if the group is already complete.
+pub fn advance_group_cycle_logic(
+    env: &Env,
+    group: &mut Group,
+) -> Result<(), StellarSaveError> {
     if group.is_complete() {
         return Err(StellarSaveError::InvalidState);
     }
-
-    // Increment cycle counter
-    group.advance_cycle();
-
+    group.advance_cycle(env);
     Ok(())
 }
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use soroban_sdk::{testutils::Address as _, Env};
 
+    fn make_group(env: &Env, max_members: u32, cycle_duration: u64, started_at: u64) -> Group {
+        let creator = Address::generate(env);
+        let mut g = Group::new(1, creator, 10_000_000, cycle_duration, max_members, 2, started_at);
+        // Simulate min members joined so activate works
+        g.member_count = max_members;
+        g.activate(started_at);
+        g
+    }
+
+    // ── get_current_cycle ──────────────────────────────────────────────────
+
     #[test]
-    fn test_advance_group_cycle_logic_success() {
+    fn test_get_current_cycle_before_start() {
         let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let mut group = Group::new(
-            1,
-            creator,
-            10_000_000, // 1 XLM
-            604800,     // 1 week
-            3,          // 3 members
-            1234567890,
-        );
-
-        assert_eq!(group.current_cycle, 0);
-        assert!(group.is_active);
-
-        let result = advance_group_cycle_logic(&mut group);
-
-        assert!(result.is_ok());
-        assert_eq!(group.current_cycle, 1);
-        assert!(group.is_active); // Still active, not complete yet
+        let g = make_group(&env, 4, 604800, 1_000_000);
+        // now < started_at
+        assert_eq!(get_current_cycle(&g, 999_999), 0);
     }
 
     #[test]
-    fn test_advance_group_cycle_logic_multiple_times() {
+    fn test_get_current_cycle_at_start() {
         let env = Env::default();
-        let creator = Address::generate(&env);
+        let g = make_group(&env, 4, 604800, 1_000_000);
+        assert_eq!(get_current_cycle(&g, 1_000_000), 0);
+    }
 
-        let mut group = Group::new(
-            1,
-            creator,
-            10_000_000,
-            604800,
-            3,
-            1234567890,
-        );
+    #[test]
+    fn test_get_current_cycle_mid_first_cycle() {
+        let env = Env::default();
+        let g = make_group(&env, 4, 604800, 0);
+        assert_eq!(get_current_cycle(&g, 300_000), 0);
+    }
 
-        // Advance through all cycles
-        for i in 0..3 {
-            let result = advance_group_cycle_logic(&mut group);
-            assert!(result.is_ok());
-            assert_eq!(group.current_cycle, i + 1);
+    #[test]
+    fn test_get_current_cycle_exact_boundary() {
+        let env = Env::default();
+        let g = make_group(&env, 4, 604800, 0);
+        // Exactly at the start of cycle 1
+        assert_eq!(get_current_cycle(&g, 604800), 1);
+    }
+
+    #[test]
+    fn test_get_current_cycle_multiple_cycles() {
+        let env = Env::default();
+        let g = make_group(&env, 4, 604800, 0);
+        assert_eq!(get_current_cycle(&g, 604800 * 2 + 1), 2);
+        assert_eq!(get_current_cycle(&g, 604800 * 3), 3);
+    }
+
+    #[test]
+    fn test_get_current_cycle_capped_at_max_members() {
+        let env = Env::default();
+        let g = make_group(&env, 3, 604800, 0);
+        // Way past all cycles
+        assert_eq!(get_current_cycle(&g, 604800 * 100), 3);
+    }
+
+    // ── is_cycle_expired ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_is_cycle_expired_false_before_deadline() {
+        let env = Env::default();
+        let g = make_group(&env, 4, 604800, 0);
+        // Deadline for cycle 0 = 604800; now = 604799
+        assert_eq!(is_cycle_expired(&g, 0, 604799, 0).unwrap(), false);
+    }
+
+    #[test]
+    fn test_is_cycle_expired_false_at_deadline() {
+        let env = Env::default();
+        let g = make_group(&env, 4, 604800, 0);
+        assert_eq!(is_cycle_expired(&g, 0, 604800, 0).unwrap(), false);
+    }
+
+    #[test]
+    fn test_is_cycle_expired_true_after_deadline() {
+        let env = Env::default();
+        let g = make_group(&env, 4, 604800, 0);
+        assert_eq!(is_cycle_expired(&g, 0, 604801, 0).unwrap(), true);
+    }
+
+    #[test]
+    fn test_is_cycle_expired_grace_period() {
+        let env = Env::default();
+        let g = make_group(&env, 4, 604800, 0);
+        // 60-second grace: deadline + 60 = 604860; now = 604850 → still active
+        assert_eq!(is_cycle_expired(&g, 0, 604850, 60).unwrap(), false);
+        // now = 604861 → expired
+        assert_eq!(is_cycle_expired(&g, 0, 604861, 60).unwrap(), true);
+    }
+
+    // ── advance_group_cycle_logic ─────────────────────────────────────────
+
+    #[test]
+    fn test_advance_cycle_logic_success() {
+        let env = Env::default();
+        let mut g = make_group(&env, 3, 604800, 0);
+        assert_eq!(g.current_cycle, 0);
+        advance_group_cycle_logic(&env, &mut g).unwrap();
+        assert_eq!(g.current_cycle, 1);
+        assert!(g.is_active);
+    }
+
+    #[test]
+    fn test_advance_cycle_logic_to_completion() {
+        let env = Env::default();
+        let mut g = make_group(&env, 2, 604800, 0);
+        advance_group_cycle_logic(&env, &mut g).unwrap();
+        advance_group_cycle_logic(&env, &mut g).unwrap();
+        assert!(g.is_complete());
+        assert!(!g.is_active);
+    }
+
+    #[test]
+    fn test_advance_cycle_logic_error_when_complete() {
+        let env = Env::default();
+        let mut g = make_group(&env, 2, 604800, 0);
+        g.current_cycle = 2;
+        g.is_active = false;
+        let err = advance_group_cycle_logic(&env, &mut g).unwrap_err();
+        assert_eq!(err, StellarSaveError::InvalidState);
+    }
+
+    #[test]
+    fn test_advance_cycle_logic_preserves_config() {
+        let env = Env::default();
+        let mut g = make_group(&env, 4, 604800, 0);
+        let orig_amount = g.contribution_amount;
+        let orig_duration = g.cycle_duration;
+        advance_group_cycle_logic(&env, &mut g).unwrap();
+        assert_eq!(g.contribution_amount, orig_amount);
+        assert_eq!(g.cycle_duration, orig_duration);
+    }
+
+    #[test]
+    fn test_advance_cycle_logic_full_progression() {
+        let env = Env::default();
+        let mut g = make_group(&env, 4, 604800, 0);
+        for expected in 1u32..=4 {
+            advance_group_cycle_logic(&env, &mut g).unwrap();
+            assert_eq!(g.current_cycle, expected);
         }
+        assert!(g.is_complete());
+    }
 
-        // After final advancement, group should be complete and inactive
-        assert!(group.is_complete());
-        assert!(!group.is_active);
+    // ── get_cycle_deadline ────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_cycle_deadline_cycle_0() {
+        let env = Env::default();
+        let g = make_group(&env, 4, 604800, 0);
+        assert_eq!(get_cycle_deadline(&g, 0).unwrap(), 604800);
     }
 
     #[test]
-    fn test_advance_group_cycle_logic_when_complete() {
+    fn test_get_cycle_deadline_cycle_1() {
         let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let mut group = Group::new(
-            1,
-            creator,
-            10_000_000,
-            604800,
-            2,
-            1234567890,
-        );
-
-        // Advance to completion
-        group.current_cycle = 2;
-        group.is_active = false;
-
-        let result = advance_group_cycle_logic(&mut group);
-
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), StellarSaveError::InvalidState);
+        let g = make_group(&env, 4, 604800, 0);
+        assert_eq!(get_cycle_deadline(&g, 1).unwrap(), 604800 * 2);
     }
 
     #[test]
-    fn test_advance_group_cycle_logic_completion() {
+    fn test_get_cycle_deadline_with_offset_start() {
         let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let mut group = Group::new(
-            1,
-            creator,
-            10_000_000,
-            604800,
-            2,
-            1234567890,
-        );
-
-        // Advance to the final cycle
-        group.current_cycle = 1;
-
-        let result = advance_group_cycle_logic(&mut group);
-
-        assert!(result.is_ok());
-        assert!(group.is_complete());
-        assert!(!group.is_active);
-    }
-
-    #[test]
-    fn test_advance_group_cycle_logic_intermediate() {
-        let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let mut group = Group::new(
-            1,
-            creator,
-            10_000_000,
-            604800,
-            5,
-            1234567890,
-        );
-
-        // Advance from cycle 0 to 1 (not completion)
-        let result = advance_group_cycle_logic(&mut group);
-
-        assert!(result.is_ok());
-        assert_eq!(group.current_cycle, 1);
-        assert!(group.is_active); // Still active
-    }
-
-    #[test]
-    fn test_advance_group_cycle_logic_maintains_properties() {
-        let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let original_contribution = 10_000_000;
-        let original_cycle_duration = 604800;
-        let original_max_members = 4;
-
-        let mut group = Group::new(
-            1,
-            creator.clone(),
-            original_contribution,
-            original_cycle_duration,
-            original_max_members,
-            1234567890,
-        );
-
-        advance_group_cycle_logic(&mut group).unwrap();
-
-        // Verify immutable properties are unchanged
-        assert_eq!(group.contribution_amount, original_contribution);
-        assert_eq!(group.cycle_duration, original_cycle_duration);
-        assert_eq!(group.max_members, original_max_members);
-        assert_eq!(group.creator, creator);
-    }
-
-    #[test]
-    fn test_advance_group_cycle_logic_progression() {
-        let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 4, 1234567890);
-
-        // Verify cycle progression
-        assert_eq!(group.current_cycle, 0);
-        assert!(!group.is_complete());
-
-        advance_group_cycle_logic(&mut group).unwrap();
-        assert_eq!(group.current_cycle, 1);
-        assert!(!group.is_complete());
-
-        advance_group_cycle_logic(&mut group).unwrap();
-        assert_eq!(group.current_cycle, 2);
-        assert!(!group.is_complete());
-
-        advance_group_cycle_logic(&mut group).unwrap();
-        assert_eq!(group.current_cycle, 3);
-        assert!(!group.is_complete());
-
-        advance_group_cycle_logic(&mut group).unwrap();
-        assert_eq!(group.current_cycle, 4);
-        assert!(group.is_complete());
-    }
-
-    #[test]
-    fn test_advance_group_cycle_logic_error_on_already_complete() {
-        let env = Env::default();
-        let creator = Address::generate(&env);
-
-        let mut group = Group::new(1, creator, 10_000_000, 604800, 2, 1234567890);
-        group.current_cycle = 2; // Already complete
-
-        let result = advance_group_cycle_logic(&mut group);
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), StellarSaveError::InvalidState);
+        let g = make_group(&env, 4, 604800, 1_000_000);
+        assert_eq!(get_cycle_deadline(&g, 0).unwrap(), 1_000_000 + 604800);
     }
 }

--- a/contracts/stellar-save/src/error.rs
+++ b/contracts/stellar-save/src/error.rs
@@ -77,6 +77,10 @@ pub enum StellarSaveError {
     /// Added for ID Generation: The counter has reached its maximum limit.
     /// Error Code: 9003
     Overflow = 9003,
+
+    /// The cycle deadline has passed; contributions are no longer accepted.
+    /// Error Code: 3005
+    CycleDeadlineExpired = 3005,
 }
 
 impl StellarSaveError {
@@ -142,6 +146,9 @@ impl StellarSaveError {
             }
             StellarSaveError::Overflow => {
                 "The ID counter has reached its maximum limit. No more IDs can be generated."
+            }
+            StellarSaveError::CycleDeadlineExpired => {
+                "The cycle deadline has passed. Contributions are no longer accepted for this cycle."
             }
         }
     }

--- a/contracts/stellar-save/src/events.rs
+++ b/contracts/stellar-save/src/events.rs
@@ -93,6 +93,24 @@ pub struct ContractUnpaused {
     pub timestamp: u64,
 }
 
+/// Event emitted when a cycle starts.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CycleStarted {
+    pub group_id: u64,
+    pub cycle_id: u32,
+    pub started_at: u64,
+}
+
+/// Event emitted when a cycle ends (transitions to next).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CycleEnded {
+    pub group_id: u64,
+    pub cycle_id: u32,
+    pub ended_at: u64,
+}
+
 /// Utility functions for emitting events.
 pub struct EventEmitter;
 
@@ -231,6 +249,16 @@ impl EventEmitter {
     pub fn emit_contract_unpaused(env: &Env, admin: Address, timestamp: u64) {
         let event = ContractUnpaused { admin, timestamp };
         env.events().publish(("contract_unpaused",), event);
+    }
+
+    pub fn emit_cycle_started(env: &Env, group_id: u64, cycle_id: u32, started_at: u64) {
+        let event = CycleStarted { group_id, cycle_id, started_at };
+        env.events().publish(("cycle_started",), event);
+    }
+
+    pub fn emit_cycle_ended(env: &Env, group_id: u64, cycle_id: u32, ended_at: u64) {
+        let event = CycleEnded { group_id, cycle_id, ended_at };
+        env.events().publish(("cycle_ended",), event);
     }
 }
 

--- a/contracts/stellar-save/src/lib.rs
+++ b/contracts/stellar-save/src/lib.rs
@@ -28,6 +28,7 @@ pub mod payout_executor;
 pub mod pool;
 pub mod status;
 pub mod storage;
+pub mod cycle_advancement;
 
 // Re-export for convenience
 pub use contribution::ContributionRecord;
@@ -2710,6 +2711,31 @@ pub fn is_member(
         env.storage().persistent().set(&status_key, &true);
 
         Ok(())
+    }
+
+    /// Advances the group to the next cycle when the current cycle's deadline has passed.
+    ///
+    /// This is the time-based cycle progression entry point. It checks whether
+    /// enough time has elapsed since the group started to warrant moving to the
+    /// next cycle, then performs the transition atomically.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `group_id` - ID of the group to advance
+    /// * `caller` - Address of the caller (used for event attribution)
+    ///
+    /// # Returns
+    /// * `Ok(true)` - Cycle was advanced successfully
+    /// * `Ok(false)` - No advancement needed (deadline not yet reached)
+    /// * `Err(StellarSaveError::GroupNotFound)` - Group does not exist
+    /// * `Err(StellarSaveError::InvalidState)` - Group is not active / not started / already complete
+    pub fn advance_cycle_for_group(
+        env: Env,
+        group_id: u64,
+        caller: Address,
+    ) -> Result<bool, StellarSaveError> {
+        caller.require_auth();
+        crate::cycle_advancement::try_advance_cycle(&env, group_id, &caller)
     }
 }
 


### PR DESCRIPTION
closes #432 

## Summary

Implements time-based cycle progression for the Stellar-Save ROSCA smart contract. 
This covers cycle calculation, deadline validation, automatic transitions, and event 
emission — all as described in issue requirements for cycle advancement.

## Changes

### `cycle_advancement.rs` (rewritten)
- `get_current_cycle(group, now)` — calculates current cycle index using `floor((now - started_at) / cycle_duration)`, capped at `max_members`
- `get_cycle_start()` / `get_cycle_deadline()` — boundary helpers with overflow protection
- `is_cycle_expired(group, cycle, now, grace_period)` — deadline check with optional buffer for minor clock drift
- `try_advance_cycle(env, group_id, caller)` — main transition function: loads group from storage, verifies deadline has passed, emits `CycleEnded`, increments cycle, persists state, emits `CycleStarted` or `GroupStatusChanged` on completion. Idempotent — returns `Ok(false)` if deadline hasn't passed yet
- `advance_group_cycle_logic(env, group)` — pure logic version for unit testing
- Fixed existing bug: `advance_cycle()` was being called without the required `env` argument

### `events.rs`
- Added `CycleStarted` event struct and `emit_cycle_started()`
- Added `CycleEnded` event struct and `emit_cycle_ended()`

### `error.rs`
- Added `CycleDeadlineExpired = 3005` error variant with message

### `lib.rs`
- Declared `pub mod cycle_advancement`
- Added `advance_cycle_for_group(env, group_id, caller)` as the public contract entry point for triggering cycle transitions

## Tests

18 unit tests added in `cycle_advancement.rs` covering:
- Cycle index calculation (before start, at boundary, mid-cycle, multi-cycle, capped at max)
- Deadline expiry with and without grace period
- Full cycle progression through completion
- Error on advancing a completed group
- Config immutability after advancement

## Notes

- Cycle transitions are idempotent — calling `advance_cycle_for_group` multiple times before the deadline is safe
- Grace period in `is_cycle_expired` defaults to `0` but can be set by callers to handle minor ledger timestamp drift
- No cycles can be skipped — progression is always `current + 1`
