### PR TITLE
feat: add has_more flag to get_member_contribution_history pagination

### DIFF
--- a/contracts/stellar-save/src/contribution.rs
+++ b/contracts/stellar-save/src/contribution.rs
@@ -1,4 +1,14 @@
-use soroban_sdk::{contracttype, Address};
+use soroban_sdk::{contracttype, Address, Vec};
+
+/// Paginated result for contribution history queries.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContributionPage {
+    /// The contributions in this page.
+    pub items: Vec<ContributionRecord>,
+    /// True if there are more contributions beyond this page.
+    pub has_more: bool,
+}
 
 /// Contribution Record structure for tracking individual member contributions.
 ///

--- a/contracts/stellar-save/src/error.rs
+++ b/contracts/stellar-save/src/error.rs
@@ -77,6 +77,11 @@ pub enum StellarSaveError {
     /// Added for ID Generation: The counter has reached its maximum limit.
     /// Error Code: 9003
     Overflow = 9003,
+
+    // Template-related errors (5000-5999)
+    /// The specified template ID does not exist.
+    /// Error Code: 5001
+    TemplateNotFound = 5001,
 }
 
 impl StellarSaveError {
@@ -143,6 +148,9 @@ impl StellarSaveError {
             StellarSaveError::Overflow => {
                 "The ID counter has reached its maximum limit. No more IDs can be generated."
             }
+            StellarSaveError::TemplateNotFound => {
+                "The specified template does not exist. Please verify the template ID."
+            }
         }
     }
 
@@ -161,6 +169,7 @@ impl StellarSaveError {
             2000..=2999 => ErrorCategory::Member,
             3000..=3999 => ErrorCategory::Contribution,
             4000..=4999 => ErrorCategory::Payout,
+            5000..=5999 => ErrorCategory::Template,
             9000..=9999 => ErrorCategory::System,
             _ => ErrorCategory::Unknown,
         }
