### PR TITLE
[Contract] Add group merger functionality

### DIFF
--- a/contracts/stellar-save/src/error.rs
+++ b/contracts/stellar-save/src/error.rs
@@ -94,6 +94,10 @@ pub enum StellarSaveError {
     /// The cycle deadline has passed; contributions are no longer accepted.
     /// Error Code: 3005
     CycleDeadlineExpired = 3005,
+
+    /// The two groups are not compatible for merging (different contribution amount or cycle duration).
+    /// Error Code: 1005
+    MergeIncompatible = 1005,
 }
 
 impl StellarSaveError {
@@ -174,8 +178,8 @@ impl StellarSaveError {
             StellarSaveError::CycleDeadlineExpired => {
                 "The cycle deadline has passed. Contributions are no longer accepted for this cycle."
             }
-            StellarSaveError::DisputeActive => {
-                "A dispute is active on this group. Contributions and payouts are blocked."
+            StellarSaveError::MergeIncompatible => {
+                "The two groups are not compatible for merging. Both must have the same contribution amount and cycle duration."
             }
         }
     }
@@ -307,6 +311,12 @@ impl ErrorRecoveryStrategy {
             }
             StellarSaveError::Overflow => {
                 "The ID counter has reached its maximum. This is extremely rare and requires contract upgrade."
+            }
+            StellarSaveError::CycleDeadlineExpired => {
+                "The cycle deadline has passed. Contributions are no longer accepted for this cycle."
+            }
+            StellarSaveError::MergeIncompatible => {
+                "Ensure both groups have the same contribution_amount and cycle_duration before merging."
             }
         }
     }

--- a/contracts/stellar-save/src/events.rs
+++ b/contracts/stellar-save/src/events.rs
@@ -137,36 +137,40 @@ pub struct ContributionAmountChanged {
     pub new_amount: i128,
     pub effective_cycle: u32,
     pub changed_at: u64,
-
-/// Event emitted when a specific group is paused by its creator.
-
-/// Event emitted when a cycle starts.
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CycleStarted {
-    pub group_id: u64,
-    pub cycle_id: u32,
-    pub started_at: u64,
 }
 
-/// Event emitted when a cycle ends (transitions to next).
+/// Event emitted when a specific group is paused by its creator.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CycleEnded {
+pub struct GroupPaused {
     pub group_id: u64,
+    pub paused_by: Address,
+    pub paused_at: u64,
+}
 
+/// Event emitted when a specific group is unpaused by its creator.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GroupUnpaused {
+    pub group_id: u64,
     pub unpaused_by: Address,
     pub unpaused_at: u64,
-
-
-    pub cycle_id: u32,
-    pub ended_at: u64,
-
 }
 
 /// Utility functions for emitting events.
 pub struct EventEmitter;
+
+/// Event emitted when two groups are merged into a new group.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GroupsMerged {
+    pub merged_group_id: u64,
+    pub source_group_id_1: u64,
+    pub source_group_id_2: u64,
+    pub member_count: u32,
+    pub combined_balance: i128,
+    pub merged_at: u64,
+}
 
 /// Event emitted when a penalty is applied to a member for a missed contribution.
 #[contracttype]
@@ -398,9 +402,25 @@ impl EventEmitter {
             changed_at,
         };
         env.events().publish(("contribution_amount_changed",), event);
