### PR TITLE
[Contract] Add group invitation system

### DIFF
--- a/contracts/stellar-save/src/error.rs
+++ b/contracts/stellar-save/src/error.rs
@@ -98,6 +98,10 @@ pub enum StellarSaveError {
     /// The two groups are not compatible for merging (different contribution amount or cycle duration).
     /// Error Code: 1005
     MergeIncompatible = 1005,
+
+    /// The address has not been invited to join this invitation-only group.
+    /// Error Code: 2004
+    NotInvited = 2004,
 }
 
 impl StellarSaveError {
@@ -180,6 +184,9 @@ impl StellarSaveError {
             }
             StellarSaveError::MergeIncompatible => {
                 "The two groups are not compatible for merging. Both must have the same contribution amount and cycle duration."
+            }
+            StellarSaveError::NotInvited => {
+                "This address has not been invited to join the group. Only invited addresses can join invitation-only groups."
             }
         }
     }
@@ -317,6 +324,9 @@ impl ErrorRecoveryStrategy {
             }
             StellarSaveError::MergeIncompatible => {
                 "Ensure both groups have the same contribution_amount and cycle_duration before merging."
+            }
+            StellarSaveError::NotInvited => {
+                "Ask the group creator to invite your address before attempting to join."
             }
         }
     }

--- a/contracts/stellar-save/src/events.rs
+++ b/contracts/stellar-save/src/events.rs
@@ -184,6 +184,26 @@ pub struct MilestoneReached {
     pub reached_at_cycle: u32,
 }
 
+/// Event emitted when a creator invites an address to join a group.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MemberInvited {
+    pub group_id: u64,
+    pub invited: Address,
+    pub invited_by: Address,
+    pub invited_at: u64,
+}
+
+/// Event emitted when a creator revokes a pending invitation.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InvitationRevoked {
+    pub group_id: u64,
+    pub revoked: Address,
+    pub revoked_by: Address,
+    pub revoked_at: u64,
+}
+
 /// Event emitted when a penalty is applied to a member for a missed contribution.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -480,6 +500,38 @@ impl EventEmitter {
             reached_at_cycle,
         };
         env.events().publish(("milestone_reached",), event);