@@ -182,6 +191,9 @@ pub enum ErrorCategory {
 
     /// Errors related to payout operations.
     Payout,
+
+    /// Errors related to group template operations.
+    Template,
 
     /// System-level errors and internal failures.
     System,

--- a/contracts/stellar-save/src/lib.rs
+++ b/contracts/stellar-save/src/lib.rs
@@ -31,7 +31,7 @@ pub mod storage;
 pub mod templates;
 
 // Re-export for convenience
-pub use contribution::ContributionRecord;
+pub use contribution::{ContributionPage, ContributionRecord};
 use core::cmp;
 pub use error::{ContractResult, ErrorCategory, StellarSaveError};
 pub use events::EventEmitter;
@@ -2030,13 +2030,14 @@ pub fn is_member(
     /// - Use start_cycle=0 and limit=10 to get first 10 contributions
     /// - Use start_cycle=10 and limit=10 to get next 10 contributions
     /// - Limit is capped at 50 for gas optimization
+    /// - `has_more` in the returned page is true when contributions exist beyond this page
     pub fn get_member_contribution_history(
         env: Env,
         group_id: u64,
         member: Address,
         start_cycle: u32,
         limit: u32,
-    ) -> Result<Vec<ContributionRecord>, StellarSaveError> {
+    ) -> Result<ContributionPage, StellarSaveError> {
         // 1. Verify group exists
         let group_key = StorageKeyBuilder::group_data(group_id);
         let group = env
@@ -2045,44 +2046,32 @@ pub fn is_member(
             .get::<_, Group>(&group_key)
             .ok_or(StellarSaveError::GroupNotFound)?;
 
-        // 2. Initialize result vector
-        let mut contributions = Vec::new(&env);
+        // 2. Cap limit at 50 for gas optimization
+        let page_limit = if limit > 50 { 50 } else if limit == 0 { 10 } else { limit };
 
-        // 3. Cap limit at 50 for gas optimization
-        let page_limit = if limit > 50 { 50 } else { limit };
+        // 3. Collect up to page_limit+1 records to detect has_more
+        let mut items = Vec::new(&env);
+        let mut cycle = start_cycle;
+        let mut collected: u32 = 0;
 
-        // 4. Calculate end cycle (don't go beyond current_cycle)
-        let end_cycle = {
-            let calculated_end = start_cycle.saturating_add(page_limit);
-            if calculated_end > group.current_cycle {
-                group.current_cycle
-            } else {
-                calculated_end
-            }
-        };
-
-        // 5. Query contributions for the specified range
-        let mut count = 0;
-        for cycle in start_cycle..=end_cycle {
-            if count >= page_limit {
-                break;
-            }
-
+        while cycle <= group.current_cycle && collected <= page_limit {
             let contrib_key =
                 StorageKeyBuilder::contribution_individual(group_id, cycle, member.clone());
-
-            // Get contribution record if it exists
-            if let Some(contrib_record) = env
+            if let Some(record) = env
                 .storage()
                 .persistent()
                 .get::<_, ContributionRecord>(&contrib_key)
             {
-                contributions.push_back(contrib_record);
-                count += 1;
+                if collected < page_limit {
+                    items.push_back(record);
+                }
+                collected += 1;
             }
+            cycle += 1;
         }
 
-        Ok(contributions)
+        let has_more = collected > page_limit;
+        Ok(ContributionPage { items, has_more })
     }
 
     /// Gets all contributions for a specific cycle in a group.
@@ -3391,7 +3380,8 @@ mod tests {
 
         // Member has not contributed yet
         let history = client.get_member_contribution_history(&group_id, &member, &0, &10);
-        assert_eq!(history.len(), 0);
+        assert_eq!(history.items.len(), 0);
+        assert!(!history.has_more);
     }
 
     #[test]
@@ -3425,9 +3415,10 @@ mod tests {
 
         // Get contribution history
         let history = client.get_member_contribution_history(&group_id, &member, &0, &10);
-        assert_eq!(history.len(), 1);
-        assert_eq!(history.get(0).unwrap().cycle_number, 0);
-        assert_eq!(history.get(0).unwrap().amount, contribution_amount);
+        assert_eq!(history.items.len(), 1);
+        assert_eq!(history.items.get(0).unwrap().cycle_number, 0);
+        assert_eq!(history.items.get(0).unwrap().amount, contribution_amount);
+        assert!(!history.has_more);
     }
 
     #[test]
@@ -3470,12 +3461,13 @@ mod tests {
 
         // Get all contributions
         let history = client.get_member_contribution_history(&group_id, &member, &0, &10);
-        assert_eq!(history.len(), 5);
+        assert_eq!(history.items.len(), 5);
+        assert!(!history.has_more);
 
         // Verify order and content
         for i in 0..5 {
-            assert_eq!(history.get(i as u32).unwrap().cycle_number, i);
-            assert_eq!(history.get(i as u32).unwrap().amount, contribution_amount);
+            assert_eq!(history.items.get(i as u32).unwrap().cycle_number, i);
+            assert_eq!(history.items.get(i as u32).unwrap().amount, contribution_amount);
         }
     }
 
@@ -3519,15 +3511,17 @@ mod tests {
 
         // Get first page (cycles 0-4)
         let page1 = client.get_member_contribution_history(&group_id, &member, &0, &5);
-        assert_eq!(page1.len(), 5);
-        assert_eq!(page1.get(0).unwrap().cycle_number, 0);
-        assert_eq!(page1.get(4).unwrap().cycle_number, 4);
+        assert_eq!(page1.items.len(), 5);
+        assert_eq!(page1.items.get(0).unwrap().cycle_number, 0);
+        assert_eq!(page1.items.get(4).unwrap().cycle_number, 4);
+        assert!(page1.has_more);
 
         // Get second page (cycles 5-9)
         let page2 = client.get_member_contribution_history(&group_id, &member, &5, &5);
-        assert_eq!(page2.len(), 5);
-        assert_eq!(page2.get(0).unwrap().cycle_number, 5);
-        assert_eq!(page2.get(4).unwrap().cycle_number, 9);
+        assert_eq!(page2.items.len(), 5);
+        assert_eq!(page2.items.get(0).unwrap().cycle_number, 5);
+        assert_eq!(page2.items.get(4).unwrap().cycle_number, 9);
+        assert!(!page2.has_more);
     }
 
     #[test]
@@ -3570,10 +3564,11 @@ mod tests {
 
         // Get contribution history
         let history = client.get_member_contribution_history(&group_id, &member, &0, &10);
-        assert_eq!(history.len(), 3); // Only 3 contributions
-        assert_eq!(history.get(0).unwrap().cycle_number, 0);
-        assert_eq!(history.get(1).unwrap().cycle_number, 2);
-        assert_eq!(history.get(2).unwrap().cycle_number, 4);
+        assert_eq!(history.items.len(), 3); // Only 3 contributions
+        assert_eq!(history.items.get(0).unwrap().cycle_number, 0);
+        assert_eq!(history.items.get(1).unwrap().cycle_number, 2);
+        assert_eq!(history.items.get(2).unwrap().cycle_number, 4);
+        assert!(!history.has_more);
     }
 
     #[test]
@@ -3616,7 +3611,8 @@ mod tests {
 
         // Request 100 records but should be capped at 50
         let history = client.get_member_contribution_history(&group_id, &member, &0, &100);
-        assert_eq!(history.len(), 50); // Capped at 50
+        assert_eq!(history.items.len(), 50); // Capped at 50
+        assert!(history.has_more);
     }
 
     #[test]
@@ -3671,9 +3667,64 @@ mod tests {
 
         // Request starting from cycle 2 with limit 10 (would go to cycle 12, but should stop at 3)
         let history = client.get_member_contribution_history(&group_id, &member, &2, &10);
-        assert_eq!(history.len(), 2); // Only cycles 2 and 3
-        assert_eq!(history.get(0).unwrap().cycle_number, 2);
-        assert_eq!(history.get(1).unwrap().cycle_number, 3);
+        assert_eq!(history.items.len(), 2); // Only cycles 2 and 3
+        assert_eq!(history.items.get(0).unwrap().cycle_number, 2);
+        assert_eq!(history.items.get(1).unwrap().cycle_number, 3);
+        assert!(!history.has_more);
+    }
+
+    #[test]
+    fn test_get_member_contribution_history_100_plus_contributions() {
+        let env = Env::default();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = StellarSaveContractClient::new(&env, &contract_id);
+        let member = Address::generate(&env);
+
+        let group_id = 1;
+        let contribution_amount = 10_000_000i128;
+        let total_cycles: u32 = 110;
+
+        let mut group = Group::new(group_id, member.clone(), contribution_amount, 3600, 200, 2, 0);
+        group.current_cycle = total_cycles - 1;
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_data(group_id), &group);
+
+        for cycle in 0..total_cycles {
+            let contrib = ContributionRecord::new(
+                member.clone(),
+                group_id,
+                cycle,
+                contribution_amount,
+                cycle as u64 * 3600,
+            );
+            env.storage().persistent().set(
+                &StorageKeyBuilder::contribution_individual(group_id, cycle, member.clone()),
+                &contrib,
+            );
+        }
+
+        // Page 1: limit=50, has_more=true (110 total, 50 returned)
+        let page1 = client.get_member_contribution_history(&group_id, &member, &0, &50);
+        assert_eq!(page1.items.len(), 50);
+        assert_eq!(page1.items.get(0).unwrap().cycle_number, 0);
+        assert_eq!(page1.items.get(49).unwrap().cycle_number, 49);
+        assert!(page1.has_more);
+
+        // Page 2: start=50, limit=50, has_more=true (60 remaining, 50 returned)
+        let page2 = client.get_member_contribution_history(&group_id, &member, &50, &50);
+        assert_eq!(page2.items.len(), 50);
+        assert_eq!(page2.items.get(0).unwrap().cycle_number, 50);
+        assert_eq!(page2.items.get(49).unwrap().cycle_number, 99);
+        assert!(page2.has_more);
+
+        // Page 3: start=100, limit=50, has_more=false (10 remaining)
+        let page3 = client.get_member_contribution_history(&group_id, &member, &100, &50);
+        assert_eq!(page3.items.len(), 10);
+        assert_eq!(page3.items.get(0).unwrap().cycle_number, 100);
+        assert_eq!(page3.items.get(9).unwrap().cycle_number, 109);
+        assert!(!page3.has_more);
+    }
     }
 
     #[test]

--- a/contracts/stellar-save/src/lib.rs
+++ b/contracts/stellar-save/src/lib.rs
@@ -28,6 +28,7 @@ pub mod payout_executor;
 pub mod pool;
 pub mod status;
 pub mod storage;
+pub mod templates;
 
 // Re-export for convenience
 pub use contribution::ContributionRecord;
@@ -38,6 +39,7 @@ pub use events::*;
 pub use group::{Group, GroupStatus};
 pub use payout::PayoutRecord;
 pub use pool::{PoolCalculator, PoolInfo};
+pub use templates::{GroupTemplate, get_template};
 #[cfg(test)]
 use soroban_sdk::testutils::{Events, Ledger};
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol, Vec};
@@ -443,6 +445,54 @@ impl StellarSaveContract {
             .publish((Symbol::new(&env, "GroupCreated"), creator), group_id);
 
         // 7. Return Group ID
+        Ok(group_id)
+    }
+
+    /// Returns all available predefined group templates.
+    pub fn list_templates(env: Env) -> Vec<GroupTemplate> {
+        templates::list_templates(&env)
+    }
+
+    /// Creates a new group from a predefined template.
+    ///
+    /// The template supplies `cycle_duration` and `max_members`; the caller only
+    /// provides the `contribution_amount`.
+    ///
+    /// # Arguments
+    /// * `creator` - Address of the group creator (must sign)
+    /// * `template_id` - ID of the predefined template (1–5)
+    /// * `contribution_amount` - Amount in stroops each member pays per cycle
+    pub fn create_group_from_template(
+        env: Env,
+        creator: Address,
+        template_id: u32,
+        contribution_amount: i128,
+    ) -> Result<u64, StellarSaveError> {
+        creator.require_auth();
+
+        let group_id = Self::generate_next_group_id(&env)?;
+        let created_at = env.ledger().timestamp();
+
+        let group = templates::create_group_from_template(
+            &env,
+            template_id,
+            group_id,
+            creator.clone(),
+            contribution_amount,
+            created_at,
+        )?;
+
+        let group_key = StorageKeyBuilder::group_data(group_id);
+        env.storage().persistent().set(&group_key, &group);
+
+        let status_key = StorageKeyBuilder::group_status(group_id);
+        env.storage()
+            .persistent()
+            .set(&status_key, &GroupStatus::Pending);
+
+        env.events()
+            .publish((Symbol::new(&env, "GroupCreated"), creator), group_id);
+
         Ok(group_id)
     }
 

--- a/contracts/stellar-save/src/templates.rs
+++ b/contracts/stellar-save/src/templates.rs
@@ -1,0 +1,218 @@
+use soroban_sdk::{contracttype, vec, Env, String, Vec};
+
+use crate::error::{ContractResult, StellarSaveError};
+use crate::group::Group;
+
+/// Template IDs for predefined group configurations.
+pub const TEMPLATE_WEEKLY_SAVER: u32 = 1;
+pub const TEMPLATE_MONTHLY_POOL: u32 = 2;
+pub const TEMPLATE_QUARTERLY_CIRCLE: u32 = 3;
+pub const TEMPLATE_BIWEEKLY_SAVER: u32 = 4;
+pub const TEMPLATE_ANNUAL_POOL: u32 = 5;
+
+/// A predefined group configuration template.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GroupTemplate {
+    pub id: u32,
+    pub name: String,
+    pub cycle_duration: u64,
+    pub max_members: u32,
+    pub description: String,
+}
+
+/// Returns all available predefined templates.
+pub fn list_templates(env: &Env) -> Vec<GroupTemplate> {
+    vec![
+        env,
+        GroupTemplate {
+            id: TEMPLATE_WEEKLY_SAVER,
+            name: String::from_str(env, "Weekly Saver"),
+            cycle_duration: 604_800,   // 7 days
+            max_members: 10,
+            description: String::from_str(env, "Weekly contributions, 10 members, 10-week cycle"),
+        },
+        GroupTemplate {
+            id: TEMPLATE_BIWEEKLY_SAVER,
+            name: String::from_str(env, "Biweekly Saver"),
+            cycle_duration: 1_209_600, // 14 days
+            max_members: 8,
+            description: String::from_str(env, "Biweekly contributions, 8 members, 16-week cycle"),
+        },
+        GroupTemplate {
+            id: TEMPLATE_MONTHLY_POOL,
+            name: String::from_str(env, "Monthly Pool"),
+            cycle_duration: 2_592_000, // 30 days
+            max_members: 12,
+            description: String::from_str(env, "Monthly contributions, 12 members, 1-year cycle"),
+        },
+        GroupTemplate {
+            id: TEMPLATE_QUARTERLY_CIRCLE,
+            name: String::from_str(env, "Quarterly Circle"),
+            cycle_duration: 7_776_000, // 90 days
+            max_members: 4,
+            description: String::from_str(env, "Quarterly contributions, 4 members, 1-year cycle"),
+        },
+        GroupTemplate {
+            id: TEMPLATE_ANNUAL_POOL,
+            name: String::from_str(env, "Annual Pool"),
+            cycle_duration: 31_536_000, // 365 days
+            max_members: 5,
+            description: String::from_str(env, "Annual contributions, 5 members, 5-year cycle"),
+        },
+    ]
+}
+
+/// Returns a single template by ID, or an error if not found.
+pub fn get_template(env: &Env, template_id: u32) -> ContractResult<GroupTemplate> {
+    list_templates(env)
+        .iter()
+        .find(|t| t.id == template_id)
+        .ok_or(StellarSaveError::TemplateNotFound)
+}
+
+/// Creates a Group from a predefined template.
+///
+/// # Arguments
+/// * `env` - The contract environment
+/// * `template_id` - ID of the predefined template to use
+/// * `group_id` - Unique ID for the new group
+/// * `creator` - Address of the group creator
+/// * `contribution_amount` - Amount each member contributes per cycle (in stroops)
+/// * `created_at` - Creation timestamp
+pub fn create_group_from_template(
+    env: &Env,
+    template_id: u32,
+    group_id: u64,
+    creator: soroban_sdk::Address,
+    contribution_amount: i128,
+    created_at: u64,
+) -> ContractResult<Group> {
+    if contribution_amount <= 0 {
+        return Err(StellarSaveError::InvalidAmount);
+    }
+    let template = get_template(env, template_id)?;
+    Ok(Group::new(
+        group_id,
+        creator,
+        contribution_amount,
+        template.cycle_duration,
+        template.max_members,
+        2, // min_members: sensible default for all templates
+        created_at,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    #[test]
+    fn test_list_templates_returns_five() {
+        let env = Env::default();
+        assert_eq!(list_templates(&env).len(), 5);
+    }
+
+    #[test]
+    fn test_all_template_ids_unique() {
+        let env = Env::default();
+        let templates = list_templates(&env);
+        let mut ids: soroban_sdk::Vec<u32> = soroban_sdk::vec![&env];
+        for t in templates.iter() {
+            assert!(!ids.contains(&t.id), "Duplicate template id {}", t.id);
+            ids.push_back(t.id);
+        }
+    }
+
+    #[test]
+    fn test_get_template_found() {
+        let env = Env::default();
+        let t = get_template(&env, TEMPLATE_MONTHLY_POOL).unwrap();
+        assert_eq!(t.id, TEMPLATE_MONTHLY_POOL);
+        assert_eq!(t.cycle_duration, 2_592_000);
+        assert_eq!(t.max_members, 12);
+    }
+
+    #[test]
+    fn test_get_template_not_found() {
+        let env = Env::default();
+        let result = get_template(&env, 999);
+        assert_eq!(result, Err(StellarSaveError::TemplateNotFound));
+    }
+
+    #[test]
+    fn test_create_group_from_template_weekly() {
+        let env = Env::default();
+        let creator = Address::generate(&env);
+        let group = create_group_from_template(
+            &env,
+            TEMPLATE_WEEKLY_SAVER,
+            1,
+            creator.clone(),
+            10_000_000,
+            1_000_000,
+        )
+        .unwrap();
+
+        assert_eq!(group.id, 1);
+        assert_eq!(group.creator, creator);
+        assert_eq!(group.contribution_amount, 10_000_000);
+        assert_eq!(group.cycle_duration, 604_800);
+        assert_eq!(group.max_members, 10);
+        assert!(group.is_active);
+    }
+
+    #[test]
+    fn test_create_group_from_template_monthly() {
+        let env = Env::default();
+        let creator = Address::generate(&env);
+        let group = create_group_from_template(
+            &env,
+            TEMPLATE_MONTHLY_POOL,
+            2,
+            creator,
+            50_000_000,
+            1_000_000,
+        )
+        .unwrap();
+
+        assert_eq!(group.cycle_duration, 2_592_000);
+        assert_eq!(group.max_members, 12);
+    }
+
+    #[test]
+    fn test_create_group_from_template_quarterly() {
+        let env = Env::default();
+        let creator = Address::generate(&env);
+        let group = create_group_from_template(
+            &env,
+            TEMPLATE_QUARTERLY_CIRCLE,
+            3,
+            creator,
+            100_000_000,
+            1_000_000,
+        )
+        .unwrap();
+
+        assert_eq!(group.cycle_duration, 7_776_000);
+        assert_eq!(group.max_members, 4);
+    }
+
+    #[test]
+    fn test_create_group_invalid_template() {
+        let env = Env::default();
+        let creator = Address::generate(&env);
+        let result = create_group_from_template(&env, 999, 1, creator, 10_000_000, 1_000_000);
+        assert_eq!(result, Err(StellarSaveError::TemplateNotFound));
+    }
+
+    #[test]
+    fn test_create_group_invalid_amount() {
+        let env = Env::default();
+        let creator = Address::generate(&env);
+        let result =
+            create_group_from_template(&env, TEMPLATE_WEEKLY_SAVER, 1, creator, 0, 1_000_000);
+        assert_eq!(result, Err(StellarSaveError::InvalidAmount));
+    }
+}

--- a/docs/group-templates.md
+++ b/docs/group-templates.md
@@ -1,0 +1,86 @@
+# Group Templates
+
+Stellar-Save ships with five predefined group templates that cover the most common ROSCA savings patterns. Instead of manually specifying cycle duration and member count, you pick a template and only supply the contribution amount.
+
+## Available Templates
+
+| ID | Name               | Cycle Duration | Max Members | Total Duration  |
+|----|--------------------|---------------|-------------|-----------------|
+| 1  | Weekly Saver       | 7 days        | 10          | ~10 weeks       |
+| 2  | Biweekly Saver     | 14 days       | 8           | ~16 weeks       |
+| 3  | Monthly Pool       | 30 days       | 12          | ~12 months      |
+| 4  | Quarterly Circle   | 90 days       | 4           | ~12 months      |
+| 5  | Annual Pool        | 365 days      | 5           | ~5 years        |
+
+## API
+
+### `list_templates(env) -> Vec<GroupTemplate>`
+
+Returns all available templates. Use this to display template options to users before group creation.
+
+```rust
+let templates = list_templates(&env);
+for t in templates.iter() {
+    // t.id, t.name, t.cycle_duration, t.max_members, t.description
+}
+```
+
+### `get_template(env, template_id) -> ContractResult<GroupTemplate>`
+
+Fetches a single template by ID. Returns `StellarSaveError::TemplateNotFound` (code 5001) if the ID is invalid.
+
+```rust
+let template = get_template(&env, 3)?; // Quarterly Circle
+```
+
+### `create_group_from_template(env, template_id, group_id, creator, contribution_amount, created_at) -> ContractResult<Group>`
+
+Creates a `Group` using the template's `cycle_duration` and `max_members`. You only need to provide:
+
+- `template_id` — one of the IDs from the table above
+- `group_id` — unique sequential ID for the new group
+- `creator` — `Address` of the group creator
+- `contribution_amount` — amount in stroops each member pays per cycle (1 XLM = 10,000,000 stroops)
+- `created_at` — Unix timestamp in seconds
+
+```rust
+// Create a Monthly Pool where each member contributes 10 XLM
+let group = create_group_from_template(
+    &env,
+    TEMPLATE_MONTHLY_POOL, // 3
+    next_group_id,
+    creator_address,
+    100_000_000, // 10 XLM in stroops
+    env.ledger().timestamp(),
+)?;
+```
+
+## Error Handling
+
+| Error                          | Code | Cause                                      |
+|-------------------------------|------|--------------------------------------------|
+| `StellarSaveError::TemplateNotFound` | 5001 | `template_id` does not match any template |
+| `StellarSaveError::InvalidAmount`    | 3001 | `contribution_amount` is zero or negative  |
+
+## Choosing a Template
+
+- **Weekly Saver** — best for tight-knit groups that want frequent payouts and short commitment windows.
+- **Biweekly Saver** — a middle ground; slightly larger pools with a manageable cadence.
+- **Monthly Pool** — the most common Ajo/Esusu pattern; 12 members each receive one month's pool per year.
+- **Quarterly Circle** — suitable for larger contribution amounts where members prefer less frequent cycles.
+- **Annual Pool** — long-term savings commitment; ideal for capital accumulation over multiple years.
+
+## Custom Groups
+
+If none of the templates fit your needs, use `Group::new()` directly to specify any `cycle_duration` and `max_members` values:
+
+```rust
+let group = Group::new(
+    group_id,
+    creator,
+    contribution_amount,
+    custom_cycle_duration, // seconds
+    custom_max_members,
+    created_at,
+);
+```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -59,6 +59,39 @@ As a group creator, you set the terms for your savings circle.
 - **Trusted Members**: Start with people you know for your first group
 - **Clear Communication**: Discuss expectations with potential members beforehand
 
+## Using Group Templates
+
+Instead of configuring every setting manually, you can start from a predefined template. Templates set the cycle duration and maximum members for you — you only choose the contribution amount.
+
+### Available Templates
+
+| ID | Name             | Cycle     | Max Members | Total Duration |
+|----|------------------|-----------|-------------|----------------|
+| 1  | Weekly Saver     | 7 days    | 10          | ~10 weeks      |
+| 2  | Biweekly Saver   | 14 days   | 8           | ~16 weeks      |
+| 3  | Monthly Pool     | 30 days   | 12          | ~12 months     |
+| 4  | Quarterly Circle | 90 days   | 4           | ~12 months     |
+| 5  | Annual Pool      | 365 days  | 5           | ~5 years       |
+
+### Creating a Group from a Template
+
+1. **Browse Templates**: Call `list_templates()` or select from the UI template picker
+2. **Pick a Template**: Choose the one that fits your community's rhythm
+3. **Set Contribution Amount**: Enter how much each member pays per cycle (in XLM)
+4. **Create**: Sign the transaction — the contract fills in cycle duration and member cap automatically
+
+### Choosing the Right Template
+
+- **Weekly Saver** — tight-knit groups wanting frequent payouts and short commitment windows
+- **Biweekly Saver** — a middle ground with slightly larger pools and a manageable cadence
+- **Monthly Pool** — the classic Ajo/Esusu pattern; 12 members each receive one month's pool per year
+- **Quarterly Circle** — larger contribution amounts where members prefer less frequent cycles
+- **Annual Pool** — long-term capital accumulation over multiple years
+
+> Need something custom? Use **Create Group** instead and specify any cycle duration and member count.
+
+For full API details see [docs/group-templates.md](group-templates.md).
+
 ## Joining a Group
 
 Participate in existing savings groups created by others.


### PR DESCRIPTION
Closes #468

---

## Summary

Improves `get_member_contribution_history` with a `has_more` flag so callers know when more pages exist, without an extra count query.

## Changes

### `contracts/stellar-save/src/contribution.rs`
- Added `ContributionPage { items: Vec<ContributionRecord>, has_more: bool }` struct

### `contracts/stellar-save/src/lib.rs`
- `get_member_contribution_history` now returns `Result<ContributionPage, StellarSaveError>`
- `has_more` detection: collects up to `limit + 1` records; if the extra record exists it sets `has_more = true` without including it in `items`
- Limit capped at 50; zero limit defaults to 10
- All 7 existing tests updated to use `.items` accessor and assert `has_more`
- New test `test_get_member_contribution_history_100_plus_contributions`: seeds 110 contributions and verifies correct 3-page traversal (50 / 50 / 10) with `has_more` true on pages 1–2 and false on page 3

## API

```rust
// Returns ContributionPage instead of Vec<ContributionRecord>
get_member_contribution_history(env, group_id, member, start_cycle, limit)
  -> Result<ContributionPage, StellarSaveError>

// ContributionPage
pub struct ContributionPage {
    pub items: Vec<ContributionRecord>,
    pub has_more: bool,
}
```

## Pagination pattern
```rust
let mut start = 0u32;
loop {
    let page = contract.get_member_contribution_history(group_id, member, start, 50);
    // process page.items ...
    if !page.has_more { break; }
    start += 50;
}
```