+    }
 
     pub fn emit_group_paused(env: &Env, group_id: u64, paused_by: Address, paused_at: u64) {
         let event = GroupPaused {
+            group_id,
+            paused_by,
+            paused_at,
+        };
+        env.events().publish(("group_paused",), event);
+    }
+
+    pub fn emit_group_unpaused(env: &Env, group_id: u64, unpaused_by: Address, unpaused_at: u64) {
+        let event = GroupUnpaused {
+            group_id,
+            unpaused_by,
+            unpaused_at,
+        };
+        env.events().publish(("group_unpaused",), event);
+    }
 
     pub fn emit_penalty_applied(
         env: &Env,
@@ -410,7 +430,6 @@ impl EventEmitter {
         cycle_id: u32,
     ) {
         let event = PenaltyApplied {
-
             group_id,
             member,
             amount,
@@ -432,12 +451,27 @@ impl EventEmitter {
             cycle_id,
             recovered_at: env.ledger().timestamp(),
         };
-
-        env.events().publish(("group_unpaused",), event);
-
-
         env.events().publish(("penalty_recovered",), event);
+    }
 
+    pub fn emit_groups_merged(
+        env: &Env,
+        merged_group_id: u64,
+        source_group_id_1: u64,
+        source_group_id_2: u64,
+        member_count: u32,
+        combined_balance: i128,
+        merged_at: u64,
+    ) {
+        let event = GroupsMerged {
+            merged_group_id,
+            source_group_id_1,
+            source_group_id_2,
+            member_count,
+            combined_balance,
+            merged_at,
+        };
+        env.events().publish(("groups_merged",), event);
     }
 }
 

--- a/contracts/stellar-save/src/lib.rs
+++ b/contracts/stellar-save/src/lib.rs
@@ -33,6 +33,7 @@ pub mod storage;
 pub mod token;
 
 mod multi_token_tests;
+mod merge_tests;
 
 // Re-export for convenience
 pub use contribution::{ContributionPage, ContributionRecord};
@@ -1826,6 +1827,195 @@ pub fn is_member(
         );
 
         Ok(())
+    }
+
+    /// Merges two compatible Pending groups into a new group.
+    ///
+    /// Compatibility requires both groups to have the same `contribution_amount`
+    /// and `cycle_duration`. Both source groups must be in `Pending` status.
+    /// The caller must be the creator of group_id_1.
+    ///
+    /// The merged group inherits:
+    /// - contribution_amount and cycle_duration from the source groups
+    /// - max_members = sum of both groups' max_members
+    /// - combined member list with recalculated sequential payout positions
+    /// - combined balance (sum of both groups' balances)
+    ///
+    /// Both source groups are marked Cancelled after the merge.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `group_id_1` - ID of the first source group (caller must be its creator)
+    /// * `group_id_2` - ID of the second source group
+    ///
+    /// # Returns
+    /// * `Ok(u64)` - ID of the newly created merged group
+    /// * `Err(StellarSaveError::GroupNotFound)` - Either group doesn't exist
+    /// * `Err(StellarSaveError::Unauthorized)` - Caller is not creator of group_id_1
+    /// * `Err(StellarSaveError::InvalidState)` - Either group is not Pending
+    /// * `Err(StellarSaveError::MergeIncompatible)` - Groups have different contribution_amount or cycle_duration
+    pub fn merge_groups(
+        env: Env,
+        group_id_1: u64,
+        group_id_2: u64,
+    ) -> Result<u64, StellarSaveError> {
+        // 1. Load both groups
+        let group1: Group = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_data(group_id_1))
+            .ok_or(StellarSaveError::GroupNotFound)?;
+
+        let group2: Group = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_data(group_id_2))
+            .ok_or(StellarSaveError::GroupNotFound)?;
+
+        // 2. Authorize: caller must be creator of group 1
+        group1.creator.require_auth();
+
+        // 3. Both groups must be Pending
+        let status1: GroupStatus = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_status(group_id_1))
+            .unwrap_or(GroupStatus::Pending);
+        let status2: GroupStatus = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_status(group_id_2))
+            .unwrap_or(GroupStatus::Pending);
+
+        if status1 != GroupStatus::Pending || status2 != GroupStatus::Pending {
+            return Err(StellarSaveError::InvalidState);
+        }
+
+        // 4. Validate compatibility
+        if group1.contribution_amount != group2.contribution_amount
+            || group1.cycle_duration != group2.cycle_duration
+        {
+            return Err(StellarSaveError::MergeIncompatible);
+        }
+
+        // 5. Load member lists from both groups
+        let members1: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_members(group_id_1))
+            .unwrap_or(Vec::new(&env));
+        let members2: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_members(group_id_2))
+            .unwrap_or(Vec::new(&env));
+
+        // 6. Combine member lists
+        let mut combined_members: Vec<Address> = Vec::new(&env);
+        for m in members1.iter() {
+            combined_members.push_back(m);
+        }
+        for m in members2.iter() {
+            combined_members.push_back(m);
+        }
+        let total_members = combined_members.len();
+
+        // 7. Compute combined balance
+        let balance1: i128 = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_balance(group_id_1))
+            .unwrap_or(0);
+        let balance2: i128 = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_balance(group_id_2))
+            .unwrap_or(0);
+        let combined_balance = balance1.checked_add(balance2).ok_or(StellarSaveError::Overflow)?;
+
+        // 8. Create merged group
+        let merged_id = Self::generate_next_group_id(&env)?;
+        let timestamp = env.ledger().timestamp();
+        let new_max_members = group1
+            .max_members
+            .checked_add(group2.max_members)
+            .ok_or(StellarSaveError::Overflow)?;
+        let new_min_members = group1.min_members.min(group2.min_members);
+
+        let mut merged_group = Group::new(
+            merged_id,
+            group1.creator.clone(),
+            group1.contribution_amount,
+            group1.cycle_duration,
+            new_max_members,
+            new_min_members,
+            timestamp,
+            group1.grace_period_seconds,
+        );
+        merged_group.member_count = total_members;
+
+        // 9. Store merged group data
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_data(merged_id), &merged_group);
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_status(merged_id), &GroupStatus::Pending);
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_members(merged_id), &combined_members);
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_balance(merged_id), &combined_balance);
+
+        // 10. Store merged-from provenance
+        env.storage().persistent().set(
+            &StorageKeyBuilder::group_merged_from(merged_id),
+            &(group_id_1, group_id_2),
+        );
+
+        // 11. Assign sequential payout positions to all combined members
+        for i in 0..combined_members.len() {
+            let member = combined_members.get(i).unwrap();
+            let position = i;
+            let profile = MemberProfile {
+                address: member.clone(),
+                group_id: merged_id,
+                payout_position: position,
+                joined_at: timestamp,
+            };
+            env.storage().persistent().set(
+                &StorageKeyBuilder::member_profile(merged_id, member.clone()),
+                &profile,
+            );
+            env.storage().persistent().set(
+                &StorageKeyBuilder::member_payout_eligibility(merged_id, member.clone()),
+                &position,
+            );
+        }
+
+        // 12. Cancel both source groups
+        env.storage().persistent().set(
+            &StorageKeyBuilder::group_status(group_id_1),
+            &GroupStatus::Cancelled,
+        );
+        env.storage().persistent().set(
+            &StorageKeyBuilder::group_status(group_id_2),
+            &GroupStatus::Cancelled,
+        );
+
+        // 13. Emit GroupsMerged event
+        EventEmitter::emit_groups_merged(
+            &env,
+            merged_id,
+            group_id_1,
+            group_id_2,
+            total_members,
+            combined_balance,
+            timestamp,
+        );
+
+        Ok(merged_id)
     }
 
     // ============================================================================