+    }
+
+    pub fn emit_member_invited(
+        env: &Env,
+        group_id: u64,
+        invited: Address,
+        invited_by: Address,
+        invited_at: u64,
+    ) {
+        let event = MemberInvited {
+            group_id,
+            invited,
+            invited_by,
+            invited_at,
+        };
+        env.events().publish(("member_invited",), event);
+    }
+
+    pub fn emit_invitation_revoked(
+        env: &Env,
+        group_id: u64,
+        revoked: Address,
+        revoked_by: Address,
+        revoked_at: u64,
+    ) {
+        let event = InvitationRevoked {
+            group_id,
+            revoked,
+            revoked_by,
+            revoked_at,
+        };
+        env.events().publish(("invitation_revoked",), event);
     }
 
     pub fn emit_groups_merged(

--- a/contracts/stellar-save/src/group.rs
+++ b/contracts/stellar-save/src/group.rs
@@ -219,6 +219,8 @@ pub struct Group {
     /// Maximum allowed value is 604800 (7 days). Defaults to 0 (no grace period).
     pub grace_period_seconds: u64,
 
+    /// When true, only addresses explicitly invited by the creator may join.
+    pub invitation_only: bool,
 }
 
 impl Group {
@@ -324,6 +326,7 @@ impl Group {
 
             grace_period_seconds,
 
+            invitation_only: false,
         }
     }
 

--- a/contracts/stellar-save/src/invitation_tests.rs
+++ b/contracts/stellar-save/src/invitation_tests.rs
@@ -1,0 +1,393 @@
+#[cfg(test)]
+mod tests {
+    use crate::{
+        group::{Group, GroupStatus},
+        storage::StorageKeyBuilder,
+        MemberProfile, StellarSaveContract, StellarSaveError,
+    };
+    use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    fn setup_pending_group(env: &Env, group_id: u64, creator: &Address) {
+        let group = Group::new(
+            group_id,
+            creator.clone(),
+            100,
+            3600,
+            5,
+            2,
+            env.ledger().timestamp(),
+            0,
+        );
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_data(group_id), &group);
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_status(group_id), &GroupStatus::Pending);
+    }
+
+    fn setup_invitation_only_group(env: &Env, group_id: u64, creator: &Address) {
+        let mut group = Group::new(
+            group_id,
+            creator.clone(),
+            100,
+            3600,
+            5,
+            2,
+            env.ledger().timestamp(),
+            0,
+        );
+        group.invitation_only = true;
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_data(group_id), &group);
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_status(group_id), &GroupStatus::Pending);
+    }
+
+    // ── set_invitation_only ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_invitation_only_enables_flag() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        setup_pending_group(&env, 1, &creator);
+
+        client.set_invitation_only(&1u64, &true);
+
+        let group = client.get_group(&1u64);
+        assert!(group.invitation_only);
+    }
+
+    #[test]
+    fn test_set_invitation_only_disables_flag() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        setup_invitation_only_group(&env, 1, &creator);
+
+        client.set_invitation_only(&1u64, &false);
+
+        let group = client.get_group(&1u64);
+        assert!(!group.invitation_only);
+    }
+
+    #[test]
+    fn test_set_invitation_only_fails_when_active() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        setup_pending_group(&env, 1, &creator);
+        // Force Active
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_status(1), &GroupStatus::Active);
+
+        let result = client.try_set_invitation_only(&1u64, &true);
+        assert_eq!(result, Err(Ok(StellarSaveError::InvalidState)));
+    }
+
+    // ── invite_member ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_invite_member_success() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let invitee = Address::generate(&env);
+        setup_invitation_only_group(&env, 1, &creator);
+
+        client.invite_member(&1u64, &invitee);
+
+        let invitations: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_invitations(1))
+            .unwrap();
+        assert!(invitations.contains(&invitee));
+    }
+
+    #[test]
+    fn test_invite_member_idempotent() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let invitee = Address::generate(&env);
+        setup_invitation_only_group(&env, 1, &creator);
+
+        client.invite_member(&1u64, &invitee);
+        client.invite_member(&1u64, &invitee); // second call — no duplicate
+
+        let invitations: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_invitations(1))
+            .unwrap();
+        assert_eq!(invitations.len(), 1);
+    }
+
+    #[test]
+    fn test_invite_member_group_not_found() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let invitee = Address::generate(&env);
+        let result = client.try_invite_member(&999u64, &invitee);
+        assert_eq!(result, Err(Ok(StellarSaveError::GroupNotFound)));
+    }
+
+    #[test]
+    fn test_invite_member_fails_when_active() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let invitee = Address::generate(&env);
+        setup_invitation_only_group(&env, 1, &creator);
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_status(1), &GroupStatus::Active);
+
+        let result = client.try_invite_member(&1u64, &invitee);
+        assert_eq!(result, Err(Ok(StellarSaveError::InvalidState)));
+    }
+
+    #[test]
+    fn test_invite_member_fails_if_already_member() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let invitee = Address::generate(&env);
+        setup_invitation_only_group(&env, 1, &creator);
+
+        // Manually add invitee as a member
+        let profile = MemberProfile {
+            address: invitee.clone(),
+            group_id: 1,
+            payout_position: 0,
+            joined_at: 0,
+        };
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::member_profile(1, invitee.clone()), &profile);
+
+        let result = client.try_invite_member(&1u64, &invitee);
+        assert_eq!(result, Err(Ok(StellarSaveError::AlreadyMember)));
+    }
+
+    // ── revoke_invitation ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_revoke_invitation_success() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let invitee = Address::generate(&env);
+        setup_invitation_only_group(&env, 1, &creator);
+
+        client.invite_member(&1u64, &invitee);
+        client.revoke_invitation(&1u64, &invitee);
+
+        let invitations: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_invitations(1))
+            .unwrap_or(Vec::new(&env));
+        assert!(!invitations.contains(&invitee));
+    }
+
+    #[test]
+    fn test_revoke_invitation_not_invited() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let invitee = Address::generate(&env);
+        setup_invitation_only_group(&env, 1, &creator);
+
+        let result = client.try_revoke_invitation(&1u64, &invitee);
+        assert_eq!(result, Err(Ok(StellarSaveError::NotInvited)));
+    }
+
+    #[test]
+    fn test_revoke_invitation_group_not_found() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let invitee = Address::generate(&env);
+        let result = client.try_revoke_invitation(&999u64, &invitee);
+        assert_eq!(result, Err(Ok(StellarSaveError::GroupNotFound)));
+    }
+
+    #[test]
+    fn test_revoke_invitation_fails_when_active() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let invitee = Address::generate(&env);
+        setup_invitation_only_group(&env, 1, &creator);
+        client.invite_member(&1u64, &invitee);
+
+        env.storage()
+            .persistent()
+            .set(&StorageKeyBuilder::group_status(1), &GroupStatus::Active);
+
+        let result = client.try_revoke_invitation(&1u64, &invitee);
+        assert_eq!(result, Err(Ok(StellarSaveError::InvalidState)));
+    }
+
+    // ── join_group invitation checks ──────────────────────────────────────────
+
+    #[test]
+    fn test_join_group_invited_member_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let invitee = Address::generate(&env);
+        setup_invitation_only_group(&env, 1, &creator);
+        client.invite_member(&1u64, &invitee);
+
+        client.join_group(&1u64, &invitee);
+
+        assert!(client.is_member(&1u64, &invitee).unwrap());
+    }
+
+    #[test]
+    fn test_join_group_uninvited_member_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let outsider = Address::generate(&env);
+        setup_invitation_only_group(&env, 1, &creator);
+
+        let result = client.try_join_group(&1u64, &outsider);
+        assert_eq!(result, Err(Ok(StellarSaveError::NotInvited)));
+    }
+
+    #[test]
+    fn test_join_group_open_group_no_invitation_needed() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let member = Address::generate(&env);
+        setup_pending_group(&env, 1, &creator); // invitation_only = false
+
+        client.join_group(&1u64, &member);
+
+        assert!(client.is_member(&1u64, &member).unwrap());
+    }
+
+    #[test]
+    fn test_join_group_after_revocation_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let invitee = Address::generate(&env);
+        setup_invitation_only_group(&env, 1, &creator);
+
+        client.invite_member(&1u64, &invitee);
+        client.revoke_invitation(&1u64, &invitee);
+
+        let result = client.try_join_group(&1u64, &invitee);
+        assert_eq!(result, Err(Ok(StellarSaveError::NotInvited)));
+    }
+
+    // ── event emission ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_invite_member_emits_event() {
+        use soroban_sdk::testutils::Events;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let invitee = Address::generate(&env);
+        setup_invitation_only_group(&env, 1, &creator);
+
+        client.invite_member(&1u64, &invitee);
+
+        let all_events = env.events().all();
+        let mut found = false;
+        for i in 0..all_events.len() {
+            let (_, topics, _) = all_events.get(i).unwrap();
+            if topics.len() == 1 {
+                found = true;
+                break;
+            }
+        }
+        assert!(found, "expected MemberInvited event");
+    }
+
+    #[test]
+    fn test_revoke_invitation_emits_event() {
+        use soroban_sdk::testutils::Events;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarSaveContract, ());
+        let client = crate::StellarSaveContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let invitee = Address::generate(&env);
+        setup_invitation_only_group(&env, 1, &creator);
+
+        client.invite_member(&1u64, &invitee);
+        let events_before = env.events().all().len();
+
+        client.revoke_invitation(&1u64, &invitee);
+
+        let all_events = env.events().all();
+        assert!(all_events.len() > events_before, "expected InvitationRevoked event");
+    }
+}

