### PR TITLE
feat: contribution limits, auto cycle advancement & completion rewards (#470, #471, #472)

### DIFF
--- a/contracts/stellar-save/src/error.rs
+++ b/contracts/stellar-save/src/error.rs
@@ -56,6 +56,14 @@ pub enum StellarSaveError {
     /// Error Code: 3004
     ContributionNotFound = 3004,
 
+    /// The contribution amount is below the configured minimum.
+    /// Error Code: 3006
+    ContributionTooLow = 3006,
+
+    /// The contribution amount exceeds the configured maximum.
+    /// Error Code: 3007
+    ContributionTooHigh = 3007,
+
     // Payout-related errors (4000-4999)
     /// The payout operation failed due to insufficient funds or transfer error.
     /// Error Code: 4001
@@ -77,6 +85,15 @@ pub enum StellarSaveError {
     /// The SEP-41 transfer_from or transfer call failed during contribution or payout.
     /// Error Code: 5002
     TokenTransferFailed = 5002,
+
+    // Reward-related errors (6000-6999)
+    /// The member has already claimed their completion reward.
+    /// Error Code: 6001
+    RewardAlreadyClaimed = 6001,
+
+    /// The member is not eligible to claim a completion reward.
+    /// Error Code: 6002
+    RewardNotEligible = 6002,
 
     // System-related errors (9000-9999)
     /// An internal contract error occurred.
@@ -141,6 +158,12 @@ impl StellarSaveError {
             StellarSaveError::ContributionNotFound => {
                 "The contribution record was not found for the specified member and cycle."
             }
+            StellarSaveError::ContributionTooLow => {
+                "The contribution amount is below the configured minimum limit."
+            }
+            StellarSaveError::ContributionTooHigh => {
+                "The contribution amount exceeds the configured maximum limit."
+            }
 
             // Payout-related errors
             StellarSaveError::PayoutFailed => {
@@ -159,6 +182,14 @@ impl StellarSaveError {
             }
             StellarSaveError::TokenTransferFailed => {
                 "The token transfer failed. Ensure the member has granted sufficient allowance to the contract."
+            }
+
+            // Reward-related errors
+            StellarSaveError::RewardAlreadyClaimed => {
+                "You have already claimed your completion reward for this group."
+            }
+            StellarSaveError::RewardNotEligible => {
+                "You are not eligible to claim a completion reward. Only members who completed all cycles are eligible."
             }
 
             // System-related errors
@@ -196,6 +227,7 @@ impl StellarSaveError {
             3000..=3999 => ErrorCategory::Contribution,
             4000..=4999 => ErrorCategory::Payout,
             5000..=5999 => ErrorCategory::Token,
+            6000..=6999 => ErrorCategory::Reward,
             9000..=9999 => ErrorCategory::System,
             _ => ErrorCategory::Unknown,
         }
@@ -220,6 +252,9 @@ pub enum ErrorCategory {
 
     /// Errors related to token validation and transfer operations.
     Token,
+
+    /// Errors related to completion reward operations.
+    Reward,
 
     /// System-level errors and internal failures.
     System,
@@ -296,6 +331,14 @@ impl ErrorRecoveryStrategy {
             }
             StellarSaveError::TokenTransferFailed => {
                 "Ensure you have called `approve` on the token contract granting the StellarSave contract an allowance of at least the contribution amount before calling `contribute`."
+            }
+
+            // Reward errors - recovery strategies
+            StellarSaveError::RewardAlreadyClaimed => {
+                "You have already claimed your reward for this group. Each member can only claim once."
+            }
+            StellarSaveError::RewardNotEligible => {
+                "Only members who contributed in every cycle are eligible. Verify your contribution history."
             }
 
             // System errors - recovery strategies

--- a/contracts/stellar-save/src/events.rs
+++ b/contracts/stellar-save/src/events.rs
@@ -165,6 +165,25 @@ pub struct CycleEnded {
 
 }
 
+/// Event emitted when a cycle advances to the next cycle.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CycleAdvanced {
+    pub group_id: u64,
+    pub new_cycle: u32,
+    pub advanced_at: u64,
+}
+
+/// Event emitted when a member claims their completion reward.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RewardClaimed {
+    pub group_id: u64,
+    pub member: Address,
+    pub amount: i128,
+    pub claimed_at: u64,
+}
+
 /// Utility functions for emitting events.
 pub struct EventEmitter;
 
@@ -438,6 +457,25 @@ impl EventEmitter {
 
         env.events().publish(("penalty_recovered",), event);
 
+    }
+
+    pub fn emit_cycle_advanced(env: &Env, group_id: u64, new_cycle: u32, advanced_at: u64) {
+        let event = CycleAdvanced {
+            group_id,
+            new_cycle,
+            advanced_at,
+        };
+        env.events().publish(("cycle_advanced",), event);
+    }
+
+    pub fn emit_reward_claimed(env: &Env, group_id: u64, member: Address, amount: i128, claimed_at: u64) {
+        let event = RewardClaimed {
+            group_id,
+            member,
+            amount,
+            claimed_at,
+        };
+        env.events().publish(("reward_claimed",), event);
     }
 }
 

--- a/contracts/stellar-save/src/group.rs
+++ b/contracts/stellar-save/src/group.rs
@@ -219,6 +219,10 @@ pub struct Group {
     /// Maximum allowed value is 604800 (7 days). Defaults to 0 (no grace period).
     pub grace_period_seconds: u64,
 
+    /// Accumulated reward pool from contribution fees (1% of each contribution).
+    /// Distributed equally among members who complete all cycles.
+    pub reward_pool: i128,
+
 }
 
 impl Group {
@@ -324,6 +328,7 @@ impl Group {
 
             grace_period_seconds,
 
+            reward_pool: 0,
         }
     }
 

--- a/contracts/stellar-save/src/lib.rs
+++ b/contracts/stellar-save/src/lib.rs
@@ -357,6 +357,54 @@ impl StellarSaveContract {
         Ok(())
     }
 
+    /// Updates the global contribution amount limits.
+    ///
+    /// Only the contract admin can call this function.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `admin` - Admin address (must match stored config admin)
+    /// * `min_contribution` - New minimum contribution amount (must be > 0)
+    /// * `max_contribution` - New maximum contribution amount (must be >= min_contribution)
+    ///
+    /// # Returns
+    /// * `Ok(())` - Limits updated successfully
+    /// * `Err(StellarSaveError::Unauthorized)` - Caller is not the admin
+    /// * `Err(StellarSaveError::ContributionTooLow)` - min_contribution <= 0
+    /// * `Err(StellarSaveError::ContributionTooHigh)` - max_contribution < min_contribution
+    pub fn update_contribution_limits(
+        env: Env,
+        admin: Address,
+        min_contribution: i128,
+        max_contribution: i128,
+    ) -> Result<(), StellarSaveError> {
+        admin.require_auth();
+
+        if min_contribution <= 0 {
+            return Err(StellarSaveError::ContributionTooLow);
+        }
+        if max_contribution < min_contribution {
+            return Err(StellarSaveError::ContributionTooHigh);
+        }
+
+        let key = StorageKeyBuilder::contract_config();
+        let mut config = env
+            .storage()
+            .persistent()
+            .get::<_, ContractConfig>(&key)
+            .ok_or(StellarSaveError::Unauthorized)?;
+
+        if config.admin != admin {
+            return Err(StellarSaveError::Unauthorized);
+        }
+
+        config.min_contribution = min_contribution;
+        config.max_contribution = max_contribution;
+        env.storage().persistent().set(&key, &config);
+
+        Ok(())
+    }
+
     /// Creates a new savings group (ROSCA).
     /// Tasks: Validate parameters, Generate ID, Initialize Struct, Store Data, Emit Event.
     pub fn create_group(
@@ -382,9 +430,13 @@ impl StellarSaveContract {
             .persistent()
             .get::<_, ContractConfig>(&config_key)
         {
-            if contribution_amount < config.min_contribution
-                || contribution_amount > config.max_contribution
-                || max_members < config.min_members
+            if contribution_amount < config.min_contribution {
+                return Err(StellarSaveError::ContributionTooLow);
+            }
+            if contribution_amount > config.max_contribution {
+                return Err(StellarSaveError::ContributionTooHigh);
+            }
+            if max_members < config.min_members
                 || max_members > config.max_members
                 || cycle_duration < config.min_cycle_duration
                 || cycle_duration > config.max_cycle_duration
@@ -2835,7 +2887,7 @@ pub fn is_member(
         member.require_auth();
 
         let group_key = StorageKeyBuilder::group_data(group_id);
-        let group: Group = env
+        let mut group: Group = env
             .storage()
             .persistent()
             .get(&group_key)
@@ -2859,8 +2911,16 @@ pub fn is_member(
         // Validate contribution amount matches group requirement
         Self::validate_contribution_amount(&env, group_id, amount)?;
 
+        // Collect 1% reward fee and accumulate in group.reward_pool
+        let reward_amount = amount / 100;
+        let net_contribution = amount - reward_amount;
+        group.reward_pool = group.reward_pool
+            .checked_add(reward_amount)
+            .ok_or(StellarSaveError::Overflow)?;
+        env.storage().persistent().set(&group_key, &group);
+
         let timestamp = env.ledger().timestamp();
-        Self::record_contribution(&env, group_id, group.current_cycle, member.clone(), amount, timestamp)?;
+        Self::record_contribution(&env, group_id, group.current_cycle, member.clone(), net_contribution, timestamp)?;
 
         EventEmitter::emit_contribution_made(
             &env,
@@ -2944,6 +3004,98 @@ pub fn is_member(
 
         let withdrawal_key = StorageKeyBuilder::member_profile(group_id, member.clone());
         env.storage().persistent().remove(&withdrawal_key);
+
+        Ok(())
+    }
+
+    /// Claims the completion reward for a member who participated in all cycles.
+    ///
+    /// The reward pool is accumulated from 1% of each contribution. After the group
+    /// completes, eligible members (those who contributed every cycle) can claim an
+    /// equal share of the reward pool.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `member` - Address of the member claiming the reward
+    /// * `group_id` - ID of the completed group
+    ///
+    /// # Returns
+    /// * `Ok(())` - Reward claimed successfully
+    /// * `Err(StellarSaveError::GroupNotFound)` - Group doesn't exist
+    /// * `Err(StellarSaveError::NotMember)` - Caller is not a member
+    /// * `Err(StellarSaveError::InvalidState)` - Group is not yet complete
+    /// * `Err(StellarSaveError::RewardNotEligible)` - Member missed at least one cycle
+    /// * `Err(StellarSaveError::RewardAlreadyClaimed)` - Reward already claimed
+    pub fn claim_completion_reward(
+        env: Env,
+        member: Address,
+        group_id: u64,
+    ) -> Result<(), StellarSaveError> {
+        member.require_auth();
+
+        // Load group
+        let group_key = StorageKeyBuilder::group_data(group_id);
+        let group: Group = env
+            .storage()
+            .persistent()
+            .get(&group_key)
+            .ok_or(StellarSaveError::GroupNotFound)?;
+
+        // Group must be complete
+        if !group.is_complete() {
+            return Err(StellarSaveError::InvalidState);
+        }
+
+        // Verify member exists
+        let member_key = StorageKeyBuilder::member_profile(group_id, member.clone());
+        if !env.storage().persistent().has(&member_key) {
+            return Err(StellarSaveError::NotMember);
+        }
+
+        // Prevent double claiming
+        let claimed_key = StorageKeyBuilder::member_reward_claimed(group_id, member.clone());
+        if env.storage().persistent().has(&claimed_key) {
+            return Err(StellarSaveError::RewardAlreadyClaimed);
+        }
+
+        // Verify member contributed in every cycle (0..max_members)
+        for cycle in 0..group.max_members {
+            let contrib_key = StorageKeyBuilder::contribution_individual(
+                group_id,
+                cycle,
+                member.clone(),
+            );
+            if !env.storage().persistent().has(&contrib_key) {
+                return Err(StellarSaveError::RewardNotEligible);
+            }
+        }
+
+        // Calculate equal share: reward_pool / max_members
+        let reward_share = group.reward_pool
+            .checked_div(group.max_members as i128)
+            .unwrap_or(0);
+
+        if reward_share <= 0 {
+            return Err(StellarSaveError::RewardNotEligible);
+        }
+
+        // Mark as claimed before transfer (checks-effects-interactions)
+        env.storage().persistent().set(&claimed_key, &true);
+
+        // Transfer reward via the group's token
+        let token_config_key = StorageKeyBuilder::group_token_config(group_id);
+        if let Some(token_config) = env
+            .storage()
+            .persistent()
+            .get::<_, crate::group::TokenConfig>(&token_config_key)
+        {
+            let token_client = soroban_sdk::token::TokenClient::new(&env, &token_config.token_address);
+            token_client.transfer(&env.current_contract_address(), &member, &reward_share);
+        }
+
+        // Emit RewardClaimed event
+        let timestamp = env.ledger().timestamp();
+        EventEmitter::emit_reward_claimed(&env, group_id, member, reward_share, timestamp);
 
         Ok(())
     }

--- a/contracts/stellar-save/src/payout_executor.rs
+++ b/contracts/stellar-save/src/payout_executor.rs
@@ -540,20 +540,18 @@ fn advance_cycle_or_complete(
     group: &mut Group,
 ) -> Result<(), StellarSaveError> {
     // Call group.advance_cycle to increment cycle and handle completion logic
-    // This method:
-    // - Increments current_cycle by 1
-    // - Checks if current_cycle >= max_members (group is complete)
-    // - If complete: sets status = Completed, is_active = false
-    // - If complete: emits GroupCompleted event automatically
-    // - Panics if group is already complete (defensive check)
     group.advance_cycle(env);
 
     // Save the updated group to storage
-    // This persists the incremented cycle number and any status changes
     let group_key = StorageKeyBuilder::group_data(group.id);
     env.storage().persistent().set(&group_key, group);
 
-    // Cycle advancement and storage completed successfully
+    // Emit CycleAdvanced event (only when group is not yet complete)
+    if !group.is_complete() {
+        let timestamp = env.ledger().timestamp();
+        EventEmitter::emit_cycle_advanced(env, group.id, group.current_cycle, timestamp);
+    }
+
     Ok(())
 }
 

--- a/contracts/stellar-save/src/storage.rs
+++ b/contracts/stellar-save/src/storage.rs
@@ -99,6 +99,10 @@ pub enum MemberKey {
     /// Tracks total amount contributed by member across all cycles.
     TotalContributions(u64, Address),
 
+    /// Member reward claimed flag: MEMBER_REWARD_CLAIMED_{group_id}_{address}
+    /// Tracks whether a member has claimed their completion reward.
+    RewardClaimed(u64, Address),
+
     /// Member total penalties: MEMBER_PENALTY_{group_id}_{address}
     /// Tracks cumulative penalty amount charged to a member for missed contributions.
     PenaltyTotal(u64, Address),
@@ -263,6 +267,11 @@ impl StorageKeyBuilder {
     /// Creates a key for member total contributions.
     pub fn member_total_contributions(group_id: u64, address: Address) -> StorageKey {
         StorageKey::Member(MemberKey::TotalContributions(group_id, address))
+    }
+
+    /// Creates a key for tracking whether a member has claimed their completion reward.
+    pub fn member_reward_claimed(group_id: u64, address: Address) -> StorageKey {
+        StorageKey::Member(MemberKey::RewardClaimed(group_id, address))
     }
 
     /// Creates a key for member cumulative penalty total.


### PR DESCRIPTION
## Summary

This PR implements three issues in a single atomic change.

---

### Closes #470 — Add Contribution Amount Validation Ranges

- Added `ContributionTooLow` (3006) and `ContributionTooHigh` (3007) error variants to `error.rs` with messages and recovery guidance
- Added `update_contribution_limits(env, admin, min_contribution, max_contribution)` admin function — requires admin auth, validates `min > 0` and `max >= min`
- Updated `create_group()` to return the specific `ContributionTooLow` / `ContributionTooHigh` errors instead of the generic `InvalidState` when the amount is outside configured limits

### Closes #471 — Implement Automatic Cycle Advancement

- Added `CycleAdvanced { group_id, new_cycle, advanced_at }` event struct to `events.rs`
- Added `EventEmitter::emit_cycle_advanced()`
- Updated `advance_cycle_or_complete()` in `payout_executor.rs` to emit `CycleAdvanced` atomically after each successful payout (final cycle emits the existing `GroupCompleted` event instead)

### Closes #472 — Add Group Completion Rewards

- Added `pub reward_pool: i128` field to `Group` struct (initialized to `0`)
- Updated `contribute()` to deduct 1% (`amount / 100`) as a reward fee and accumulate it in `group.reward_pool`
- Added `claim_completion_reward(env, member, group_id)` — verifies group is complete, member contributed every cycle, prevents double claiming, transfers equal share (`reward_pool / max_members`) via the group token, emits `RewardClaimed`
- Added `RewardClaimed` event struct and `emit_reward_claimed()`
- Added `RewardAlreadyClaimed` (6001) and `RewardNotEligible` (6002) error variants
- Added `MemberKey::RewardClaimed` storage key and `StorageKeyBuilder::member_reward_claimed()`

## Files Changed

| File | Changes |
|------|---------|
| `src/error.rs` | New error variants + Reward category |
| `src/events.rs` | CycleAdvanced + RewardClaimed events |
| `src/group.rs` | reward_pool field on Group struct |
| `src/storage.rs` | MemberKey::RewardClaimed + key builder |
| `src/lib.rs` | update_contribution_limits(), updated create_group(), updated contribute(), claim_completion_reward() |
| `src/payout_executor.rs` | emit CycleAdvanced in advance_cycle_or_complete() |