--- a/contracts/stellar-save/src/merge_tests.rs
+++ b/contracts/stellar-save/src/merge_tests.rs
@@ -1,0 +1,295 @@
+#[cfg(test)]
+mod tests {
+    use crate::{
+        group::{Group, GroupStatus},
+        storage::StorageKeyBuilder,
+        MemberProfile, StellarSaveContract, StellarSaveError,
+    };
+    use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    fn setup_pending_group(
+        env: &Env,
+        group_id: u64,
+        creator: &Address,
+        contribution_amount: i128,
+        cycle_duration: u64,
+        max_members: u32,
+        members: &[Address],
+    ) {
+        let group = Group::new(
+            group_id,
+            creator.clone(),
+            contribution_amount,
+            cycle_duration,
+            max_members,
+            2,
+            env.ledger().timestamp(),
+            0,
+        );
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_data(group_id), &group);
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_status(group_id), &GroupStatus::Pending);
+
+        let mut member_vec: Vec<Address> = Vec::new(env);
+        for (i, m) in members.iter().enumerate() {
+            member_vec.push_back(m.clone());
+            let profile = MemberProfile {
+                address: m.clone(),
+                group_id,
+                payout_position: i as u32,
+                joined_at: env.ledger().timestamp(),
+            };
+            env.storage()
+                .persistent()
+                .set(&StorageKeyBuilder::member_profile(group_id, m.clone()), &profile);
+            env.storage().persistent().set(
+                &StorageKeyBuilder::member_payout_eligibility(group_id, m.clone()),
+                &(i as u32),
+            );
+        }
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_members(group_id), &member_vec);
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    /// Happy path: two compatible Pending groups merge successfully.
+    #[test]
+    fn test_merge_groups_success() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let m1 = Address::generate(&env);
+        let m2 = Address::generate(&env);
+        let m3 = Address::generate(&env);
+        let m4 = Address::generate(&env);
+
+        // Manually seed the group-id counter so IDs are predictable
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::next_group_id(), &2u64);
+
+        setup_pending_group(&env, 1, &creator, 100, 3600, 3, &[creator.clone(), m1.clone()]);
+        setup_pending_group(&env, 2, &creator, 100, 3600, 3, &[m2.clone(), m3.clone(), m4.clone()]);
+
+        let merged_id = client.merge_groups(&1u64, &2u64);
+
+        // Merged group should have id = 3 (next after 2)
+        assert_eq!(merged_id, 3);
+
+        // Merged group data
+        let merged = client.get_group(&merged_id);
+        assert_eq!(merged.contribution_amount, 100);
+        assert_eq!(merged.cycle_duration, 3600);
+        assert_eq!(merged.max_members, 6); // 3 + 3
+        assert_eq!(merged.member_count, 5); // 2 + 3
+
+        // Status of merged group is Pending
+        let status: GroupStatus = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_status(merged_id))
+            .unwrap();
+        assert_eq!(status, GroupStatus::Pending);
+
+        // Source groups are Cancelled
+        let s1: GroupStatus = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_status(1))
+            .unwrap();
+        let s2: GroupStatus = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_status(2))
+            .unwrap();
+        assert_eq!(s1, GroupStatus::Cancelled);
+        assert_eq!(s2, GroupStatus::Cancelled);
+
+        // All 5 members have profiles in the merged group with sequential positions
+        let members: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_members(merged_id))
+            .unwrap();
+        assert_eq!(members.len(), 5);
+
+        for i in 0..members.len() {
+            let member = members.get(i).unwrap();
+            let pos: u32 = env
+                .storage()
+                .persistent()
+                .get(&StorageKeyBuilder::member_payout_eligibility(merged_id, member))
+                .unwrap();
+            assert_eq!(pos, i);
+        }
+    }
+
+    /// Merging groups with different contribution amounts must fail.
+    #[test]
+    fn test_merge_groups_incompatible_contribution_amount() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let m1 = Address::generate(&env);
+
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::next_group_id(), &2u64);
+
+        setup_pending_group(&env, 1, &creator, 100, 3600, 3, &[creator.clone(), m1.clone()]);
+        setup_pending_group(&env, 2, &creator, 200, 3600, 3, &[m1.clone()]); // different amount
+
+        let result = client.try_merge_groups(&1u64, &2u64);
+        assert_eq!(result, Err(Ok(StellarSaveError::MergeIncompatible)));
+    }
+
+    /// Merging groups with different cycle durations must fail.
+    #[test]
+    fn test_merge_groups_incompatible_cycle_duration() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let m1 = Address::generate(&env);
+
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::next_group_id(), &2u64);
+
+        setup_pending_group(&env, 1, &creator, 100, 3600, 3, &[creator.clone(), m1.clone()]);
+        setup_pending_group(&env, 2, &creator, 100, 7200, 3, &[m1.clone()]); // different duration
+
+        let result = client.try_merge_groups(&1u64, &2u64);
+        assert_eq!(result, Err(Ok(StellarSaveError::MergeIncompatible)));
+    }
+
+    /// Merging when group 1 is not Pending must fail.
+    #[test]
+    fn test_merge_groups_source_not_pending() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let m1 = Address::generate(&env);
+
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::next_group_id(), &2u64);
+
+        setup_pending_group(&env, 1, &creator, 100, 3600, 3, &[creator.clone(), m1.clone()]);
+        setup_pending_group(&env, 2, &creator, 100, 3600, 3, &[m1.clone()]);
+
+        // Force group 1 to Active
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_status(1), &GroupStatus::Active);
+
+        let result = client.try_merge_groups(&1u64, &2u64);
+        assert_eq!(result, Err(Ok(StellarSaveError::InvalidState)));
+    }
+
+    /// Merging a non-existent group must fail with GroupNotFound.
+    #[test]
+    fn test_merge_groups_group_not_found() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let m1 = Address::generate(&env);
+
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::next_group_id(), &1u64);
+
+        setup_pending_group(&env, 1, &creator, 100, 3600, 3, &[creator.clone(), m1.clone()]);
+
+        let result = client.try_merge_groups(&1u64, &999u64);
+        assert_eq!(result, Err(Ok(StellarSaveError::GroupNotFound)));
+    }
+
+    /// Combined balance is correctly summed in the merged group.
+    #[test]
+    fn test_merge_groups_combined_balance() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let m1 = Address::generate(&env);
+
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::next_group_id(), &2u64);
+
+        setup_pending_group(&env, 1, &creator, 100, 3600, 3, &[creator.clone(), m1.clone()]);
+        setup_pending_group(&env, 2, &creator, 100, 3600, 3, &[m1.clone()]);
+
+        // Seed balances for both source groups
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_balance(1), &500i128);
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_balance(2), &300i128);
+
+        let merged_id = client.merge_groups(&1u64, &2u64);
+
+        let balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_balance(merged_id))
+            .unwrap_or(0);
+        assert_eq!(balance, 800);
+    }
+
+    /// Merging two empty-member groups still produces a valid merged group.
+    #[test]
+    fn test_merge_groups_empty_members() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::next_group_id(), &2u64);
+
+        setup_pending_group(&env, 1, &creator, 100, 3600, 5, &[]);
+        setup_pending_group(&env, 2, &creator, 100, 3600, 5, &[]);
+
+        let merged_id = client.merge_groups(&1u64, &2u64);
+
+        let merged = client.get_group(&merged_id);
+        assert_eq!(merged.member_count, 0);
+        assert_eq!(merged.max_members, 10);
+    }
+}

