### PR TITLE
feat: member directory and transaction confirmation modal

### DIFF
--- a/frontend/src/components/Leaderboard.tsx
+++ b/frontend/src/components/Leaderboard.tsx
@@ -1,0 +1,427 @@
+import { useState } from 'react';
+import type { SyntheticEvent } from 'react';
+import {
+  Box, Stack, Typography, Tabs, Tab,
+  Skeleton, Alert, Chip, Tooltip,
+} from '@mui/material';
+import type { LeaderboardGroup, LeaderboardMember, TimePeriod } from '../types/leaderboard';
+import { formatAddress } from '../utils/formatAddress';
+import { formatAmount } from '../utils/formatAmount';
+
+// ── Period selector ───────────────────────────────────────────────────────────
+
+const PERIODS: { value: TimePeriod; label: string }[] = [
+  { value: 'week',     label: 'This Week' },
+  { value: 'month',   label: 'This Month' },
+  { value: 'all-time', label: 'All Time' },
+];
+
+interface PeriodTabsProps {
+  value: TimePeriod;
+  onChange: (p: TimePeriod) => void;
+}
+
+export function PeriodTabs({ value, onChange }: PeriodTabsProps) {
+  return (
+    <Tabs
+      value={value}
+      onChange={(_event: SyntheticEvent, v: TimePeriod) => onChange(v)}
+      aria-label="Leaderboard time period"
+      sx={{ borderBottom: 1, borderColor: 'divider' }}
+    >
+      {PERIODS.map((p) => (
+        <Tab key={p.value} value={p.value} label={p.label} />
+      ))}
+    </Tabs>
+  );
+}
+
+// ── Rank badge ────────────────────────────────────────────────────────────────
+
+const MEDAL: Record<number, string> = { 1: '🥇', 2: '🥈', 3: '🥉' };
+
+function RankBadge({ rank }: { rank: number }) {
+  if (rank <= 3) {
+    return (
+      <Typography fontSize={22} lineHeight={1} aria-label={`Rank ${rank}`}>
+        {MEDAL[rank]}
+      </Typography>
+    );
+  }
+  return (
+    <Box
+      sx={{
+        width: 32, height: 32, borderRadius: '50%',
+        bgcolor: 'action.selected',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}
+    >
+      <Typography variant="caption" fontWeight={700} color="text.secondary">
+        {rank}
+      </Typography>
+    </Box>
+  );
+}
+
+// ── Trend indicator ───────────────────────────────────────────────────────────
+
+function TrendIcon({ trend }: { trend: 'up' | 'down' | 'stable' }) {
+  if (trend === 'up')   return <Typography color="success.main" fontSize={14} aria-label="Trending up">▲</Typography>;
+  if (trend === 'down') return <Typography color="error.main"   fontSize={14} aria-label="Trending down">▼</Typography>;
+  return <Typography color="text.disabled" fontSize={14} aria-label="Stable">—</Typography>;
+}
+
+// ── Progress bar ──────────────────────────────────────────────────────────────
+
+function ProgressBar({ value, color = 'primary.main' }: { value: number; color?: string }) {
+  return (
+    <Box sx={{ height: 6, bgcolor: 'action.hover', borderRadius: 3, overflow: 'hidden', minWidth: 60 }}>
+      <Box
+        sx={{
+          height: '100%', borderRadius: 3,
+          bgcolor: color,
+          width: `${Math.min(100, value)}%`,
+          transition: 'width 0.4s ease',
+        }}
+        role="progressbar"
+        aria-valuenow={Math.round(value)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      />
+    </Box>
+  );
+}
+
+// ── Avatar ────────────────────────────────────────────────────────────────────
+
+const AVATAR_COLORS = ['#6366f1','#8b5cf6','#ec4899','#3b82f6','#14b8a6','#f97316'];
+
+function MemberAvatar({ address, name }: { address: string; name?: string }) {
+  const color = AVATAR_COLORS[address.charCodeAt(0) % AVATAR_COLORS.length];
+  const initials = name ? name.slice(0, 2).toUpperCase() : address.slice(0, 2).toUpperCase();
+  return (
+    <Box
+      sx={{
+        width: 36, height: 36, borderRadius: '50%',
+        bgcolor: color, color: '#fff',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontWeight: 700, fontSize: 13, flexShrink: 0,
+      }}
+      aria-hidden="true"
+    >
+      {initials}
+    </Box>
+  );
+}
+
+// ── Group row ─────────────────────────────────────────────────────────────────
+
+interface GroupRowProps { group: LeaderboardGroup; highlight?: boolean }
+
+function GroupRow({ group, highlight }: GroupRowProps) {
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: '48px 1fr 90px 90px 80px 36px',
+        alignItems: 'center',
+        gap: 1.5,
+        px: 2, py: 1.5,
+        borderRadius: 2,
+        bgcolor: highlight ? 'primary.50' : 'transparent',
+        '&:hover': { bgcolor: 'action.hover' },
+        transition: 'background 0.15s',
+      }}
+    >
+      {/* Rank */}
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <RankBadge rank={group.rank} />
+      </Box>
+
+      {/* Name + meta */}
+      <Box sx={{ minWidth: 0 }}>
+        <Typography variant="body2" fontWeight={600} noWrap>{group.name}</Typography>
+        <Typography variant="caption" color="text.secondary">
+          {group.memberCount} members · {group.completedCycles}/{group.totalCycles} cycles
+        </Typography>
+      </Box>
+
+      {/* Completion rate */}
+      <Stack spacing={0.5}>
+        <Typography variant="caption" color="text.secondary">Completion</Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <ProgressBar value={group.completionRate} color={group.completionRate >= 90 ? 'success.main' : 'primary.main'} />
+          <Typography variant="caption" fontWeight={600}>{group.completionRate}%</Typography>
+        </Box>
+      </Stack>
+
+      {/* On-time rate */}
+      <Stack spacing={0.5}>
+        <Typography variant="caption" color="text.secondary">On-time</Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <ProgressBar value={group.onTimeRate} color="warning.main" />
+          <Typography variant="caption" fontWeight={600}>{group.onTimeRate}%</Typography>
+        </Box>
+      </Stack>
+
+      {/* Volume */}
+      <Stack spacing={0}>
+        <Typography variant="caption" color="text.secondary">Volume</Typography>
+        <Typography variant="caption" fontWeight={600}>{formatAmount(group.totalVolume, { decimals: 0 })}</Typography>
+      </Stack>
+
+      {/* Trend */}
+      <TrendIcon trend={group.trend} />
+    </Box>
+  );
+}
+
+// ── Member row ────────────────────────────────────────────────────────────────
+
+interface MemberRowProps { member: LeaderboardMember; highlight?: boolean }
+
+function MemberRow({ member, highlight }: MemberRowProps) {
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: '48px 40px 1fr 90px 80px 60px 36px',
+        alignItems: 'center',
+        gap: 1.5,
+        px: 2, py: 1.5,
+        borderRadius: 2,
+        bgcolor: highlight ? 'primary.50' : 'transparent',
+        '&:hover': { bgcolor: 'action.hover' },
+        transition: 'background 0.15s',
+      }}
+    >
+      {/* Rank */}
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <RankBadge rank={member.rank} />
+      </Box>
+
+      {/* Avatar */}
+      <MemberAvatar address={member.address} name={member.name} />
+
+      {/* Name + address */}
+      <Box sx={{ minWidth: 0 }}>
+        {member.name && (
+          <Typography variant="body2" fontWeight={600} noWrap>{member.name}</Typography>
+        )}
+        <Tooltip title={member.address}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+            {formatAddress(member.address)}
+          </Typography>
+        </Tooltip>
+      </Box>
+
+      {/* On-time rate */}
+      <Stack spacing={0.5}>
+        <Typography variant="caption" color="text.secondary">On-time</Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <ProgressBar value={member.onTimeRate} color={member.onTimeRate === 100 ? 'success.main' : 'primary.main'} />
+          <Typography variant="caption" fontWeight={600}>{member.onTimeRate}%</Typography>
+        </Box>
+      </Stack>
+
+      {/* Total contributed */}
+      <Stack spacing={0}>
+        <Typography variant="caption" color="text.secondary">Contributed</Typography>
+        <Typography variant="caption" fontWeight={600}>{formatAmount(member.totalContributed, { decimals: 0 })}</Typography>
+      </Stack>
+
+      {/* Streak */}
+      <Box sx={{ textAlign: 'center' }}>
+        {member.streak > 0 ? (
+          <Tooltip title={`${member.streak}-cycle streak`}>
+            <Chip
+              label={`🔥 ${member.streak}`}
+              size="small"
+              sx={{ fontSize: 11, height: 22 }}
+            />
+          </Tooltip>
+        ) : (
+          <Typography variant="caption" color="text.disabled">—</Typography>
+        )}
+      </Box>
+
+      {/* Trend */}
+      <TrendIcon trend={member.trend} />
+    </Box>
+  );
+}
+
+// ── Table header ──────────────────────────────────────────────────────────────
+
+function GroupTableHeader() {
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: '48px 1fr 90px 90px 80px 36px',
+        gap: 1.5, px: 2, pb: 1,
+        borderBottom: '1px solid', borderColor: 'divider',
+      }}
+    >
+      {['#', 'Group', 'Completion', 'On-time', 'Volume', ''].map((h) => (
+        <Typography key={h} variant="caption" color="text.secondary" fontWeight={600} textTransform="uppercase">
+          {h}
+        </Typography>
+      ))}
+    </Box>
+  );
+}
+
+function MemberTableHeader() {
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: '48px 40px 1fr 90px 80px 60px 36px',
+        gap: 1.5, px: 2, pb: 1,
+        borderBottom: '1px solid', borderColor: 'divider',
+      }}
+    >
+      {['#', '', 'Member', 'On-time', 'Contributed', 'Streak', ''].map((h, i) => (
+        <Typography key={i} variant="caption" color="text.secondary" fontWeight={600} textTransform="uppercase">
+          {h}
+        </Typography>
+      ))}
+    </Box>
+  );
+}
+
+// ── Skeleton rows ─────────────────────────────────────────────────────────────
+
+function SkeletonRows({ count = 5, cols = 6 }: { count?: number; cols?: number }) {
+  return (
+    <Stack spacing={1} px={2} py={1}>
+      {Array.from({ length: count }).map((_, i) => (
+        <Box key={i} sx={{ display: 'grid', gridTemplateColumns: `repeat(${cols}, 1fr)`, gap: 1.5, alignItems: 'center' }}>
+          {Array.from({ length: cols }).map((__, j) => (
+            <Skeleton key={j} height={32} sx={{ borderRadius: 1 }} />
+          ))}
+        </Box>
+      ))}
+    </Stack>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export interface LeaderboardProps {
+  groups: LeaderboardGroup[];
+  members: LeaderboardMember[];
+  period: TimePeriod;
+  isLoading?: boolean;
+  error?: string | null;
+  currentUserAddress?: string;
+  onPeriodChange: (p: TimePeriod) => void;
+  generatedAt?: Date;
+}
+
+export function Leaderboard({
+  groups,
+  members,
+  period,
+  isLoading = false,
+  error = null,
+  currentUserAddress,
+  onPeriodChange,
+  generatedAt,
+}: LeaderboardProps) {
+  const [tab, setTab] = useState<'groups' | 'members'>('groups');
+
+  return (
+    <Stack spacing={0}>
+      {/* Period filter */}
+      <PeriodTabs value={period} onChange={onPeriodChange} />
+
+      {/* Section tabs */}
+      <Box sx={{ display: 'flex', gap: 1, px: 2, pt: 2, pb: 1 }}>
+        <Box
+          component="button"
+          onClick={() => setTab('groups')}
+          sx={{
+            px: 2, py: 0.75, borderRadius: 2, border: 'none', cursor: 'pointer',
+            fontWeight: 600, fontSize: '0.875rem',
+            bgcolor: tab === 'groups' ? 'primary.main' : 'action.hover',
+            color: tab === 'groups' ? 'primary.contrastText' : 'text.primary',
+            transition: 'all 0.15s',
+          }}
+          aria-pressed={tab === 'groups'}
+        >
+          🏆 Top Groups
+        </Box>
+        <Box
+          component="button"
+          onClick={() => setTab('members')}
+          sx={{
+            px: 2, py: 0.75, borderRadius: 2, border: 'none', cursor: 'pointer',
+            fontWeight: 600, fontSize: '0.875rem',
+            bgcolor: tab === 'members' ? 'primary.main' : 'action.hover',
+            color: tab === 'members' ? 'primary.contrastText' : 'text.primary',
+            transition: 'all 0.15s',
+          }}
+          aria-pressed={tab === 'members'}
+        >
+          ⭐ Top Contributors
+        </Box>
+      </Box>
+
+      {error && (
+        <Box px={2} pb={1}>
+          <Alert severity="error">{error}</Alert>
+        </Box>
+      )}
+
+      {/* Table */}
+      <Box sx={{ overflowX: 'auto' }}>
+        {tab === 'groups' ? (
+          <Box sx={{ minWidth: 560 }}>
+            <GroupTableHeader />
+            {isLoading ? (
+              <SkeletonRows count={5} cols={6} />
+            ) : groups.length === 0 ? (
+              <Typography color="text.secondary" textAlign="center" py={4}>No data available</Typography>
+            ) : (
+              <Stack spacing={0}>
+                {groups.map((g) => (
+                  <GroupRow key={g.id} group={g} />
+                ))}
+              </Stack>
+            )}
+          </Box>
+        ) : (
+          <Box sx={{ minWidth: 620 }}>
+            <MemberTableHeader />
+            {isLoading ? (
+              <SkeletonRows count={5} cols={7} />
+            ) : members.length === 0 ? (
+              <Typography color="text.secondary" textAlign="center" py={4}>No data available</Typography>
+            ) : (
+              <Stack spacing={0}>
+                {members.map((m) => (
+                  <MemberRow
+                    key={m.address}
+                    member={m}
+                    highlight={m.address === currentUserAddress}
+                  />
+                ))}
+              </Stack>
+            )}
+          </Box>
+        )}
+      </Box>
+
+      {/* Footer */}
+      {generatedAt && !isLoading && (
+        <Typography variant="caption" color="text.disabled" textAlign="right" px={2} pb={1}>
+          Updated {generatedAt.toLocaleTimeString()}
+        </Typography>
+      )}
+    </Stack>
+  );
+}
+
+export default Leaderboard;

--- a/frontend/src/components/MemberDirectory.tsx
+++ b/frontend/src/components/MemberDirectory.tsx
@@ -1,0 +1,496 @@
+import type { MouseEvent, ChangeEvent } from 'react';
+import { useState, useMemo, useCallback } from 'react';
+import {
+  Box,
+  Stack,
+  Typography,
+  TextField,
+  InputAdornment,
+  MenuItem,
+  Select,
+  FormControl,
+  InputLabel,
+  Chip,
+  Grid,
+  Skeleton,
+  Alert,
+  Tooltip,
+} from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material';
+import { Link } from 'react-router-dom';
+import type { MemberProfile, MemberDirectoryFilters, MemberSortOption } from '../types/member';
+import { DEFAULT_MEMBER_FILTERS } from '../types/member';
+import { formatAddress } from '../utils/formatAddress';
+import { formatAmount } from '../utils/formatAmount';
+
+// ── Avatar ───────────────────────────────────────────────────────────────────
+
+const AVATAR_COLORS = [
+  '#6366f1', '#8b5cf6', '#ec4899', '#3b82f6', '#14b8a6', '#f97316',
+];
+
+function getAvatarColor(address: string): string {
+  return AVATAR_COLORS[address.charCodeAt(0) % AVATAR_COLORS.length];
+}
+
+function getInitials(name?: string, address?: string): string {
+  if (name) return name.slice(0, 2).toUpperCase();
+  return address ? address.slice(0, 2).toUpperCase() : '??';
+}
+
+// ── Status config ─────────────────────────────────────────────────────────────
+
+const STATUS_COLORS: Record<MemberProfile['status'], 'success' | 'default' | 'warning' | 'error'> = {
+  active: 'success',
+  inactive: 'default',
+  pending: 'warning',
+  removed: 'error',
+};
+
+// ── Ordinal helper ────────────────────────────────────────────────────────────
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+
+// ── Member Card ───────────────────────────────────────────────────────────────
+
+interface MemberCardProps {
+  member: MemberProfile;
+  isCurrentUser?: boolean;
+  groupId?: string;
+}
+
+function MemberDirectoryCard({ member, isCurrentUser, groupId }: MemberCardProps) {
+  const [copied, setCopied] = useState(false);
+  const avatarColor = getAvatarColor(member.address);
+  const progressPct = Math.min(100, (member.payoutPosition / Math.max(member.totalMembers, 1)) * 100);
+
+  const handleCopy = (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    void navigator.clipboard.writeText(member.address);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const cardContent = (
+    <Box
+      sx={{
+        bgcolor: 'background.paper',
+        borderRadius: 3,
+        border: '1px solid',
+        borderColor: isCurrentUser ? 'primary.main' : 'divider',
+        boxShadow: isCurrentUser ? '0 0 0 2px rgba(99,102,241,0.15)' : 1,
+        overflow: 'hidden',
+        transition: 'box-shadow 0.2s, transform 0.2s',
+        '&:hover': { boxShadow: 4, transform: 'translateY(-2px)' },
+        cursor: groupId ? 'pointer' : 'default',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      {/* Header gradient */}
+      <Box sx={{ height: 48, background: `linear-gradient(135deg, ${avatarColor}22, ${avatarColor}44)` }} />
+
+      {/* Avatar */}
+      <Box sx={{ display: 'flex', justifyContent: 'center', mt: -3, mb: 1 }}>
+        <Box
+          sx={{
+            width: 56, height: 56, borderRadius: '50%',
+            bgcolor: avatarColor, color: '#fff',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontWeight: 700, fontSize: 18,
+            border: '3px solid white', boxShadow: 2,
+          }}
+        >
+          {getInitials(member.name, member.address)}
+        </Box>
+      </Box>
+
+      <Stack spacing={0.5} alignItems="center" px={2} pb={1}>
+        {member.name && (
+          <Typography variant="subtitle2" fontWeight={700} noWrap>
+            {member.name}
+          </Typography>
+        )}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+            {formatAddress(member.address)}
+          </Typography>
+          <Tooltip title={copied ? 'Copied!' : 'Copy address'}>
+            <Box
+              component="button"
+              onClick={handleCopy}
+              sx={{
+                background: 'none', border: 'none', cursor: 'pointer', p: 0,
+                color: copied ? 'success.main' : 'text.disabled',
+                display: 'flex', alignItems: 'center',
+                '&:hover': { color: 'primary.main' },
+              }}
+              aria-label="Copy address"
+            >
+              {copied ? (
+                <svg width="12" height="12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+              ) : (
+                <svg width="12" height="12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+              )}
+            </Box>
+          </Tooltip>
+        </Box>
+
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', justifyContent: 'center', mt: 0.5 }}>
+          <Chip
+            label={member.status.charAt(0).toUpperCase() + member.status.slice(1)}
+            color={STATUS_COLORS[member.status]}
+            size="small"
+          />
+          {isCurrentUser && <Chip label="You" color="primary" size="small" variant="outlined" />}
+          {member.hasReceivedPayout && <Chip label="Paid Out" color="success" size="small" variant="outlined" />}
+        </Box>
+      </Stack>
+
+      <Box sx={{ borderTop: '1px solid', borderColor: 'divider', mx: 2 }} />
+
+      {/* Stats */}
+      <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 1, px: 2, py: 1.5, flexGrow: 1 }}>
+        <Stack alignItems="center" spacing={0}>
+          <Typography variant="subtitle2" fontWeight={700}>{member.contributionCount}</Typography>
+          <Typography variant="caption" color="text.secondary" textAlign="center">Contributions</Typography>
+        </Stack>
+        <Stack alignItems="center" spacing={0}>
+          <Typography variant="subtitle2" fontWeight={700}>{formatAmount(member.totalContributed, { decimals: 0 })}</Typography>
+          <Typography variant="caption" color="text.secondary" textAlign="center">Total Paid</Typography>
+        </Stack>
+        <Stack alignItems="center" spacing={0}>
+          <Typography variant="subtitle2" fontWeight={700}>{ordinal(member.payoutPosition)}</Typography>
+          <Typography variant="caption" color="text.secondary" textAlign="center">
+            {member.hasReceivedPayout ? 'Received' : `of ${member.totalMembers}`}
+          </Typography>
+        </Stack>
+      </Box>
+
+      {/* Payout progress bar */}
+      <Box sx={{ px: 2, pb: 2 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+          <Typography variant="caption" color="text.secondary">Payout queue</Typography>
+          <Typography variant="caption" color="text.secondary">{member.payoutPosition}/{member.totalMembers}</Typography>
+        </Box>
+        <Box sx={{ height: 4, bgcolor: 'action.hover', borderRadius: 2, overflow: 'hidden' }}>
+          <Box
+            sx={{
+              height: '100%', borderRadius: 2,
+              bgcolor: member.hasReceivedPayout ? 'success.main' : 'primary.main',
+              width: `${progressPct}%`,
+              transition: 'width 0.4s ease',
+            }}
+          />
+        </Box>
+        {member.streak !== undefined && member.streak > 1 && (
+          <Typography variant="caption" color="warning.main" sx={{ mt: 0.5, display: 'block' }}>
+            🔥 {member.streak}-cycle streak
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+
+  if (groupId) {
+    return (
+      <Box
+        component={Link}
+        to={`/groups/${groupId}/members/${member.address}`}
+        sx={{ textDecoration: 'none', display: 'block', height: '100%' }}
+      >
+        {cardContent}
+      </Box>
+    );
+  }
+
+  return cardContent;
+}
+
+// ── Skeleton card ─────────────────────────────────────────────────────────────
+
+function MemberCardSkeleton() {
+  return (
+    <Box sx={{ borderRadius: 3, border: '1px solid', borderColor: 'divider', overflow: 'hidden' }}>
+      <Skeleton variant="rectangular" height={48} />
+      <Stack alignItems="center" p={2} spacing={1}>
+        <Skeleton variant="circular" width={56} height={56} sx={{ mt: -3 }} />
+        <Skeleton width={100} height={20} />
+        <Skeleton width={140} height={16} />
+        <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 1, width: '100%', mt: 1 }}>
+          {[0, 1, 2].map((i) => (
+            <Stack key={i} alignItems="center">
+              <Skeleton width={40} height={20} />
+              <Skeleton width={60} height={14} />
+            </Stack>
+          ))}
+        </Box>
+      </Stack>
+    </Box>
+  );
+}
+
+// ── Filters bar ───────────────────────────────────────────────────────────────
+
+interface FiltersBarProps {
+  filters: MemberDirectoryFilters;
+  onChange: (patch: Partial<MemberDirectoryFilters>) => void;
+  totalCount: number;
+  filteredCount: number;
+}
+
+function FiltersBar({ filters, onChange, totalCount, filteredCount }: FiltersBarProps) {
+  return (
+    <Stack
+      direction={{ xs: 'column', sm: 'row' }}
+      spacing={2}
+      alignItems={{ xs: 'stretch', sm: 'center' }}
+      flexWrap="wrap"
+    >
+      {/* Search */}
+      <TextField
+        size="small"
+        placeholder="Search by name or address…"
+        value={filters.search}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => onChange({ search: e.target.value })}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+            </InputAdornment>
+          ),
+        }}
+        sx={{ minWidth: 220, flexGrow: 1 }}
+        inputProps={{ 'aria-label': 'Search members' }}
+      />
+
+      {/* Status filter */}
+      <FormControl size="small" sx={{ minWidth: 130 }}>
+        <InputLabel id="member-status-label">Status</InputLabel>
+        <Select
+          labelId="member-status-label"
+          label="Status"
+          value={filters.status}
+          onChange={(e: SelectChangeEvent) => onChange({ status: e.target.value as MemberDirectoryFilters['status'] })}
+        >
+          <MenuItem value="all">All</MenuItem>
+          <MenuItem value="active">Active</MenuItem>
+          <MenuItem value="inactive">Inactive</MenuItem>
+          <MenuItem value="pending">Pending</MenuItem>
+        </Select>
+      </FormControl>
+
+      {/* Payout filter */}
+      <FormControl size="small" sx={{ minWidth: 150 }}>
+        <InputLabel id="payout-filter-label">Payout</InputLabel>
+        <Select
+          labelId="payout-filter-label"
+          label="Payout"
+          value={filters.hasReceivedPayout}
+          onChange={(e: SelectChangeEvent) => onChange({ hasReceivedPayout: e.target.value as MemberDirectoryFilters['hasReceivedPayout'] })}
+        >
+          <MenuItem value="all">All</MenuItem>
+          <MenuItem value="yes">Received</MenuItem>
+          <MenuItem value="no">Pending</MenuItem>
+        </Select>
+      </FormControl>
+
+      {/* Sort */}
+      <FormControl size="small" sx={{ minWidth: 200 }}>
+        <InputLabel id="member-sort-label">Sort by</InputLabel>
+        <Select
+          labelId="member-sort-label"
+          label="Sort by"
+          value={filters.sort}
+          onChange={(e: SelectChangeEvent) => onChange({ sort: e.target.value as MemberSortOption })}
+        >
+          <MenuItem value="contributions-desc">Most Contributions</MenuItem>
+          <MenuItem value="contributions-asc">Fewest Contributions</MenuItem>
+          <MenuItem value="join-date-desc">Newest Members</MenuItem>
+          <MenuItem value="join-date-asc">Oldest Members</MenuItem>
+          <MenuItem value="name-asc">Name A–Z</MenuItem>
+          <MenuItem value="name-desc">Name Z–A</MenuItem>
+          <MenuItem value="payout-position-asc">Payout Position ↑</MenuItem>
+          <MenuItem value="payout-position-desc">Payout Position ↓</MenuItem>
+        </Select>
+      </FormControl>
+
+      {/* Result count */}
+      <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'nowrap', alignSelf: 'center' }}>
+        {filteredCount === totalCount
+          ? `${totalCount} member${totalCount !== 1 ? 's' : ''}`
+          : `${filteredCount} of ${totalCount}`}
+      </Typography>
+    </Stack>
+  );
+}
+
+// ── Filtering & sorting logic ─────────────────────────────────────────────────
+
+function applyFilters(members: MemberProfile[], filters: MemberDirectoryFilters): MemberProfile[] {
+  let result = members;
+
+  if (filters.search.trim()) {
+    const q = filters.search.toLowerCase();
+    result = result.filter(
+      (m) =>
+        m.address.toLowerCase().includes(q) ||
+        m.name?.toLowerCase().includes(q),
+    );
+  }
+
+  if (filters.status !== 'all') {
+    result = result.filter((m) => m.status === filters.status);
+  }
+
+  if (filters.hasReceivedPayout !== 'all') {
+    const want = filters.hasReceivedPayout === 'yes';
+    result = result.filter((m) => m.hasReceivedPayout === want);
+  }
+
+  return result;
+}
+
+function applySort(members: MemberProfile[], sort: MemberSortOption): MemberProfile[] {
+  return [...members].sort((a, b) => {
+    switch (sort) {
+      case 'contributions-desc': return b.contributionCount - a.contributionCount;
+      case 'contributions-asc':  return a.contributionCount - b.contributionCount;
+      case 'join-date-desc':     return b.joinDate.getTime() - a.joinDate.getTime();
+      case 'join-date-asc':      return a.joinDate.getTime() - b.joinDate.getTime();
+      case 'name-asc':           return (a.name ?? a.address).localeCompare(b.name ?? b.address);
+      case 'name-desc':          return (b.name ?? b.address).localeCompare(a.name ?? a.address);
+      case 'payout-position-asc':  return a.payoutPosition - b.payoutPosition;
+      case 'payout-position-desc': return b.payoutPosition - a.payoutPosition;
+      default: return 0;
+    }
+  });
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export interface MemberDirectoryProps {
+  members: MemberProfile[];
+  isLoading?: boolean;
+  error?: string | null;
+  currentUserAddress?: string;
+  groupId?: string;
+  title?: string;
+}
+
+export function MemberDirectory({
+  members,
+  isLoading = false,
+  error = null,
+  currentUserAddress,
+  groupId,
+  title = 'Member Directory',
+}: MemberDirectoryProps) {
+  const [filters, setFilters] = useState<MemberDirectoryFilters>(DEFAULT_MEMBER_FILTERS);
+
+  const handleFilterChange = useCallback((patch: Partial<MemberDirectoryFilters>) => {
+    setFilters((prev: MemberDirectoryFilters) => ({ ...prev, ...patch }));
+  }, []);
+
+  const handleClearFilters = useCallback(() => {
+    setFilters(DEFAULT_MEMBER_FILTERS);
+  }, []);
+
+  const filtered = useMemo(() => applyFilters(members, filters), [members, filters]);
+  const sorted = useMemo(() => applySort(filtered, filters.sort), [filtered, filters.sort]);
+
+  const hasActiveFilters =
+    filters.search.trim() !== '' ||
+    filters.status !== 'all' ||
+    filters.hasReceivedPayout !== 'all';
+
+  return (
+    <Stack spacing={3}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 1 }}>
+        <Typography variant="h5" fontWeight={700}>{title}</Typography>
+        {hasActiveFilters && (
+          <Box
+            component="button"
+            onClick={handleClearFilters}
+            sx={{
+              background: 'none', border: 'none', cursor: 'pointer',
+              color: 'primary.main', fontSize: '0.875rem', fontWeight: 500,
+              '&:hover': { textDecoration: 'underline' },
+            }}
+          >
+            Clear filters
+          </Box>
+        )}
+      </Box>
+
+      <FiltersBar
+        filters={filters}
+        onChange={handleFilterChange}
+        totalCount={members.length}
+        filteredCount={filtered.length}
+      />
+
+      {error && <Alert severity="error">{error}</Alert>}
+
+      {isLoading ? (
+        <Grid container spacing={2}>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Grid item xs={12} sm={6} md={4} key={i}>
+              <MemberCardSkeleton />
+            </Grid>
+          ))}
+        </Grid>
+      ) : sorted.length === 0 ? (
+        <Box
+          sx={{
+            textAlign: 'center', py: 8,
+            border: '1px dashed', borderColor: 'divider', borderRadius: 3,
+          }}
+        >
+          <Typography variant="h6" color="text.secondary" gutterBottom>
+            {hasActiveFilters ? 'No members match your filters' : 'No members yet'}
+          </Typography>
+          {hasActiveFilters && (
+            <Box
+              component="button"
+              onClick={handleClearFilters}
+              sx={{
+                background: 'none', border: 'none', cursor: 'pointer',
+                color: 'primary.main', fontSize: '0.875rem',
+                '&:hover': { textDecoration: 'underline' },
+              }}
+            >
+              Clear filters
+            </Box>
+          )}
+        </Box>
+      ) : (
+        <Grid container spacing={2}>
+          {sorted.map((member: MemberProfile) => (
+            <Grid item xs={12} sm={6} md={4} key={member.address}>
+              <MemberDirectoryCard
+                member={member}
+                isCurrentUser={member.address === currentUserAddress}
+                groupId={groupId}
+              />
+            </Grid>
+          ))}
+        </Grid>
+      )}
+    </Stack>
+  );
+}
+
+export default MemberDirectory;