--- a/contracts/stellar-save/src/lib.rs
+++ b/contracts/stellar-save/src/lib.rs
@@ -35,6 +35,7 @@ pub mod token;
 mod multi_token_tests;
 mod merge_tests;
 mod milestone_tests;
+mod invitation_tests;
 pub mod milestones;
 
 // Re-export for convenience
@@ -1834,6 +1835,148 @@ pub fn is_member(
         Ok(())
     }
 
+    /// Enables or disables invitation-only mode for a group.
+    /// Only the creator can call this while the group is Pending.
+    pub fn set_invitation_only(
+        env: Env,
+        group_id: u64,
+        enabled: bool,
+    ) -> Result<(), StellarSaveError> {
+        let group_key = StorageKeyBuilder::group_data(group_id);
+        let mut group = env
+            .storage()
+            .persistent()
+            .get::<_, Group>(&group_key)
+            .ok_or(StellarSaveError::GroupNotFound)?;
+
+        group.creator.require_auth();
+
+        let status: GroupStatus = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_status(group_id))
+            .unwrap_or(GroupStatus::Pending);
+        if status != GroupStatus::Pending {
+            return Err(StellarSaveError::InvalidState);
+        }
+
+        group.invitation_only = enabled;
+        env.storage().persistent().set(&group_key, &group);
+        Ok(())
+    }
+
+    /// Invites an address to join an invitation-only group.
+    /// Only the group creator can call this; group must be Pending.
+    ///
+    /// # Errors
+    /// - `GroupNotFound` - Group doesn't exist
+    /// - `Unauthorized` - Caller is not the group creator
+    /// - `InvalidState` - Group is not Pending
+    /// - `AlreadyMember` - Address is already a member
+    pub fn invite_member(
+        env: Env,
+        group_id: u64,
+        invitee: Address,
+    ) -> Result<(), StellarSaveError> {
+        let group_key = StorageKeyBuilder::group_data(group_id);
+        let group = env
+            .storage()
+            .persistent()
+            .get::<_, Group>(&group_key)
+            .ok_or(StellarSaveError::GroupNotFound)?;
+
+        group.creator.require_auth();
+
+        let status: GroupStatus = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_status(group_id))
+            .unwrap_or(GroupStatus::Pending);
+        if status != GroupStatus::Pending {
+            return Err(StellarSaveError::InvalidState);
+        }
+
+        // Reject if already a member
+        if env
+            .storage()
+            .persistent()
+            .has(&StorageKeyBuilder::member_profile(group_id, invitee.clone()))
+        {
+            return Err(StellarSaveError::AlreadyMember);
+        }
+
+        let inv_key = StorageKeyBuilder::group_invitations(group_id);
+        let mut invitations: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&inv_key)
+            .unwrap_or(Vec::new(&env));
+
+        if !invitations.contains(&invitee) {
+            invitations.push_back(invitee.clone());
+            env.storage().persistent().set(&inv_key, &invitations);
+        }
+
+        let timestamp = env.ledger().timestamp();
+        EventEmitter::emit_member_invited(&env, group_id, invitee, group.creator, timestamp);
+        Ok(())
+    }
+
+    /// Revokes a pending invitation for an address.
+    /// Only the group creator can call this; group must be Pending.
+    ///
+    /// # Errors
+    /// - `GroupNotFound` - Group doesn't exist
+    /// - `Unauthorized` - Caller is not the group creator
+    /// - `InvalidState` - Group is not Pending
+    /// - `NotInvited` - Address was not invited
+    pub fn revoke_invitation(
+        env: Env,
+        group_id: u64,
+        invitee: Address,
+    ) -> Result<(), StellarSaveError> {
+        let group_key = StorageKeyBuilder::group_data(group_id);
+        let group = env
+            .storage()
+            .persistent()
+            .get::<_, Group>(&group_key)
+            .ok_or(StellarSaveError::GroupNotFound)?;
+
+        group.creator.require_auth();
+
+        let status: GroupStatus = env
+            .storage()
+            .persistent()
+            .get(&StorageKeyBuilder::group_status(group_id))
+            .unwrap_or(GroupStatus::Pending);
+        if status != GroupStatus::Pending {
+            return Err(StellarSaveError::InvalidState);
+        }
+
+        let inv_key = StorageKeyBuilder::group_invitations(group_id);
+        let invitations: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&inv_key)
+            .unwrap_or(Vec::new(&env));
+
+        if !invitations.contains(&invitee) {
+            return Err(StellarSaveError::NotInvited);
+        }
+
+        let mut new_list: Vec<Address> = Vec::new(&env);
+        for addr in invitations.iter() {
+            if addr != invitee {
+                new_list.push_back(addr);
+            }
+        }
+        env.storage().persistent().set(&inv_key, &new_list);
+
+        let timestamp = env.ledger().timestamp();
+        EventEmitter::emit_invitation_revoked(&env, group_id, invitee, group.creator, timestamp);
+        Ok(())
+    }
+
     /// Merges two compatible Pending groups into a new group.
     ///
     /// Compatibility requires both groups to have the same `contribution_amount`