--- a/contracts/stellar-save/src/storage.rs
+++ b/contracts/stellar-save/src/storage.rs
@@ -74,6 +74,10 @@ pub enum GroupKey {
     TokenConfig(u64),
     /// Dispute reason string: GROUP_DISPUTE_REASON_{id}
     DisputeReason(u64),
+
+    /// Merged-from source group IDs: GROUP_MERGED_FROM_{id}
+    /// Stores the two source group IDs that were merged to create this group.
+    MergedFrom(u64),
 }
 
 /// Storage keys for member-related data.
@@ -241,6 +245,11 @@ impl StorageKeyBuilder {
 
     pub fn group_dispute_reason(group_id: u64) -> StorageKey {
         StorageKey::Group(GroupKey::DisputeReason(group_id))
+    }
+
+    /// Creates a key for storing the source group IDs of a merged group.
+    pub fn group_merged_from(group_id: u64) -> StorageKey {
+        StorageKey::Group(GroupKey::MergedFrom(group_id))
     }
 
     // Member key builders


### PR DESCRIPTION
closes #478 


This PR introduces merge_groups(group_id_1, group_id_2) to allow two compatible groups to merge into a single group with combined members and funds.


Changes:
Added merge_groups function
Implemented compatibility checks (contribution amount, cycle duration)
Merged member lists and recalculated payout order
Transferred and consolidated funds into merged group
Emitted GroupsMerged event