### PR TITLE
feat: add group chat/comments system (#540)

### DIFF
--- a/frontend/src/components/GroupComments.css
+++ b/frontend/src/components/GroupComments.css
@@ -1,0 +1,156 @@
+.group-comments {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.group-comments-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--color-text, #1a1a1a);
+}
+
+.group-comments-count {
+  font-weight: 400;
+  color: var(--color-text-muted, #888);
+}
+
+.group-comments-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.group-comments-empty {
+  color: var(--color-text-muted, #888);
+  font-style: italic;
+  padding: 1rem 0;
+}
+
+.group-comment {
+  background: var(--color-surface-alt, #f9f9f9);
+  border: 1px solid var(--color-border, #e5e5e5);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.group-comment-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.group-comment-author {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--color-text, #1a1a1a);
+}
+
+.group-comment-creator-badge {
+  font-size: 0.8rem;
+}
+
+.group-comment-time {
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #888);
+}
+
+.group-comment-content {
+  font-size: 0.95rem;
+  color: var(--color-text-secondary, #444);
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.group-comment-content code {
+  background: var(--color-code-bg, #f0f0f0);
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+  font-family: monospace;
+  font-size: 0.9em;
+}
+
+.group-comment-delete {
+  align-self: flex-end;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-danger, #e53e3e);
+  font-size: 0.8rem;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+}
+
+.group-comment-delete:hover {
+  background: var(--color-danger-bg, #fff5f5);
+}
+
+.group-comments-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.group-comments-input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid var(--color-border, #ddd);
+  border-radius: 8px;
+  font-size: 0.95rem;
+  resize: vertical;
+  font-family: inherit;
+  background: var(--color-surface, #fff);
+  color: var(--color-text, #1a1a1a);
+  box-sizing: border-box;
+}
+
+.group-comments-input:focus {
+  outline: 2px solid var(--color-primary, #6366f1);
+  outline-offset: 1px;
+}
+
+.group-comments-form-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.group-comments-char-count {
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #888);
+}
+
+.group-comments-submit {
+  background: var(--color-primary, #6366f1);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.5rem 1.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.group-comments-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.group-comments-submit:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.group-comments-login-prompt {
+  color: var(--color-text-muted, #888);
+  font-style: italic;
+  font-size: 0.9rem;
+  margin: 0;
+}

--- a/frontend/src/components/GroupComments.tsx
+++ b/frontend/src/components/GroupComments.tsx
@@ -1,0 +1,165 @@
+import { useState } from "react";
+import "./GroupComments.css";
+
+export interface Comment {
+  id: string;
+  authorAddress: string;
+  authorName?: string;
+  content: string;
+  timestamp: Date;
+  deleted?: boolean;
+}
+
+export interface GroupCommentsProps {
+  groupId: string;
+  comments: Comment[];
+  currentUserAddress?: string;
+  creatorAddress?: string;
+  onPost: (content: string) => void;
+  onDelete?: (commentId: string) => void;
+}
+
+/** Minimal markdown: bold, italic, inline code, line breaks */
+function renderMarkdown(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*([^*]+)\*/g, "<em>$1</em>")
+    .replace(/\n/g, "<br />");
+}
+
+function formatTimestamp(date: Date): string {
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function shortAddress(address: string): string {
+  if (address.length <= 12) return address;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+export function GroupComments({
+  comments,
+  currentUserAddress,
+  creatorAddress,
+  onPost,
+  onDelete,
+}: GroupCommentsProps) {
+  const [draft, setDraft] = useState("");
+  const MAX_LENGTH = 500;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = draft.trim();
+    if (!trimmed || !currentUserAddress) return;
+    onPost(trimmed);
+    setDraft("");
+  };
+
+  const canModerate = (comment: Comment) =>
+    onDelete &&
+    (currentUserAddress === creatorAddress ||
+      currentUserAddress === comment.authorAddress);
+
+  const visibleComments = comments.filter((c) => !c.deleted);
+
+  return (
+    <section className="group-comments" aria-label="Group comments">
+      <h3 className="group-comments-title">
+        Comments{" "}
+        <span className="group-comments-count">({visibleComments.length})</span>
+      </h3>
+
+      <ul className="group-comments-list" aria-label="Comment list">
+        {visibleComments.length === 0 && (
+          <li className="group-comments-empty">
+            No comments yet. Be the first to say something!
+          </li>
+        )}
+        {visibleComments.map((comment) => (
+          <li
+            key={comment.id}
+            className="group-comment"
+            data-testid={`comment-${comment.id}`}
+          >
+            <div className="group-comment-meta">
+              <span className="group-comment-author">
+                {comment.authorName ?? shortAddress(comment.authorAddress)}
+                {comment.authorAddress === creatorAddress && (
+                  <span className="group-comment-creator-badge" title="Group creator">
+                    {" "}
+                    👑
+                  </span>
+                )}
+              </span>
+              <time
+                className="group-comment-time"
+                dateTime={comment.timestamp.toISOString()}
+              >
+                {formatTimestamp(comment.timestamp)}
+              </time>
+            </div>
+            <div
+              className="group-comment-content"
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{
+                __html: renderMarkdown(comment.content),
+              }}
+            />
+            {canModerate(comment) && (
+              <button
+                className="group-comment-delete"
+                onClick={() => onDelete!(comment.id)}
+                aria-label={`Delete comment by ${comment.authorName ?? shortAddress(comment.authorAddress)}`}
+              >
+                Delete
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {currentUserAddress ? (
+        <form
+          className="group-comments-form"
+          onSubmit={handleSubmit}
+          aria-label="Post a comment"
+        >
+          <textarea
+            className="group-comments-input"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="Write a comment… (supports **bold**, *italic*, `code`)"
+            maxLength={MAX_LENGTH}
+            rows={3}
+            aria-label="Comment text"
+          />
+          <div className="group-comments-form-footer">
+            <span className="group-comments-char-count">
+              {draft.length}/{MAX_LENGTH}
+            </span>
+            <button
+              type="submit"
+              className="group-comments-submit"
+              disabled={!draft.trim()}
+              aria-label="Post comment"
+            >
+              Post
+            </button>
+          </div>
+        </form>
+      ) : (
+        <p className="group-comments-login-prompt">
+          Connect your wallet to leave a comment.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/test/GroupComments.test.tsx
+++ b/frontend/src/test/GroupComments.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { GroupComments } from "../components/GroupComments";
+import type { Comment } from "../components/GroupComments";
+
+const CREATOR = "GCREATOR1234";
+const USER = "GUSER5678";
+
+const baseComments: Comment[] = [
+  {
+    id: "c1",
+    authorAddress: CREATOR,
+    authorName: "Alice",
+    content: "Hello everyone!",
+    timestamp: new Date("2024-01-15T10:00:00Z"),
+  },
+  {
+    id: "c2",
+    authorAddress: USER,
+    authorName: "Bob",
+    content: "**Bold** and *italic* and `code`",
+    timestamp: new Date("2024-01-15T11:00:00Z"),
+  },
+];
+
+function renderComments(
+  overrides: Partial<Parameters<typeof GroupComments>[0]> = {},
+) {
+  const onPost = vi.fn();
+  const onDelete = vi.fn();
+  render(
+    <GroupComments
+      groupId="g1"
+      comments={baseComments}
+      currentUserAddress={USER}
+      creatorAddress={CREATOR}
+      onPost={onPost}
+      onDelete={onDelete}
+      {...overrides}
+    />,
+  );
+  return { onPost, onDelete };
+}
+
+describe("GroupComments", () => {
+  it("renders the comments section", () => {
+    renderComments();
+    expect(screen.getByRole("region", { name: "Group comments" })).toBeInTheDocument();
+  });
+
+  it("displays comment count", () => {
+    renderComments();
+    expect(screen.getByText("(2)")).toBeInTheDocument();
+  });
+
+  it("renders each comment", () => {
+    renderComments();
+    expect(screen.getByTestId("comment-c1")).toBeInTheDocument();
+    expect(screen.getByTestId("comment-c2")).toBeInTheDocument();
+  });
+
+  it("shows author names", () => {
+    renderComments();
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+  });
+
+  it("shows creator badge for creator's comment", () => {
+    renderComments();
+    expect(screen.getByTitle("Group creator")).toBeInTheDocument();
+  });
+
+  it("renders bold markdown", () => {
+    renderComments();
+    const comment = screen.getByTestId("comment-c2");
+    expect(comment.querySelector("strong")).toBeInTheDocument();
+    expect(comment.querySelector("strong")?.textContent).toBe("Bold");
+  });
+
+  it("renders italic markdown", () => {
+    renderComments();
+    const comment = screen.getByTestId("comment-c2");
+    expect(comment.querySelector("em")?.textContent).toBe("italic");
+  });
+
+  it("renders inline code markdown", () => {
+    renderComments();
+    const comment = screen.getByTestId("comment-c2");
+    expect(comment.querySelector("code")?.textContent).toBe("code");
+  });
+
+  it("shows empty state when no comments", () => {
+    renderComments({ comments: [] });
+    expect(screen.getByText(/No comments yet/)).toBeInTheDocument();
+  });
+
+  it("shows comment form when user is connected", () => {
+    renderComments();
+    expect(screen.getByLabelText("Comment text")).toBeInTheDocument();
+    expect(screen.getByLabelText("Post comment")).toBeInTheDocument();
+  });
+
+  it("shows login prompt when no user connected", () => {
+    renderComments({ currentUserAddress: undefined });
+    expect(screen.getByText(/Connect your wallet/)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Comment text")).not.toBeInTheDocument();
+  });
+
+  it("Post button is disabled when textarea is empty", () => {
+    renderComments();
+    expect(screen.getByLabelText("Post comment")).toBeDisabled();
+  });
+
+  it("Post button enables when text is entered", () => {
+    renderComments();
+    fireEvent.change(screen.getByLabelText("Comment text"), {
+      target: { value: "Hello!" },
+    });
+    expect(screen.getByLabelText("Post comment")).not.toBeDisabled();
+  });
+
+  it("calls onPost with trimmed content and clears input", () => {
+    const { onPost } = renderComments();
+    const textarea = screen.getByLabelText("Comment text");
+    fireEvent.change(textarea, { target: { value: "  My comment  " } });
+    fireEvent.click(screen.getByLabelText("Post comment"));
+    expect(onPost).toHaveBeenCalledWith("My comment");
+    expect((textarea as HTMLTextAreaElement).value).toBe("");
+  });
+
+  it("does not call onPost when content is only whitespace", () => {
+    const { onPost } = renderComments();
+    fireEvent.change(screen.getByLabelText("Comment text"), {
+      target: { value: "   " },
+    });
+    fireEvent.click(screen.getByLabelText("Post comment"));
+    expect(onPost).not.toHaveBeenCalled();
+  });
+
+  it("shows delete button for own comment", () => {
+    renderComments();
+    // Bob (USER) can delete their own comment c2
+    expect(screen.getByLabelText(/Delete comment by Bob/)).toBeInTheDocument();
+  });
+
+  it("creator can delete any comment", () => {
+    // Render as creator
+    renderComments({ currentUserAddress: CREATOR });
+    // Creator can delete both comments
+    expect(screen.getAllByRole("button", { name: /Delete comment/ })).toHaveLength(2);
+  });
+
+  it("calls onDelete with comment id", () => {
+    const { onDelete } = renderComments();
+    fireEvent.click(screen.getByLabelText(/Delete comment by Bob/));
+    expect(onDelete).toHaveBeenCalledWith("c2");
+  });
+
+  it("does not render deleted comments", () => {
+    const comments: Comment[] = [
+      { ...baseComments[0], deleted: true },
+      baseComments[1],
+    ];
+    renderComments({ comments });
+    expect(screen.queryByTestId("comment-c1")).not.toBeInTheDocument();
+    expect(screen.getByTestId("comment-c2")).toBeInTheDocument();
+  });
+
+  it("shows short address when no authorName", () => {
+    const comments: Comment[] = [
+      {
+        id: "c3",
+        authorAddress: "GABCDEFGHIJKLMNOP",
+        content: "Anonymous",
+        timestamp: new Date(),
+      },
+    ];
+    renderComments({ comments });
+    expect(screen.getByText("GABCDE…MNOP")).toBeInTheDocument();
+  });
+
+  it("shows character count", () => {
+    renderComments();
+    fireEvent.change(screen.getByLabelText("Comment text"), {
+      target: { value: "Hello" },
+    });
+    expect(screen.getByText("5/500")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
pr close #540 

- Add GroupComments component with comment posting and display
- Show author address/name with timestamp on each comment
- Support basic markdown: **bold**, *italic*, `code` (XSS-safe)
- Show creator badge (👑) on group creator's comments
- Add moderation: creator can delete any comment, members delete own
- Support soft-delete via deleted flag
- Show login prompt when wallet not connected
- Add 21 tests covering all functionality