@@ -2981,6 +3124,19 @@ pub fn is_member(
         // Task 3: Check group not full
         if group.member_count >= group.max_members {
             return Err(StellarSaveError::GroupFull);
+        }
+
+        // Task 3b: Check invitation if group is invitation-only
+        if group.invitation_only {
+            let inv_key = StorageKeyBuilder::group_invitations(group_id);
+            let invitations: Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&inv_key)
+                .unwrap_or(Vec::new(&env));
+            if !invitations.contains(&member) {
+                return Err(StellarSaveError::NotInvited);
+            }
         }
 
         // Task 4: Assign payout position

--- a/contracts/stellar-save/src/storage.rs
+++ b/contracts/stellar-save/src/storage.rs
@@ -78,6 +78,10 @@ pub enum GroupKey {
     /// Merged-from source group IDs: GROUP_MERGED_FROM_{id}
     /// Stores the two source group IDs that were merged to create this group.
     MergedFrom(u64),
+
+    /// Invitation list: GROUP_INVITATIONS_{id}
+    /// Stores the Vec<Address> of addresses invited to join this group.
+    Invitations(u64),
 }
 
 /// Storage keys for member-related data.
@@ -254,6 +258,11 @@ impl StorageKeyBuilder {
     /// Creates a key for storing the source group IDs of a merged group.
     pub fn group_merged_from(group_id: u64) -> StorageKey {
         StorageKey::Group(GroupKey::MergedFrom(group_id))
+    }
+
+    /// Creates a key for the invitation list of a group.
+    pub fn group_invitations(group_id: u64) -> StorageKey {
+        StorageKey::Group(GroupKey::Invitations(group_id))
     }
 
     // Member key builders


### PR DESCRIPTION
closes #476 


This PR introduces an invitation system that allows groups to operate in invitation-only mode, restricting membership to explicitly invited addresses.

Changes:
Added invitation_only flag and invited_members set to Group struct
Implemented invite_member(group_id, address) (creator-only)
Updated join_group() to enforce invitation checks when enabled
Added revoke_invitation(group_id, address) function
Emitted MemberInvited and InvitationRevoked events