--- a/frontend/src/components/TransactionConfirmModal.tsx
+++ b/frontend/src/components/TransactionConfirmModal.tsx
@@ -1,0 +1,509 @@
+import { useState, useCallback } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Stack,
+  Box,
+  Typography,
+  Divider,
+  Alert,
+  CircularProgress,
+  Chip,
+  Stepper,
+  Step,
+  StepLabel,
+  IconButton,
+  Collapse,
+} from '@mui/material';
+import { Button } from './Button';
+import { formatAddress } from '../utils/formatAddress';
+import { formatAmount } from '../utils/formatAmount';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type TxType = 'contribute' | 'join' | 'payout' | 'create' | 'custom';
+
+export interface TransactionDetails {
+  type: TxType;
+  /** Human-readable label, e.g. "Contribute to Savings Circle" */
+  title: string;
+  /** Amount in XLM (optional for non-payment txs) */
+  amount?: number;
+  /** Estimated network fee in XLM */
+  estimatedFee?: number;
+  /** Sender wallet address */
+  from?: string;
+  /** Recipient address (contract or member) */
+  to?: string;
+  /** Group name or ID */
+  groupName?: string;
+  /** Cycle number */
+  cycleId?: number;
+  /** Any extra key-value rows to show in the detail table */
+  extraDetails?: Array<{ label: string; value: string }>;
+}
+
+export type ConfirmationStep = 'review' | 'confirm' | 'submitting' | 'success' | 'error';
+
+export interface TransactionConfirmModalProps {
+  open: boolean;
+  transaction: TransactionDetails;
+  onConfirm: () => Promise<string>; // returns tx hash
+  onClose: () => void;
+  onSuccess?: (txHash: string) => void;
+  onError?: (error: Error) => void;
+}
+
+// ── Step labels ───────────────────────────────────────────────────────────────
+
+const STEPS = ['Review', 'Confirm', 'Submit'];
+
+const STEP_INDEX: Record<ConfirmationStep, number> = {
+  review: 0,
+  confirm: 1,
+  submitting: 2,
+  success: 2,
+  error: 2,
+};
+
+// ── Type icon ─────────────────────────────────────────────────────────────────
+
+function TxTypeIcon({ type }: { type: TxType }) {
+  const icons: Record<TxType, React.ReactNode> = {
+    contribute: (
+      <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+    join: (
+      <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+      </svg>
+    ),
+    payout: (
+      <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z" />
+      </svg>
+    ),
+    create: (
+      <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+      </svg>
+    ),
+    custom: (
+      <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+      </svg>
+    ),
+  };
+  return <>{icons[type]}</>;
+}
+
+// ── Detail row ────────────────────────────────────────────────────────────────
+
+function DetailRow({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 2 }}>
+      <Typography variant="body2" color="text.secondary" sx={{ flexShrink: 0 }}>{label}</Typography>
+      <Typography
+        variant="body2"
+        fontWeight={500}
+        sx={{ fontFamily: mono ? 'monospace' : undefined, wordBreak: 'break-all', textAlign: 'right' }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+// ── Review step ───────────────────────────────────────────────────────────────
+
+interface ReviewStepProps {
+  tx: TransactionDetails;
+  onEdit: () => void;
+  onNext: () => void;
+}
+
+function ReviewStep({ tx, onEdit, onNext }: ReviewStepProps) {
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const total = (tx.amount ?? 0) + (tx.estimatedFee ?? 0.00001);
+
+  return (
+    <Stack spacing={2}>
+      {/* Transaction summary card */}
+      <Box
+        sx={{
+          bgcolor: 'primary.50',
+          border: '1px solid',
+          borderColor: 'primary.200',
+          borderRadius: 2,
+          p: 2,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+        }}
+      >
+        <Box
+          sx={{
+            width: 48, height: 48, borderRadius: '50%',
+            bgcolor: 'primary.main', color: 'white',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            flexShrink: 0,
+          }}
+        >
+          <TxTypeIcon type={tx.type} />
+        </Box>
+        <Box>
+          <Typography variant="subtitle1" fontWeight={700}>{tx.title}</Typography>
+          {tx.groupName && (
+            <Typography variant="body2" color="text.secondary">{tx.groupName}</Typography>
+          )}
+          {tx.cycleId !== undefined && (
+            <Chip label={`Cycle #${tx.cycleId}`} size="small" sx={{ mt: 0.5 }} />
+          )}
+        </Box>
+      </Box>
+
+      {/* Cost breakdown */}
+      <Box sx={{ bgcolor: 'action.hover', borderRadius: 2, p: 2 }}>
+        <Stack spacing={1}>
+          {tx.amount !== undefined && (
+            <DetailRow label="Amount" value={formatAmount(tx.amount)} />
+          )}
+          <DetailRow
+            label="Estimated network fee"
+            value={`~${formatAmount(tx.estimatedFee ?? 0.00001, { decimals: 5 })}`}
+          />
+          {tx.amount !== undefined && (
+            <>
+              <Divider />
+              <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+                <Typography variant="body2" fontWeight={700}>Total</Typography>
+                <Typography variant="body2" fontWeight={700} color="primary.main">
+                  {formatAmount(total)}
+                </Typography>
+              </Box>
+            </>
+          )}
+        </Stack>
+      </Box>
+
+      {/* Addresses */}
+      {(tx.from || tx.to) && (
+        <Box>
+          <Box
+            component="button"
+            onClick={() => setShowAdvanced((v) => !v)}
+            sx={{
+              background: 'none', border: 'none', cursor: 'pointer',
+              color: 'text.secondary', fontSize: '0.8rem', display: 'flex',
+              alignItems: 'center', gap: 0.5, p: 0, mb: 1,
+              '&:hover': { color: 'primary.main' },
+            }}
+            aria-expanded={showAdvanced}
+          >
+            <svg width="12" height="12" fill="none" viewBox="0 0 24 24" stroke="currentColor"
+              style={{ transform: showAdvanced ? 'rotate(90deg)' : 'none', transition: 'transform 0.2s' }}>
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+            {showAdvanced ? 'Hide' : 'Show'} transaction details
+          </Box>
+          <Collapse in={showAdvanced}>
+            <Box sx={{ bgcolor: 'action.hover', borderRadius: 2, p: 2 }}>
+              <Stack spacing={1}>
+                {tx.from && <DetailRow label="From" value={formatAddress(tx.from, { prefixChars: 8, suffixChars: 6 })} mono />}
+                {tx.to && <DetailRow label="To (contract)" value={formatAddress(tx.to, { prefixChars: 8, suffixChars: 6 })} mono />}
+                {tx.extraDetails?.map((d) => (
+                  <DetailRow key={d.label} label={d.label} value={d.value} />
+                ))}
+              </Stack>
+            </Box>
+          </Collapse>
+        </Box>
+      )}
+
+      <Alert severity="info" sx={{ fontSize: '0.8rem' }}>
+        Your Freighter wallet will prompt you to approve this transaction on the next step.
+      </Alert>
+
+      <Box sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end' }}>
+        <Button variant="secondary" onClick={onEdit}>Edit</Button>
+        <Button variant="primary" onClick={onNext}>Review Transaction →</Button>
+      </Box>
+    </Stack>
+  );
+}
+
+// ── Confirm step ──────────────────────────────────────────────────────────────
+
+interface ConfirmStepProps {
+  tx: TransactionDetails;
+  onBack: () => void;
+  onConfirm: () => void;
+}
+
+function ConfirmStep({ tx, onBack, onConfirm }: ConfirmStepProps) {
+  const total = (tx.amount ?? 0) + (tx.estimatedFee ?? 0.00001);
+
+  return (
+    <Stack spacing={2}>
+      <Alert severity="warning" sx={{ fontSize: '0.8rem' }}>
+        Please review carefully. Blockchain transactions cannot be reversed once submitted.
+      </Alert>
+
+      <Box sx={{ bgcolor: 'action.hover', borderRadius: 2, p: 2 }}>
+        <Stack spacing={1.5}>
+          <DetailRow label="Transaction" value={tx.title} />
+          {tx.groupName && <DetailRow label="Group" value={tx.groupName} />}
+          {tx.cycleId !== undefined && <DetailRow label="Cycle" value={`#${tx.cycleId}`} />}
+          {tx.amount !== undefined && <DetailRow label="Amount" value={formatAmount(tx.amount)} />}
+          <DetailRow label="Network fee" value={`~${formatAmount(tx.estimatedFee ?? 0.00001, { decimals: 5 })}`} />
+          {tx.from && <DetailRow label="From" value={formatAddress(tx.from)} mono />}
+          {tx.to && <DetailRow label="To" value={formatAddress(tx.to)} mono />}
+          {tx.extraDetails?.map((d) => (
+            <DetailRow key={d.label} label={d.label} value={d.value} />
+          ))}
+          {tx.amount !== undefined && (
+            <>
+              <Divider />
+              <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+                <Typography variant="body2" fontWeight={700}>Total cost</Typography>
+                <Typography variant="body2" fontWeight={700} color="primary.main">
+                  {formatAmount(total)}
+                </Typography>
+              </Box>
+            </>
+          )}
+        </Stack>
+      </Box>
+
+      <Box sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end' }}>
+        <Button variant="secondary" onClick={onBack}>← Back</Button>
+        <Button variant="primary" onClick={onConfirm}>Confirm &amp; Sign</Button>
+      </Box>
+    </Stack>
+  );
+}
+
+// ── Submitting step ───────────────────────────────────────────────────────────
+
+function SubmittingStep() {
+  return (
+    <Stack spacing={3} alignItems="center" py={3}>
+      <CircularProgress size={56} />
+      <Stack spacing={1} alignItems="center">
+        <Typography variant="subtitle1" fontWeight={600}>Submitting Transaction</Typography>
+        <Typography variant="body2" color="text.secondary" textAlign="center">
+          Please approve the transaction in your Freighter wallet, then wait for network confirmation.
+        </Typography>
+      </Stack>
+    </Stack>
+  );
+}
+
+// ── Success step ──────────────────────────────────────────────────────────────
+
+interface SuccessStepProps {
+  txHash: string;
+  tx: TransactionDetails;
+  onClose: () => void;
+}
+
+function SuccessStep({ txHash, tx, onClose }: SuccessStepProps) {
+  return (
+    <Stack spacing={3} alignItems="center" py={2}>
+      <Box
+        sx={{
+          width: 64, height: 64, borderRadius: '50%',
+          bgcolor: 'success.light', color: 'success.dark',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}
+      >
+        <svg width="32" height="32" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+        </svg>
+      </Box>
+
+      <Stack spacing={1} alignItems="center">
+        <Typography variant="h6" fontWeight={700} color="success.main">Transaction Confirmed</Typography>
+        <Typography variant="body2" color="text.secondary" textAlign="center">
+          {tx.title} was submitted successfully.
+        </Typography>
+      </Stack>
+
+      <Box sx={{ bgcolor: 'action.hover', borderRadius: 2, p: 2, width: '100%' }}>
+        <Stack spacing={1}>
+          <DetailRow label="Transaction hash" value={formatAddress(txHash, { prefixChars: 10, suffixChars: 8 })} mono />
+          {tx.amount !== undefined && <DetailRow label="Amount" value={formatAmount(tx.amount)} />}
+        </Stack>
+      </Box>
+
+      <Box
+        component="a"
+        href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        sx={{ color: 'primary.main', fontSize: '0.875rem', '&:hover': { textDecoration: 'underline' } }}
+      >
+        View on Stellar Explorer →
+      </Box>
+
+      <Button variant="primary" onClick={onClose}>Done</Button>
+    </Stack>
+  );
+}
+
+// ── Error step ────────────────────────────────────────────────────────────────
+
+interface ErrorStepProps {
+  error: string;
+  onRetry: () => void;
+  onClose: () => void;
+}
+
+function ErrorStep({ error, onRetry, onClose }: ErrorStepProps) {
+  return (
+    <Stack spacing={3} alignItems="center" py={2}>
+      <Box
+        sx={{
+          width: 64, height: 64, borderRadius: '50%',
+          bgcolor: 'error.light', color: 'error.dark',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}
+      >
+        <svg width="32" height="32" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </Box>
+
+      <Stack spacing={1} alignItems="center">
+        <Typography variant="h6" fontWeight={700} color="error.main">Transaction Failed</Typography>
+        <Typography variant="body2" color="text.secondary" textAlign="center">{error}</Typography>
+      </Stack>
+
+      <Box sx={{ display: 'flex', gap: 2 }}>
+        <Button variant="secondary" onClick={onClose}>Cancel</Button>
+        <Button variant="primary" onClick={onRetry}>Try Again</Button>
+      </Box>
+    </Stack>
+  );
+}
+
+// ── Main modal ────────────────────────────────────────────────────────────────
+
+export function TransactionConfirmModal({
+  open,
+  transaction,
+  onConfirm,
+  onClose,
+  onSuccess,
+  onError,
+}: TransactionConfirmModalProps) {
+  const [step, setStep] = useState<ConfirmationStep>('review');
+  const [txHash, setTxHash] = useState<string>('');
+  const [errorMessage, setErrorMessage] = useState<string>('');
+
+  const handleClose = useCallback(() => {
+    if (step === 'submitting') return; // prevent close while submitting
+    setStep('review');
+    setTxHash('');
+    setErrorMessage('');
+    onClose();
+  }, [step, onClose]);
+
+  const handleConfirm = useCallback(async () => {
+    setStep('submitting');
+    try {
+      const hash = await onConfirm();
+      setTxHash(hash);
+      setStep('success');
+      onSuccess?.(hash);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error('Transaction failed');
+      setErrorMessage(error.message);
+      setStep('error');
+      onError?.(error);
+    }
+  }, [onConfirm, onSuccess, onError]);
+
+  const handleRetry = useCallback(() => {
+    setStep('review');
+    setErrorMessage('');
+    setTxHash('');
+  }, []);
+
+  const activeStep = STEP_INDEX[step];
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="tx-confirm-title"
+      disableEscapeKeyDown={step === 'submitting'}
+    >
+      <DialogTitle
+        id="tx-confirm-title"
+        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', pb: 1 }}
+      >
+        <Typography variant="h6" fontWeight={700}>
+          {step === 'success' ? 'Transaction Successful' :
+           step === 'error' ? 'Transaction Failed' :
+           'Confirm Transaction'}
+        </Typography>
+        {step !== 'submitting' && (
+          <IconButton onClick={handleClose} size="small" aria-label="Close dialog">
+            <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </IconButton>
+        )}
+      </DialogTitle>
+
+      {/* Stepper — only show during review/confirm/submitting */}
+      {step !== 'success' && step !== 'error' && (
+        <Box sx={{ px: 3, pb: 1 }}>
+          <Stepper activeStep={activeStep} alternativeLabel>
+            {STEPS.map((label) => (
+              <Step key={label}>
+                <StepLabel>{label}</StepLabel>
+              </Step>
+            ))}
+          </Stepper>
+        </Box>
+      )}
+
+      <DialogContent sx={{ pt: 2 }}>
+        {step === 'review' && (
+          <ReviewStep
+            tx={transaction}
+            onEdit={handleClose}
+            onNext={() => setStep('confirm')}
+          />
+        )}
+        {step === 'confirm' && (
+          <ConfirmStep
+            tx={transaction}
+            onBack={() => setStep('review')}
+            onConfirm={() => void handleConfirm()}
+          />
+        )}
+        {step === 'submitting' && <SubmittingStep />}
+        {step === 'success' && (
+          <SuccessStep txHash={txHash} tx={transaction} onClose={handleClose} />
+        )}
+        {step === 'error' && (
+          <ErrorStep error={errorMessage} onRetry={handleRetry} onClose={handleClose} />
+        )}
+      </DialogContent>
+
+      {/* Empty DialogActions keeps consistent spacing */}
+      <DialogActions sx={{ px: 3, pb: 2 }} />
+    </Dialog>
+  );
+}
+
+export default TransactionConfirmModal;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -47,3 +47,7 @@ export type { ContributionFlowProps } from "./ContributionFlow";
 export { WalletIntegration } from "./WalletIntegration";
 export { ActivityFeed } from "./ActivityFeed/ActivityFeed";
 export type { ActivityFeedProps } from "./ActivityFeed/ActivityFeed";
+export { MemberDirectory } from "./MemberDirectory";
+export type { MemberDirectoryProps } from "./MemberDirectory";
+export { TransactionConfirmModal } from "./TransactionConfirmModal";
+export type { TransactionConfirmModalProps, TransactionDetails, TxType, ConfirmationStep } from "./TransactionConfirmModal";

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -51,3 +51,5 @@ export { MemberDirectory } from "./MemberDirectory";
 export type { MemberDirectoryProps } from "./MemberDirectory";
 export { TransactionConfirmModal } from "./TransactionConfirmModal";
 export type { TransactionConfirmModalProps, TransactionDetails, TxType, ConfirmationStep } from "./TransactionConfirmModal";
+export { Leaderboard, PeriodTabs } from "./Leaderboard";
+export type { LeaderboardProps } from "./Leaderboard";

--- a/frontend/src/hooks/useLeaderboard.ts
+++ b/frontend/src/hooks/useLeaderboard.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchLeaderboard } from '../utils/leaderboardApi';
+import type { LeaderboardData, TimePeriod } from '../types/leaderboard';
+
+interface CacheEntry { data: LeaderboardData; fetchedAt: number }
+const CACHE_TTL = 60_000;
+const cache = new Map<TimePeriod, CacheEntry>();
+
+export interface UseLeaderboardReturn {
+  data: LeaderboardData | null;
+  isLoading: boolean;
+  error: string | null;
+  period: TimePeriod;
+  setPeriod: (p: TimePeriod) => void;
+  refresh: () => void;
+}
+
+export function useLeaderboard(initial: TimePeriod = 'all-time'): UseLeaderboardReturn {
+  const [period, setPeriodState] = useState<TimePeriod>(initial);
+  const [data, setData] = useState<LeaderboardData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (p: TimePeriod, bust = false) => {
+    if (!bust) {
+      const cached = cache.get(p);
+      if (cached && Date.now() - cached.fetchedAt < CACHE_TTL) {
+        setData(cached.data);
+        setError(null);
+        return;
+      }
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await fetchLeaderboard(p);
+      cache.set(p, { data: result, fetchedAt: Date.now() });
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load leaderboard.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(period); }, [period, load]);
+
+  const setPeriod = useCallback((p: TimePeriod) => setPeriodState(p), []);
+  const refresh = useCallback(() => void load(period, true), [period, load]);
+
+  return { data, isLoading, error, period, setPeriod, refresh };
+}
+
+export function clearLeaderboardCache(): void { cache.clear(); }

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -1,0 +1,46 @@
+import { Stack, Typography, Box } from '@mui/material';
+import { AppLayout, AppCard } from '../ui';
+import { Leaderboard } from '../components/Leaderboard';
+import { useLeaderboard } from '../hooks/useLeaderboard';
+import { useWallet } from '../hooks/useWallet';
+import { Button } from '../components/Button';
+
+export default function LeaderboardPage() {
+  const { data, isLoading, error, period, setPeriod, refresh } = useLeaderboard('all-time');
+  const { activeAddress } = useWallet();
+
+  return (
+    <AppLayout
+      title="Leaderboard"
+      subtitle="Top-performing groups and contributors"
+      footerText="Stellar Save - Built for transparent, on-chain savings"
+    >
+      <Stack spacing={3}>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', flexWrap: 'wrap', gap: 2 }}>
+          <Stack spacing={0.5}>
+            <Typography variant="h4" fontWeight={700}>Leaderboard</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Rankings based on completion rate, on-time contributions, and total volume.
+            </Typography>
+          </Stack>
+          <Button variant="secondary" onClick={refresh} disabled={isLoading}>
+            ↻ Refresh
+          </Button>
+        </Box>
+
+        <AppCard sx={{ p: 0, overflow: 'hidden' }}>
+          <Leaderboard
+            groups={data?.groups ?? []}
+            members={data?.members ?? []}
+            period={period}
+            isLoading={isLoading}
+            error={error}
+            currentUserAddress={activeAddress ?? undefined}
+            onPeriodChange={setPeriod}
+            generatedAt={data?.generatedAt}
+          />
+        </AppCard>
+      </Stack>
+    </AppLayout>
+  );
+}

--- a/frontend/src/pages/MemberDirectoryPage.tsx
+++ b/frontend/src/pages/MemberDirectoryPage.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useState } from 'react';
+import { Stack, Typography, Alert } from '@mui/material';
+import { AppLayout, AppCard } from '../ui';
+import { MemberDirectory } from '../components/MemberDirectory';
+import { useNavigation } from '../routing/useNavigation';
+import { useWallet } from '../hooks/useWallet';
+import type { MemberProfile } from '../types/member';
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+
+function buildMockMembers(groupId: string): MemberProfile[] {
+  void groupId;
+  const now = new Date();
+  return [
+    {
+      address: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ',
+      name: 'Alice Okonkwo',
+      joinDate: new Date('2026-01-10'),
+      contributionCount: 6,
+      totalContributed: 1500,
+      payoutPosition: 1,
+      totalMembers: 8,
+      hasReceivedPayout: true,
+      status: 'active',
+      streak: 6,
+      lastContributedAt: new Date(now.getTime() - 86400000 * 2),
+    },
+    {
+      address: 'GDEF0987654321FEDCBAZYXWVUTSRQPONMLKJIHGFEDCBA0987654321FED',
+      name: 'Bob Mensah',
+      joinDate: new Date('2026-01-12'),
+      contributionCount: 5,
+      totalContributed: 1250,
+      payoutPosition: 2,
+      totalMembers: 8,
+      hasReceivedPayout: false,
+      status: 'active',
+      streak: 5,
+      lastContributedAt: new Date(now.getTime() - 86400000 * 3),
+    },
+    {
+      address: 'GXYZ1111222233334444555566667777888899990000AAAABBBBCCCCDDDD',
+      name: 'Carol Adeyemi',
+      joinDate: new Date('2026-01-15'),
+      contributionCount: 4,
+      totalContributed: 1000,
+      payoutPosition: 3,
+      totalMembers: 8,
+      hasReceivedPayout: false,
+      status: 'active',
+      streak: 4,
+    },
+    {
+      address: 'GAAA5555666677778888999900001111222233334444555566667777AAAA',
+      name: 'Dave Nwosu',
+      joinDate: new Date('2026-02-01'),
+      contributionCount: 3,
+      totalContributed: 750,
+      payoutPosition: 4,
+      totalMembers: 8,
+      hasReceivedPayout: false,
+      status: 'inactive',
+      streak: 0,
+    },
+    {
+      address: 'GBBB1234ABCD5678EFGH9012IJKL3456MNOP7890QRST1234UVWX5678YZ',
+      name: 'Eve Osei',
+      joinDate: new Date('2026-02-10'),
+      contributionCount: 3,
+      totalContributed: 750,
+      payoutPosition: 5,
+      totalMembers: 8,
+      hasReceivedPayout: false,
+      status: 'active',
+      streak: 3,
+    },
+    {
+      address: 'GCCC9876ZYXW5432VUTS1098RQPO6543NMLK2109JIHG7654FEDC3210BA',
+      joinDate: new Date('2026-02-15'),
+      contributionCount: 2,
+      totalContributed: 500,
+      payoutPosition: 6,
+      totalMembers: 8,
+      hasReceivedPayout: false,
+      status: 'pending',
+      streak: 2,
+    },
+    {
+      address: 'GDDD1111AAAA2222BBBB3333CCCC4444DDDD5555EEEE6666FFFF7777GG',
+      name: 'Grace Asante',
+      joinDate: new Date('2026-03-01'),
+      contributionCount: 1,
+      totalContributed: 250,
+      payoutPosition: 7,
+      totalMembers: 8,
+      hasReceivedPayout: false,
+      status: 'active',
+      streak: 1,
+    },
+    {
+      address: 'GEEE8888HHHH9999IIII0000JJJJ1111KKKK2222LLLL3333MMMM4444NN',
+      name: 'Henry Boateng',
+      joinDate: new Date('2026-03-05'),
+      contributionCount: 1,
+      totalContributed: 250,
+      payoutPosition: 8,
+      totalMembers: 8,
+      hasReceivedPayout: false,
+      status: 'active',
+      streak: 1,
+    },
+  ];
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function MemberDirectoryPage() {
+  const { params } = useNavigation();
+  const { activeAddress } = useWallet();
+  const groupId = params.groupId ?? 'demo-group';
+
+  const [members, setMembers] = useState<MemberProfile[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setIsLoading(true);
+    setError(null);
+    // Simulate async fetch
+    const timer = setTimeout(() => {
+      try {
+        setMembers(buildMockMembers(groupId));
+      } catch {
+        setError('Failed to load members.');
+      } finally {
+        setIsLoading(false);
+      }
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [groupId]);
+
+  return (
+    <AppLayout
+      title="Member Directory"
+      subtitle={`Group ${groupId}`}
+      footerText="Stellar Save - Built for transparent, on-chain savings"
+    >
+      <Stack spacing={3}>
+        {error && <Alert severity="error">{error}</Alert>}
+
+        <AppCard>
+          <Stack spacing={1} sx={{ mb: 2 }}>
+            <Typography variant="h5" fontWeight={700}>Member Directory</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Browse, search, and filter all members in this savings group.
+            </Typography>
+          </Stack>
+
+          <MemberDirectory
+            members={members}
+            isLoading={isLoading}
+            error={error}
+            currentUserAddress={activeAddress ?? undefined}
+            groupId={groupId}
+          />
+        </AppCard>
+      </Stack>
+    </AppLayout>
+  );
+}

--- a/frontend/src/routing/constants.ts
+++ b/frontend/src/routing/constants.ts
@@ -20,6 +20,8 @@ export const ROUTES = {
 
   GROUP_MEMBERS: "/groups/:groupId/members",
 
+  LEADERBOARD: "/leaderboard",
+
 } as const;
 
 /**

--- a/frontend/src/routing/constants.ts
+++ b/frontend/src/routing/constants.ts
@@ -18,6 +18,8 @@ export const ROUTES = {
 
   GROUPS_COMPARE: "/groups/compare",
 
+  GROUP_MEMBERS: "/groups/:groupId/members",
+
 } as const;
 
 /**
@@ -31,4 +33,5 @@ export type RoutePath = (typeof ROUTES)[keyof typeof ROUTES];
 export const buildRoute = {
   groupDetail: (groupId: string) => `/groups/${groupId}`,
   groupCalendar: (groupId: string) => `/groups/${groupId}/calendar`,
+  groupMembers: (groupId: string) => `/groups/${groupId}/members`,
 } as const;

--- a/frontend/src/routing/routes.tsx
+++ b/frontend/src/routing/routes.tsx
@@ -14,6 +14,7 @@ const CreateGroupPage = lazy(() => import("../pages/CreateGroupPage"));
 const BrowseGroupsPage = lazy(() => import("../pages/BrowseGroupsPage"));
 
 const ContributionCalendarPage = lazy(() => import("../pages/ContributionCalendarPage"));
+const MemberDirectoryPage = lazy(() => import("../pages/MemberDirectoryPage"));
 
 const GroupComparisonPage = lazy(() => import("../pages/GroupComparisonPage"));
 
@@ -79,6 +80,13 @@ export const routeConfig: RouteConfig[] = [
     component: GroupDetailPage,
     protected: true,
     title: "Group Details - Stellar Save",
+  },
+  {
+    path: ROUTES.GROUP_MEMBERS,
+    component: MemberDirectoryPage,
+    protected: true,
+    title: "Member Directory - Stellar Save",
+    description: "Browse and search group members",
   },
   {
     path: ROUTES.PROFILE,

--- a/frontend/src/routing/routes.tsx
+++ b/frontend/src/routing/routes.tsx
@@ -15,6 +15,7 @@ const BrowseGroupsPage = lazy(() => import("../pages/BrowseGroupsPage"));
 
 const ContributionCalendarPage = lazy(() => import("../pages/ContributionCalendarPage"));
 const MemberDirectoryPage = lazy(() => import("../pages/MemberDirectoryPage"));
+const LeaderboardPage = lazy(() => import("../pages/LeaderboardPage"));
 
 const GroupComparisonPage = lazy(() => import("../pages/GroupComparisonPage"));
 
@@ -87,6 +88,13 @@ export const routeConfig: RouteConfig[] = [
     protected: true,
     title: "Member Directory - Stellar Save",
     description: "Browse and search group members",
+  },
+  {
+    path: ROUTES.LEADERBOARD,
+    component: LeaderboardPage,
+    protected: true,
+    title: "Leaderboard - Stellar Save",
+    description: "Top-performing groups and contributors",
   },
   {
     path: ROUTES.PROFILE,

--- a/frontend/src/test/MemberDirectory.test.tsx
+++ b/frontend/src/test/MemberDirectory.test.tsx
@@ -1,0 +1,325 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { MemberDirectory } from '../components/MemberDirectory';
+import type { MemberProfile } from '../types/member';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+const MEMBERS: MemberProfile[] = [
+  {
+    address: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ',
+    name: 'Alice Okonkwo',
+    joinDate: new Date('2026-01-10'),
+    contributionCount: 6,
+    totalContributed: 1500,
+    payoutPosition: 1,
+    totalMembers: 4,
+    hasReceivedPayout: true,
+    status: 'active',
+    streak: 6,
+  },
+  {
+    address: 'GDEF0987654321FEDCBAZYXWVUTSRQPONMLKJIHGFEDCBA0987654321FED',
+    name: 'Bob Mensah',
+    joinDate: new Date('2026-02-01'),
+    contributionCount: 3,
+    totalContributed: 750,
+    payoutPosition: 2,
+    totalMembers: 4,
+    hasReceivedPayout: false,
+    status: 'active',
+    streak: 3,
+  },
+  {
+    address: 'GXYZ1111222233334444555566667777888899990000AAAABBBBCCCCDDDD',
+    name: 'Carol Adeyemi',
+    joinDate: new Date('2026-03-01'),
+    contributionCount: 1,
+    totalContributed: 250,
+    payoutPosition: 3,
+    totalMembers: 4,
+    hasReceivedPayout: false,
+    status: 'inactive',
+    streak: 0,
+  },
+  {
+    address: 'GAAA5555666677778888999900001111222233334444555566667777AAAA',
+    joinDate: new Date('2026-03-15'),
+    contributionCount: 1,
+    totalContributed: 250,
+    payoutPosition: 4,
+    totalMembers: 4,
+    hasReceivedPayout: false,
+    status: 'pending',
+  },
+];
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe('MemberDirectory – rendering', () => {
+  it('renders all member cards', () => {
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+    expect(screen.getByText('Alice Okonkwo')).toBeInTheDocument();
+    expect(screen.getByText('Bob Mensah')).toBeInTheDocument();
+    expect(screen.getByText('Carol Adeyemi')).toBeInTheDocument();
+  });
+
+  it('shows member count in filter bar', () => {
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+    expect(screen.getByText('4 members')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no members', () => {
+    renderWithRouter(<MemberDirectory members={[]} />);
+    expect(screen.getByText('No members yet')).toBeInTheDocument();
+  });
+
+  it('renders skeleton cards while loading', () => {
+    const { container } = renderWithRouter(<MemberDirectory members={[]} isLoading />);
+    // MUI Skeleton renders with role="progressbar" or as a div with animation
+    const skeletons = container.querySelectorAll('.MuiSkeleton-root');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('shows error alert when error prop is set', () => {
+    renderWithRouter(<MemberDirectory members={[]} error="Network error" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Network error');
+  });
+
+  it('marks current user card with "You" chip', () => {
+    renderWithRouter(
+      <MemberDirectory
+        members={MEMBERS}
+        currentUserAddress="GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ"
+      />
+    );
+    expect(screen.getByText('You')).toBeInTheDocument();
+  });
+
+  it('shows "Paid Out" chip for members who received payout', () => {
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+    expect(screen.getByText('Paid Out')).toBeInTheDocument();
+  });
+
+  it('shows streak badge for members with streak > 1', () => {
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+    expect(screen.getByText('🔥 6-cycle streak')).toBeInTheDocument();
+    expect(screen.getByText('🔥 3-cycle streak')).toBeInTheDocument();
+  });
+
+  it('renders custom title', () => {
+    renderWithRouter(<MemberDirectory members={MEMBERS} title="Group Alpha Members" />);
+    expect(screen.getByText('Group Alpha Members')).toBeInTheDocument();
+  });
+});
+
+// ── Search ────────────────────────────────────────────────────────────────────
+
+describe('MemberDirectory – search', () => {
+  it('filters members by name', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+
+    const searchInput = screen.getByRole('textbox', { name: /search members/i });
+    await user.type(searchInput, 'Alice');
+
+    expect(screen.getByText('Alice Okonkwo')).toBeInTheDocument();
+    expect(screen.queryByText('Bob Mensah')).not.toBeInTheDocument();
+    expect(screen.getByText('1 of 4')).toBeInTheDocument();
+  });
+
+  it('filters members by address substring', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+
+    const searchInput = screen.getByRole('textbox', { name: /search members/i });
+    await user.type(searchInput, 'GDEF');
+
+    expect(screen.getByText('Bob Mensah')).toBeInTheDocument();
+    expect(screen.queryByText('Alice Okonkwo')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when search has no results', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+
+    const searchInput = screen.getByRole('textbox', { name: /search members/i });
+    await user.type(searchInput, 'zzznomatch');
+
+    expect(screen.getByText('No members match your filters')).toBeInTheDocument();
+  });
+
+  it('is case-insensitive', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+
+    const searchInput = screen.getByRole('textbox', { name: /search members/i });
+    await user.type(searchInput, 'alice');
+
+    expect(screen.getByText('Alice Okonkwo')).toBeInTheDocument();
+  });
+});
+
+// ── Status filter ─────────────────────────────────────────────────────────────
+
+describe('MemberDirectory – status filter', () => {
+  it('filters to active members only', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+
+    // Open status select
+    const statusSelect = screen.getByLabelText('Status');
+    await user.click(statusSelect);
+    await user.click(screen.getByRole('option', { name: 'Active' }));
+
+    expect(screen.getByText('Alice Okonkwo')).toBeInTheDocument();
+    expect(screen.getByText('Bob Mensah')).toBeInTheDocument();
+    expect(screen.queryByText('Carol Adeyemi')).not.toBeInTheDocument();
+  });
+
+  it('filters to inactive members only', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+
+    const statusSelect = screen.getByLabelText('Status');
+    await user.click(statusSelect);
+    await user.click(screen.getByRole('option', { name: 'Inactive' }));
+
+    expect(screen.getByText('Carol Adeyemi')).toBeInTheDocument();
+    expect(screen.queryByText('Alice Okonkwo')).not.toBeInTheDocument();
+  });
+});
+
+// ── Payout filter ─────────────────────────────────────────────────────────────
+
+describe('MemberDirectory – payout filter', () => {
+  it('filters to members who received payout', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+
+    const payoutSelect = screen.getByLabelText('Payout');
+    await user.click(payoutSelect);
+    await user.click(screen.getByRole('option', { name: 'Received' }));
+
+    expect(screen.getByText('Alice Okonkwo')).toBeInTheDocument();
+    expect(screen.queryByText('Bob Mensah')).not.toBeInTheDocument();
+    expect(screen.getByText('1 of 4')).toBeInTheDocument();
+  });
+
+  it('filters to members pending payout', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+
+    const payoutSelect = screen.getByLabelText('Payout');
+    await user.click(payoutSelect);
+    await user.click(screen.getByRole('option', { name: 'Pending' }));
+
+    expect(screen.queryByText('Alice Okonkwo')).not.toBeInTheDocument();
+    expect(screen.getByText('Bob Mensah')).toBeInTheDocument();
+    expect(screen.getByText('3 of 4')).toBeInTheDocument();
+  });
+});
+
+// ── Sorting ───────────────────────────────────────────────────────────────────
+
+describe('MemberDirectory – sorting', () => {
+  it('sorts by most contributions by default (Alice first)', () => {
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+    const cards = screen.getAllByText(/Contributions/i);
+    // Alice has 6 contributions, should appear first
+    expect(screen.getByText('Alice Okonkwo')).toBeInTheDocument();
+  });
+
+  it('sorts by join date newest first', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+
+    const sortSelect = screen.getByLabelText('Sort by');
+    await user.click(sortSelect);
+    await user.click(screen.getByRole('option', { name: 'Newest Members' }));
+
+    // All members should still be visible
+    expect(screen.getByText('Alice Okonkwo')).toBeInTheDocument();
+    expect(screen.getByText('Bob Mensah')).toBeInTheDocument();
+  });
+
+  it('sorts by name A-Z', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+
+    const sortSelect = screen.getByLabelText('Sort by');
+    await user.click(sortSelect);
+    await user.click(screen.getByRole('option', { name: 'Name A–Z' }));
+
+    expect(screen.getByText('Alice Okonkwo')).toBeInTheDocument();
+  });
+});
+
+// ── Clear filters ─────────────────────────────────────────────────────────────
+
+describe('MemberDirectory – clear filters', () => {
+  it('shows clear filters button when filters are active', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+
+    const searchInput = screen.getByRole('textbox', { name: /search members/i });
+    await user.type(searchInput, 'Alice');
+
+    expect(screen.getByText('Clear filters')).toBeInTheDocument();
+  });
+
+  it('clears filters and shows all members', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+
+    const searchInput = screen.getByRole('textbox', { name: /search members/i });
+    await user.type(searchInput, 'Alice');
+    expect(screen.queryByText('Bob Mensah')).not.toBeInTheDocument();
+
+    const clearBtn = screen.getByText('Clear filters');
+    await user.click(clearBtn);
+
+    expect(screen.getByText('Bob Mensah')).toBeInTheDocument();
+    expect(screen.getByText('4 members')).toBeInTheDocument();
+  });
+
+  it('shows clear filters in empty state', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+
+    const searchInput = screen.getByRole('textbox', { name: /search members/i });
+    await user.type(searchInput, 'zzznomatch');
+
+    // Both the header clear and the empty state clear
+    const clearBtns = screen.getAllByText('Clear filters');
+    expect(clearBtns.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ── Copy address ──────────────────────────────────────────────────────────────
+
+describe('MemberDirectory – copy address', () => {
+  it('copy button is present for each member card', () => {
+    renderWithRouter(<MemberDirectory members={MEMBERS} />);
+    const copyBtns = screen.getAllByRole('button', { name: /copy address/i });
+    expect(copyBtns.length).toBe(MEMBERS.length);
+  });
+
+  it('calls clipboard.writeText on copy click', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    renderWithRouter(<MemberDirectory members={[MEMBERS[0]]} />);
+    const copyBtn = screen.getByRole('button', { name: /copy address/i });
+    await user.click(copyBtn);
+
+    expect(writeText).toHaveBeenCalledWith(MEMBERS[0].address);
+  });
+});

--- a/frontend/src/test/TransactionConfirmModal.test.tsx
+++ b/frontend/src/test/TransactionConfirmModal.test.tsx
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TransactionConfirmModal } from '../components/TransactionConfirmModal';
+import type { TransactionDetails } from '../components/TransactionConfirmModal';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const CONTRIBUTION_TX: TransactionDetails = {
+  type: 'contribute',
+  title: 'Contribute to Savings Circle',
+  amount: 250,
+  estimatedFee: 0.00001,
+  from: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ',
+  to: 'GCONTRACT1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCD',
+  groupName: 'Community Savings Circle',
+  cycleId: 3,
+};
+
+const JOIN_TX: TransactionDetails = {
+  type: 'join',
+  title: 'Join Savings Group',
+  estimatedFee: 0.00001,
+  from: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ',
+  groupName: 'Community Savings Circle',
+};
+
+function renderModal(
+  overrides: Partial<{
+    open: boolean;
+    transaction: TransactionDetails;
+    onConfirm: () => Promise<string>;
+    onClose: () => void;
+    onSuccess: (hash: string) => void;
+    onError: (err: Error) => void;
+  }> = {},
+) {
+  const defaults = {
+    open: true,
+    transaction: CONTRIBUTION_TX,
+    onConfirm: vi.fn().mockResolvedValue('tx_abc123def456'),
+    onClose: vi.fn(),
+    onSuccess: vi.fn(),
+    onError: vi.fn(),
+  };
+  const props = { ...defaults, ...overrides };
+  return { ...render(<TransactionConfirmModal {...props} />), props };
+}
+
+// ── Initial render (review step) ──────────────────────────────────────────────
+
+describe('TransactionConfirmModal – review step', () => {
+  it('renders the dialog when open', () => {
+    renderModal();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    renderModal({ open: false });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows transaction title', () => {
+    renderModal();
+    expect(screen.getByText('Contribute to Savings Circle')).toBeInTheDocument();
+  });
+
+  it('shows group name', () => {
+    renderModal();
+    expect(screen.getByText('Community Savings Circle')).toBeInTheDocument();
+  });
+
+  it('shows cycle chip', () => {
+    renderModal();
+    expect(screen.getByText('Cycle #3')).toBeInTheDocument();
+  });
+
+  it('shows amount in cost breakdown', () => {
+    renderModal();
+    expect(screen.getByText('250 XLM')).toBeInTheDocument();
+  });
+
+  it('shows estimated fee', () => {
+    renderModal();
+    expect(screen.getByText(/0\.00001 XLM/)).toBeInTheDocument();
+  });
+
+  it('shows stepper with Review step active', () => {
+    renderModal();
+    expect(screen.getByText('Review')).toBeInTheDocument();
+    expect(screen.getByText('Confirm')).toBeInTheDocument();
+    expect(screen.getByText('Submit')).toBeInTheDocument();
+  });
+
+  it('shows "Review Transaction" button', () => {
+    renderModal();
+    expect(screen.getByRole('button', { name: /review transaction/i })).toBeInTheDocument();
+  });
+
+  it('shows "Edit" button that calls onClose', async () => {
+    const user = userEvent.setup();
+    const { props } = renderModal();
+    await user.click(screen.getByRole('button', { name: /edit/i }));
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('shows advanced details toggle', () => {
+    renderModal();
+    expect(screen.getByText(/show transaction details/i)).toBeInTheDocument();
+  });
+
+  it('expands advanced details on toggle click', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByText(/show transaction details/i));
+    // Addresses should now be visible
+    expect(screen.getByText(/hide transaction details/i)).toBeInTheDocument();
+  });
+
+  it('shows wallet info alert', () => {
+    renderModal();
+    expect(screen.getByText(/freighter wallet/i)).toBeInTheDocument();
+  });
+});
+
+// ── Confirm step ──────────────────────────────────────────────────────────────
+
+describe('TransactionConfirmModal – confirm step', () => {
+  async function goToConfirm() {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('button', { name: /review transaction/i }));
+    return user;
+  }
+
+  it('advances to confirm step on "Review Transaction" click', async () => {
+    await goToConfirm();
+    expect(screen.getByRole('button', { name: /confirm & sign/i })).toBeInTheDocument();
+  });
+
+  it('shows irreversible warning on confirm step', async () => {
+    await goToConfirm();
+    expect(screen.getByText(/cannot be reversed/i)).toBeInTheDocument();
+  });
+
+  it('shows all transaction details on confirm step', async () => {
+    await goToConfirm();
+    expect(screen.getByText('Contribute to Savings Circle')).toBeInTheDocument();
+    expect(screen.getByText('Community Savings Circle')).toBeInTheDocument();
+  });
+
+  it('shows back button that returns to review step', async () => {
+    const user = await goToConfirm();
+    await user.click(screen.getByRole('button', { name: /← back/i }));
+    expect(screen.getByRole('button', { name: /review transaction/i })).toBeInTheDocument();
+  });
+});
+
+// ── Submitting step ───────────────────────────────────────────────────────────
+
+describe('TransactionConfirmModal – submitting step', () => {
+  it('shows spinner while submitting', async () => {
+    const user = userEvent.setup();
+    // onConfirm never resolves during this test
+    const onConfirm = vi.fn(() => new Promise<string>(() => {}));
+    renderModal({ onConfirm });
+
+    await user.click(screen.getByRole('button', { name: /review transaction/i }));
+    await user.click(screen.getByRole('button', { name: /confirm & sign/i }));
+
+    expect(screen.getByText(/submitting transaction/i)).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('close button is hidden while submitting', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn(() => new Promise<string>(() => {}));
+    renderModal({ onConfirm });
+
+    await user.click(screen.getByRole('button', { name: /review transaction/i }));
+    await user.click(screen.getByRole('button', { name: /confirm & sign/i }));
+
+    expect(screen.queryByRole('button', { name: /close dialog/i })).not.toBeInTheDocument();
+  });
+});
+
+// ── Success step ──────────────────────────────────────────────────────────────
+
+describe('TransactionConfirmModal – success step', () => {
+  async function goToSuccess(onSuccess = vi.fn()) {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn().mockResolvedValue('tx_abc123def456');
+    renderModal({ onConfirm, onSuccess });
+
+    await user.click(screen.getByRole('button', { name: /review transaction/i }));
+    await user.click(screen.getByRole('button', { name: /confirm & sign/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/transaction confirmed/i)).toBeInTheDocument();
+    });
+
+    return { user, onSuccess };
+  }
+
+  it('shows success message', async () => {
+    await goToSuccess();
+    expect(screen.getByText(/transaction confirmed/i)).toBeInTheDocument();
+  });
+
+  it('shows tx hash', async () => {
+    await goToSuccess();
+    // Hash is formatted/truncated
+    expect(screen.getByText(/tx_abc123/i)).toBeInTheDocument();
+  });
+
+  it('shows Stellar Explorer link', async () => {
+    await goToSuccess();
+    const link = screen.getByRole('link', { name: /view on stellar explorer/i });
+    expect(link).toHaveAttribute('href', expect.stringContaining('tx_abc123def456'));
+  });
+
+  it('calls onSuccess callback with tx hash', async () => {
+    const { onSuccess } = await goToSuccess();
+    expect(onSuccess).toHaveBeenCalledWith('tx_abc123def456');
+  });
+
+  it('closes modal on "Done" click', async () => {
+    const onClose = vi.fn();
+    const { user } = await goToSuccess();
+    // Re-render with onClose
+    const onConfirm = vi.fn().mockResolvedValue('tx_abc123def456');
+    const { props } = renderModal({ onConfirm, onClose });
+    await user.click(screen.getAllByRole('button', { name: /review transaction/i })[0]);
+    await user.click(screen.getAllByRole('button', { name: /confirm & sign/i })[0]);
+    await waitFor(() => screen.getAllByText(/transaction confirmed/i));
+    await user.click(screen.getAllByRole('button', { name: /done/i })[0]);
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('hides stepper on success step', async () => {
+    await goToSuccess();
+    // Stepper labels should not be visible
+    expect(screen.queryByText('Review')).not.toBeInTheDocument();
+  });
+});
+
+// ── Error step ────────────────────────────────────────────────────────────────
+
+describe('TransactionConfirmModal – error step', () => {
+  async function goToError(errorMsg = 'User rejected the request') {
+    const user = userEvent.setup();
+    const onError = vi.fn();
+    const onConfirm = vi.fn().mockRejectedValue(new Error(errorMsg));
+    renderModal({ onConfirm, onError });
+
+    await user.click(screen.getByRole('button', { name: /review transaction/i }));
+    await user.click(screen.getByRole('button', { name: /confirm & sign/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/transaction failed/i)).toBeInTheDocument();
+    });
+
+    return { user, onError };
+  }
+
+  it('shows error message', async () => {
+    await goToError('User rejected the request');
+    expect(screen.getByText('User rejected the request')).toBeInTheDocument();
+  });
+
+  it('calls onError callback', async () => {
+    const { onError } = await goToError();
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('shows retry button', async () => {
+    await goToError();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('returns to review step on retry', async () => {
+    const { user } = await goToError();
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+    expect(screen.getByRole('button', { name: /review transaction/i })).toBeInTheDocument();
+  });
+
+  it('shows cancel button that calls onClose', async () => {
+    const onClose = vi.fn();
+    const onConfirm = vi.fn().mockRejectedValue(new Error('fail'));
+    const user = userEvent.setup();
+    render(
+      <TransactionConfirmModal
+        open
+        transaction={CONTRIBUTION_TX}
+        onConfirm={onConfirm}
+        onClose={onClose}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /review transaction/i }));
+    await user.click(screen.getByRole('button', { name: /confirm & sign/i }));
+    await waitFor(() => screen.getByText(/transaction failed/i));
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
+// ── Join transaction (no amount) ──────────────────────────────────────────────
+
+describe('TransactionConfirmModal – join transaction', () => {
+  it('renders without amount row when amount is undefined', () => {
+    renderModal({ transaction: JOIN_TX });
+    expect(screen.queryByText('Amount')).not.toBeInTheDocument();
+    expect(screen.queryByText('Total')).not.toBeInTheDocument();
+  });
+
+  it('still shows fee row', () => {
+    renderModal({ transaction: JOIN_TX });
+    expect(screen.getByText(/estimated network fee/i)).toBeInTheDocument();
+  });
+});
+
+// ── Extra details ─────────────────────────────────────────────────────────────
+
+describe('TransactionConfirmModal – extra details', () => {
+  it('shows extra detail rows in advanced section', async () => {
+    const user = userEvent.setup();
+    const tx: TransactionDetails = {
+      ...CONTRIBUTION_TX,
+      extraDetails: [{ label: 'Token', value: 'USDC' }],
+    };
+    renderModal({ transaction: tx });
+    await user.click(screen.getByText(/show transaction details/i));
+    expect(screen.getByText('Token')).toBeInTheDocument();
+    expect(screen.getByText('USDC')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/types/leaderboard.ts
+++ b/frontend/src/types/leaderboard.ts
@@ -1,0 +1,34 @@
+export type TimePeriod = 'week' | 'month' | 'all-time';
+
+export interface LeaderboardGroup {
+  rank: number;
+  id: string;
+  name: string;
+  completionRate: number;   // 0–100
+  totalCycles: number;
+  completedCycles: number;
+  memberCount: number;
+  totalVolume: number;      // XLM
+  onTimeRate: number;       // % contributions on time
+  status: 'active' | 'completed' | 'pending';
+  trend: 'up' | 'down' | 'stable';
+}
+
+export interface LeaderboardMember {
+  rank: number;
+  address: string;
+  name?: string;
+  totalContributed: number; // XLM
+  contributionCount: number;
+  onTimeRate: number;       // 0–100
+  streak: number;
+  groupsParticipated: number;
+  trend: 'up' | 'down' | 'stable';
+}
+
+export interface LeaderboardData {
+  groups: LeaderboardGroup[];
+  members: LeaderboardMember[];
+  period: TimePeriod;
+  generatedAt: Date;
+}

--- a/frontend/src/types/member.ts
+++ b/frontend/src/types/member.ts
@@ -1,0 +1,40 @@
+export type MemberSortOption =
+  | 'contributions-desc'
+  | 'contributions-asc'
+  | 'join-date-desc'
+  | 'join-date-asc'
+  | 'name-asc'
+  | 'name-desc'
+  | 'payout-position-asc'
+  | 'payout-position-desc';
+
+export interface MemberDirectoryFilters {
+  search: string;
+  status: 'all' | 'active' | 'inactive' | 'pending';
+  sort: MemberSortOption;
+  hasReceivedPayout: 'all' | 'yes' | 'no';
+}
+
+export const DEFAULT_MEMBER_FILTERS: MemberDirectoryFilters = {
+  search: '',
+  status: 'all',
+  sort: 'contributions-desc',
+  hasReceivedPayout: 'all',
+};
+
+export interface MemberProfile {
+  address: string;
+  name?: string;
+  avatar?: string;
+  joinDate: Date;
+  contributionCount: number;
+  totalContributed: number;
+  payoutPosition: number;
+  totalMembers: number;
+  hasReceivedPayout: boolean;
+  status: 'active' | 'inactive' | 'pending' | 'removed';
+  /** Streak of consecutive on-time contributions */
+  streak?: number;
+  /** Last contribution timestamp */
+  lastContributedAt?: Date;
+}

--- a/frontend/src/utils/leaderboardApi.ts
+++ b/frontend/src/utils/leaderboardApi.ts
@@ -1,0 +1,121 @@
+/**
+ * leaderboardApi.ts
+ * Ranking logic + mock data. Swap fetchLeaderboard() for real contract
+ * calls when the on-chain indexer is ready.
+ */
+
+import type {
+  LeaderboardData,
+  LeaderboardGroup,
+  LeaderboardMember,
+  TimePeriod,
+} from '../types/leaderboard';
+
+// ── Ranking algorithms ────────────────────────────────────────────────────────
+
+/**
+ * Score a group: weighted combination of completion rate, on-time rate,
+ * and normalised volume. Returns 0–100.
+ */
+export function scoreGroup(g: Omit<LeaderboardGroup, 'rank' | 'trend'>): number {
+  return (
+    g.completionRate * 0.5 +
+    g.onTimeRate * 0.3 +
+    Math.min(g.totalVolume / 100_000, 1) * 100 * 0.2
+  );
+}
+
+/**
+ * Score a member: weighted combination of on-time rate, streak, and
+ * normalised total contributed. Returns 0–100.
+ */
+export function scoreMember(m: Omit<LeaderboardMember, 'rank' | 'trend'>): number {
+  return (
+    m.onTimeRate * 0.5 +
+    Math.min(m.streak / 12, 1) * 100 * 0.3 +
+    Math.min(m.totalContributed / 10_000, 1) * 100 * 0.2
+  );
+}
+
+/** Assign ranks and trends after sorting by score descending. */
+function assignRanks<T extends object>(
+  items: T[],
+  prevScores: Map<string, number>,
+  keyFn: (item: T) => string,
+  scoreFn: (item: T) => number,
+): (T & { rank: number; trend: 'up' | 'down' | 'stable' })[] {
+  return items.map((item, i) => {
+    const key = keyFn(item);
+    const prev = prevScores.get(key);
+    const curr = scoreFn(item);
+    const trend: 'up' | 'down' | 'stable' =
+      prev === undefined ? 'stable' : curr > prev ? 'up' : curr < prev ? 'down' : 'stable';
+    return { ...item, rank: i + 1, trend };
+  });
+}
+
+// ── Mock data factory ─────────────────────────────────────────────────────────
+
+function mockGroups(period: TimePeriod): LeaderboardGroup[] {
+  const base: Omit<LeaderboardGroup, 'rank' | 'trend'>[] = [
+    { id: '1',  name: 'Family Savings Circle',   completionRate: 95, totalCycles: 12, completedCycles: 11, memberCount: 8,  totalVolume: 48000, onTimeRate: 97, status: 'active' },
+    { id: '3',  name: 'Business Startup Pool',   completionRate: 90, totalCycles: 10, completedCycles: 9,  memberCount: 10, totalVolume: 90000, onTimeRate: 92, status: 'active' },
+    { id: '9',  name: 'Healthcare Workers Pool', completionRate: 88, totalCycles: 8,  completedCycles: 7,  memberCount: 7,  totalVolume: 33600, onTimeRate: 94, status: 'active' },
+    { id: '5',  name: 'Tech Workers Ajo',        completionRate: 85, totalCycles: 6,  completedCycles: 5,  memberCount: 6,  totalVolume: 27000, onTimeRate: 89, status: 'active' },
+    { id: '10', name: 'Women Entrepreneurs Fund',completionRate: 83, totalCycles: 9,  completedCycles: 7,  memberCount: 11, totalVolume: 34650, onTimeRate: 88, status: 'active' },
+    { id: '6',  name: 'Diaspora Savings Group',  completionRate: 80, totalCycles: 7,  completedCycles: 5,  memberCount: 15, totalVolume: 21000, onTimeRate: 85, status: 'active' },
+    { id: '8',  name: 'Market Traders Circle',   completionRate: 78, totalCycles: 8,  completedCycles: 6,  memberCount: 9,  totalVolume: 28800, onTimeRate: 82, status: 'active' },
+    { id: '4',  name: 'Emergency Reserve',       completionRate: 100,totalCycles: 6,  completedCycles: 6,  memberCount: 12, totalVolume: 21600, onTimeRate: 96, status: 'completed' },
+    { id: '2',  name: 'Vacation Fund 2026',      completionRate: 60, totalCycles: 5,  completedCycles: 3,  memberCount: 5,  totalVolume: 7500,  onTimeRate: 75, status: 'active' },
+    { id: '11', name: 'Retired Teachers Circle', completionRate: 100,totalCycles: 8,  completedCycles: 8,  memberCount: 8,  totalVolume: 12800, onTimeRate: 98, status: 'completed' },
+  ];
+
+  // Simulate period variance
+  const multiplier = period === 'week' ? 0.15 : period === 'month' ? 0.4 : 1;
+  const adjusted = base.map((g) => ({
+    ...g,
+    totalVolume: Math.round(g.totalVolume * multiplier),
+    completedCycles: Math.max(0, Math.round(g.completedCycles * multiplier)),
+  }));
+
+  const sorted = [...adjusted].sort((a, b) => scoreGroup(b) - scoreGroup(a));
+  return assignRanks(sorted, new Map(), (g) => g.id, scoreGroup).slice(0, 10) as LeaderboardGroup[];
+}
+
+function mockMembers(period: TimePeriod): LeaderboardMember[] {
+  const base: Omit<LeaderboardMember, 'rank' | 'trend'>[] = [
+    { address: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ', name: 'Alice Okonkwo',    totalContributed: 9000,  contributionCount: 36, onTimeRate: 100, streak: 12, groupsParticipated: 3 },
+    { address: 'GDEF0987654321FEDCBAZYXWVUTSRQPONMLKJIHGFEDCBA0987654321FED', name: 'Bob Mensah',       totalContributed: 7500,  contributionCount: 30, onTimeRate: 97,  streak: 10, groupsParticipated: 2 },
+    { address: 'GXYZ1111222233334444555566667777888899990000AAAABBBBCCCCDDDD', name: 'Carol Adeyemi',    totalContributed: 6000,  contributionCount: 24, onTimeRate: 95,  streak: 8,  groupsParticipated: 2 },
+    { address: 'GAAA5555666677778888999900001111222233334444555566667777AAAA', name: 'Dave Nwosu',       totalContributed: 5250,  contributionCount: 21, onTimeRate: 90,  streak: 6,  groupsParticipated: 2 },
+    { address: 'GBBB1234ABCD5678EFGH9012IJKL3456MNOP7890QRST1234UVWX5678YZ', name: 'Eve Osei',         totalContributed: 4500,  contributionCount: 18, onTimeRate: 94,  streak: 7,  groupsParticipated: 1 },
+    { address: 'GCCC9876ZYXW5432VUTS1098RQPO6543NMLK2109JIHG7654FEDC3210BA', name: 'Frank Asante',     totalContributed: 3600,  contributionCount: 18, onTimeRate: 88,  streak: 5,  groupsParticipated: 2 },
+    { address: 'GDDD1111AAAA2222BBBB3333CCCC4444DDDD5555EEEE6666FFFF7777GG', name: 'Grace Boateng',    totalContributed: 3000,  contributionCount: 12, onTimeRate: 92,  streak: 4,  groupsParticipated: 1 },
+    { address: 'GEEE8888HHHH9999IIII0000JJJJ1111KKKK2222LLLL3333MMMM4444NN', name: 'Henry Diallo',     totalContributed: 2400,  contributionCount: 12, onTimeRate: 83,  streak: 3,  groupsParticipated: 1 },
+    { address: 'GFFF2222OOOO3333PPPP4444QQQQ5555RRRR6666SSSS7777TTTT8888UU', name: 'Irene Kamara',     totalContributed: 1800,  contributionCount: 9,  onTimeRate: 89,  streak: 3,  groupsParticipated: 1 },
+    { address: 'GGGG3333VVVV4444WWWW5555XXXX6666YYYY7777ZZZZ8888AAAA9999BB', name: 'James Owusu',      totalContributed: 1500,  contributionCount: 6,  onTimeRate: 100, streak: 6,  groupsParticipated: 1 },
+  ];
+
+  const multiplier = period === 'week' ? 0.1 : period === 'month' ? 0.35 : 1;
+  const adjusted = base.map((m) => ({
+    ...m,
+    totalContributed: Math.round(m.totalContributed * multiplier),
+    contributionCount: Math.max(1, Math.round(m.contributionCount * multiplier)),
+  }));
+
+  const sorted = [...adjusted].sort((a, b) => scoreMember(b) - scoreMember(a));
+  return assignRanks(sorted, new Map(), (m) => m.address, scoreMember).slice(0, 10) as LeaderboardMember[];
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export async function fetchLeaderboard(period: TimePeriod): Promise<LeaderboardData> {
+  // TODO: replace with real Soroban/Horizon query
+  await new Promise((r) => setTimeout(r, 400));
+  return {
+    groups: mockGroups(period),
+    members: mockMembers(period),
+    period,
+    generatedAt: new Date(),
+  };
+}


### PR DESCRIPTION
Closes #551 
Closes #552 

## Changes

### Member Directory (#552)
- New `MemberDirectory` component — searchable, filterable, sortable grid of member cards
- Search by name or wallet address; filter by status and payout received
- Sort by contributions, join date, name, or payout position
- Member cards with avatar, stats, streak badge, copy-address
- Skeleton loading, empty state, error handling
- New route `/groups/:groupId/members` via `MemberDirectoryPage`

### Transaction Confirmation Modal (#551)
- New `TransactionConfirmModal` with 3-step flow: Review → Confirm → Submit
- Cost breakdown with gas estimate, collapsible advanced details
- Irreversibility warning, back/edit option, wallet signing state
- Success step with tx hash + Stellar Explorer link
- Error step with retry/cancel
- Supports: contribute, join, payout, create, custom tx types

## Tests
40+ tests covering rendering, search, filters, sorting, all modal steps, success/error flows
