### PR TITLE
feat: PWA support, group templates gallery, analytics dashboard

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#6366f1" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Stellar Save</title>
   </head>
   <body>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,31 @@
+{
+  "name": "Stellar Save",
+  "short_name": "StellarSave",
+  "description": "Decentralized rotational savings on Stellar",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#6366f1",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "/vite.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ],
+  "categories": ["finance"],
+  "shortcuts": [
+    {
+      "name": "Dashboard",
+      "url": "/dashboard",
+      "description": "View your savings overview"
+    },
+    {
+      "name": "Browse Groups",
+      "url": "/groups/browse",
+      "description": "Discover savings groups"
+    }
+  ]
+}

--- a/frontend/public/offline.html
+++ b/frontend/public/offline.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Offline — Stellar Save</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body {
+        font-family: system-ui, sans-serif;
+        background: #0f172a;
+        color: #e2e8f0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-height: 100dvh;
+        gap: 1.5rem;
+        padding: 1.5rem;
+        text-align: center;
+      }
+      svg { width: 64px; height: 64px; color: #6366f1; }
+      h1 { font-size: 1.5rem; font-weight: 700; }
+      p { color: #94a3b8; max-width: 360px; line-height: 1.6; }
+      button {
+        background: #6366f1;
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        padding: 0.75rem 1.5rem;
+        font-size: 1rem;
+        cursor: pointer;
+      }
+      button:hover { background: #4f46e5; }
+    </style>
+  </head>
+  <body>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+        d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z" />
+    </svg>
+    <h1>You're offline</h1>
+    <p>No internet connection. Check your network and try again.</p>
+    <button onclick="location.reload()">Try again</button>
+  </body>
+</html>

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -2,18 +2,87 @@
  * sw.js — Stellar Save Service Worker
  *
  * Handles:
- *  1. Background push events (Web Push API)
- *  2. Scheduled contribution reminder alarms via postMessage
- *  3. Notification click → focus/open app and navigate to group detail
+ *  1. PWA caching (cache-first for static assets, network-first for API)
+ *  2. Offline fallback page
+ *  3. Background push events (Web Push API)
+ *  4. Scheduled contribution reminder alarms via postMessage
+ *  5. Notification click → focus/open app and navigate to group detail
  */
 
+const CACHE_NAME = 'stellar-save-v1';
+const STATIC_ASSETS = ['/', '/offline.html', '/manifest.json', '/vite.svg'];
 const APP_ORIGIN = self.location.origin;
 
+// ─── Install: pre-cache static shell ─────────────────────────────────────────
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+// ─── Activate: purge old caches, claim clients ───────────────────────────────
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+// ─── Fetch: caching strategies ───────────────────────────────────────────────
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Only handle same-origin GET requests
+  if (request.method !== 'GET' || !url.origin.startsWith(APP_ORIGIN.split('//')[0])) return;
+
+  // API calls: network-first, no cache fallback (let app handle errors)
+  if (url.pathname.startsWith('/api/')) {
+    event.respondWith(
+      fetch(request).catch(() => new Response(JSON.stringify({ error: 'offline' }), {
+        headers: { 'Content-Type': 'application/json' },
+      }))
+    );
+    return;
+  }
+
+  // Navigation requests: network-first, fall back to cached shell or offline page
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then((res) => {
+          const clone = res.clone();
+          caches.open(CACHE_NAME).then((c) => c.put(request, clone));
+          return res;
+        })
+        .catch(async () => {
+          const cached = await caches.match(request);
+          return cached ?? (await caches.match('/offline.html'));
+        })
+    );
+    return;
+  }
+
+  // Static assets: cache-first
+  event.respondWith(
+    caches.match(request).then(
+      (cached) =>
+        cached ??
+        fetch(request).then((res) => {
+          const clone = res.clone();
+          caches.open(CACHE_NAME).then((c) => c.put(request, clone));
+          return res;
+        })
+    )
+  );
+});
+
 // ─── Push Event ──────────────────────────────────────────────────────────────
-// Fired when the browser receives a push message from the server.
-// For client-side-only scheduling we skip the push server and use
-// the message channel below instead, but this handler is required
-// for full Web Push API compatibility.
 self.addEventListener('push', (event) => {
   if (!event.data) return;
 
@@ -39,28 +108,27 @@ self.addEventListener('push', (event) => {
 });
 
 // ─── Message Channel (client-side scheduling) ────────────────────────────────
-// The app posts a message to the SW to trigger a notification immediately
-// (after a setTimeout in the client fires). This lets us show notifications
-// even when the tab is in the background.
 self.addEventListener('message', (event) => {
-  if (!event.data || event.data.type !== 'SHOW_NOTIFICATION') return;
+  if (!event.data) return;
 
-  const { title, body, groupId } = event.data;
+  if (event.data.type === 'SHOW_NOTIFICATION') {
+    const { title, body, groupId } = event.data;
+    self.registration.showNotification(title ?? 'Contribution Reminder', {
+      body: body ?? 'Your deadline is approaching',
+      icon: '/vite.svg',
+      badge: '/vite.svg',
+      tag: groupId ? `contribution-${groupId}` : 'contribution-reminder',
+      data: { groupId, url: groupId ? `/groups/${groupId}` : '/dashboard' },
+      requireInteraction: false,
+    });
+  }
 
-  self.registration.showNotification(title ?? 'Contribution Reminder', {
-    body: body ?? 'Your deadline is approaching',
-    icon: '/vite.svg',
-    badge: '/vite.svg',
-    tag: groupId ? `contribution-${groupId}` : 'contribution-reminder',
-    data: { groupId, url: groupId ? `/groups/${groupId}` : '/dashboard' },
-    requireInteraction: false,
-  });
+  if (event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
 });
 
 // ─── Notification Click ───────────────────────────────────────────────────────
-// 1. Close the notification.
-// 2. Find an existing app window and focus it, or open a new one.
-// 3. Navigate to the group detail page.
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
 
@@ -71,23 +139,15 @@ self.addEventListener('notificationclick', (event) => {
     self.clients
       .matchAll({ type: 'window', includeUncontrolled: true })
       .then((clientList) => {
-        // Try to find an existing window on the same origin
         for (const client of clientList) {
           if (client.url.startsWith(APP_ORIGIN) && 'focus' in client) {
-            // Tell the existing window to navigate
             client.postMessage({ type: 'NAVIGATE', url: targetUrl });
             return client.focus();
           }
         }
-        // No existing window — open a new one
         if (self.clients.openWindow) {
           return self.clients.openWindow(fullUrl);
         }
       })
   );
-});
-
-// ─── Activate: claim clients immediately ─────────────────────────────────────
-self.addEventListener('activate', (event) => {
-  event.waitUntil(self.clients.claim());
 });

--- a/frontend/src/components/templates/TemplateCard.tsx
+++ b/frontend/src/components/templates/TemplateCard.tsx
@@ -1,0 +1,77 @@
+import { Box, Button, Chip, Typography } from '@mui/material';
+import type { GroupTemplate } from '../../types/template';
+
+interface TemplateCardProps {
+  template: GroupTemplate;
+  onUse: (template: GroupTemplate) => void;
+  onPreview: (template: GroupTemplate) => void;
+}
+
+const categoryColor: Record<GroupTemplate['category'], 'success' | 'warning' | 'error'> = {
+  short: 'success',
+  medium: 'warning',
+  long: 'error',
+};
+
+export function TemplateCard({ template, onUse, onPreview }: TemplateCardProps) {
+  return (
+    <Box
+      sx={{
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 2,
+        p: 2.5,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1.5,
+        bgcolor: 'background.paper',
+        transition: 'border-color 0.2s',
+        '&:hover': { borderColor: 'primary.main' },
+      }}
+    >
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+        <Typography variant="subtitle1" fontWeight="bold">
+          {template.name}
+        </Typography>
+        <Chip
+          label={template.category}
+          color={categoryColor[template.category]}
+          size="small"
+          sx={{ textTransform: 'capitalize' }}
+        />
+      </Box>
+
+      <Typography variant="body2" color="text.secondary">
+        {template.description}
+      </Typography>
+
+      <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1 }}>
+        <Stat label="Cycle" value={`${template.cycleDuration}d`} />
+        <Stat label="Members" value={`up to ${template.maxMembers}`} />
+        <Stat label="Duration" value={template.totalDuration} />
+      </Box>
+
+      <Box sx={{ display: 'flex', gap: 1, mt: 'auto', pt: 0.5 }}>
+        <Button size="small" variant="outlined" onClick={() => onPreview(template)} sx={{ flex: 1 }}>
+          Preview
+        </Button>
+        <Button size="small" variant="contained" onClick={() => onUse(template)} sx={{ flex: 1 }}>
+          Use Template
+        </Button>
+      </Box>
+    </Box>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body2" fontWeight="medium">
+        {value}
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend/src/components/templates/TemplatePreviewModal.tsx
+++ b/frontend/src/components/templates/TemplatePreviewModal.tsx
@@ -1,0 +1,45 @@
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Divider, Typography } from '@mui/material';
+import type { GroupTemplate } from '../../types/template';
+
+interface TemplatePreviewModalProps {
+  template: GroupTemplate | null;
+  onClose: () => void;
+  onUse: (template: GroupTemplate) => void;
+}
+
+export function TemplatePreviewModal({ template, onClose, onUse }: TemplatePreviewModalProps) {
+  if (!template) return null;
+
+  const rows: [string, string][] = [
+    ['Cycle duration', `${template.cycleDuration} days`],
+    ['Max members', String(template.maxMembers)],
+    ['Total duration', template.totalDuration],
+    ['Category', template.category],
+  ];
+
+  return (
+    <Dialog open={!!template} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{template.name}</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          {template.description}
+        </Typography>
+        <Divider sx={{ mb: 2 }} />
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+          {rows.map(([label, value]) => (
+            <Box key={label} sx={{ display: 'flex', justifyContent: 'space-between' }}>
+              <Typography variant="body2" color="text.secondary">{label}</Typography>
+              <Typography variant="body2" fontWeight="medium" sx={{ textTransform: 'capitalize' }}>{value}</Typography>
+            </Box>
+          ))}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+        <Button variant="contained" onClick={() => { onUse(template); onClose(); }}>
+          Use Template
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/hooks/useAnalytics.ts
+++ b/frontend/src/hooks/useAnalytics.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import type { AnalyticsData } from '../types/analytics';
+
+const MOCK_DATA: Omit<AnalyticsData, 'isLoading' | 'error'> = {
+  stats: {
+    totalContributed: 8_750,
+    totalReceived: 5_000,
+    roi: -42.9,
+    onTimePercent: 91.7,
+    activeGroups: 3,
+    completedGroups: 1,
+  },
+  history: [
+    { month: 'Nov 2025', contributed: 750, received: 0 },
+    { month: 'Dec 2025', contributed: 750, received: 0 },
+    { month: 'Jan 2026', contributed: 1_250, received: 0 },
+    { month: 'Feb 2026', contributed: 1_250, received: 0 },
+    { month: 'Mar 2026', contributed: 1_750, received: 2_400 },
+    { month: 'Apr 2026', contributed: 1_750, received: 2_600 },
+    { month: 'May 2026', contributed: 1_250, received: 0 },
+  ],
+  memberComparison: [
+    { address: 'GSELF...', label: 'You', onTimePercent: 91.7, totalContributed: 8_750 },
+    { address: 'GABC1...', label: 'GABC1...', onTimePercent: 100, totalContributed: 9_500 },
+    { address: 'GDEF2...', label: 'GDEF2...', onTimePercent: 83.3, totalContributed: 7_200 },
+    { address: 'GHIJ3...', label: 'GHIJ3...', onTimePercent: 75.0, totalContributed: 6_000 },
+  ],
+};
+
+export function useAnalytics(): AnalyticsData {
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const t = setTimeout(() => setIsLoading(false), 1000);
+    return () => clearTimeout(t);
+  }, []);
+
+  return { ...MOCK_DATA, isLoading, error: null };
+}

--- a/frontend/src/hooks/useInstallPrompt.ts
+++ b/frontend/src/hooks/useInstallPrompt.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+export interface UseInstallPromptReturn {
+  canInstall: boolean;
+  install: () => Promise<'accepted' | 'dismissed' | null>;
+  dismiss: () => void;
+}
+
+export function useInstallPrompt(): UseInstallPromptReturn {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
+
+  const install = async (): Promise<'accepted' | 'dismissed' | null> => {
+    if (!deferredPrompt) return null;
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    setDeferredPrompt(null);
+    return outcome;
+  };
+
+  const dismiss = () => setDeferredPrompt(null);
+
+  return { canInstall: deferredPrompt !== null, install, dismiss };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,15 @@ import { ToastProvider } from './components/Toast';
 import { AppRouter } from './routing/AppRouter';
 import './index.css';
 
+// Register service worker for PWA support
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(() => {
+      // SW registration failure is non-fatal
+    });
+  });
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AppThemeProvider>

--- a/frontend/src/pages/AnalyticsDashboardPage.tsx
+++ b/frontend/src/pages/AnalyticsDashboardPage.tsx
@@ -1,0 +1,162 @@
+import { Box, Card, CardContent, LinearProgress, Skeleton, Typography } from '@mui/material';
+import { AppLayout } from '../ui';
+import { useAnalytics } from '../hooks/useAnalytics';
+import type { ContributionDataPoint, MemberComparisonItem } from '../types/analytics';
+
+// ─── Stat card ────────────────────────────────────────────────────────────────
+function StatCard({ label, value, sub, isLoading }: { label: string; value: string; sub?: string; isLoading: boolean }) {
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Typography variant="caption" color="text.secondary">{label}</Typography>
+        {isLoading ? (
+          <Skeleton width="60%" height={32} />
+        ) : (
+          <Typography variant="h5" fontWeight="bold">{value}</Typography>
+        )}
+        {sub && <Typography variant="caption" color="text.secondary">{sub}</Typography>}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Bar chart (SVG) ──────────────────────────────────────────────────────────
+function BarChart({ data }: { data: ContributionDataPoint[] }) {
+  const maxVal = Math.max(...data.flatMap((d) => [d.contributed, d.received]), 1);
+  const W = 480;
+  const H = 160;
+  const barW = Math.floor((W / data.length) * 0.35);
+  const gap = Math.floor((W / data.length) * 0.1);
+  const slotW = W / data.length;
+
+  return (
+    <Box sx={{ overflowX: 'auto' }}>
+      <svg viewBox={`0 0 ${W} ${H + 24}`} style={{ width: '100%', minWidth: 320 }} aria-label="Contribution history bar chart">
+        {data.map((d, i) => {
+          const x = i * slotW + gap;
+          const hC = (d.contributed / maxVal) * H;
+          const hR = (d.received / maxVal) * H;
+          return (
+            <g key={d.month}>
+              {/* contributed bar */}
+              <rect x={x} y={H - hC} width={barW} height={hC} fill="#6366f1" rx={2}>
+                <title>{`${d.month} contributed: ${d.contributed} XLM`}</title>
+              </rect>
+              {/* received bar */}
+              <rect x={x + barW + 2} y={H - hR} width={barW} height={hR} fill="#22c55e" rx={2}>
+                <title>{`${d.month} received: ${d.received} XLM`}</title>
+              </rect>
+              {/* label */}
+              <text x={x + barW} y={H + 16} textAnchor="middle" fontSize={9} fill="#94a3b8">
+                {d.month.split(' ')[0]}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      <Box sx={{ display: 'flex', gap: 2, mt: 0.5 }}>
+        <LegendDot color="#6366f1" label="Contributed" />
+        <LegendDot color="#22c55e" label="Received" />
+      </Box>
+    </Box>
+  );
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <Box sx={{ width: 10, height: 10, borderRadius: '50%', bgcolor: color }} />
+      <Typography variant="caption" color="text.secondary">{label}</Typography>
+    </Box>
+  );
+}
+
+// ─── Member comparison ────────────────────────────────────────────────────────
+function MemberComparisonRow({ item }: { item: MemberComparisonItem }) {
+  const isYou = item.label === 'You';
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+      <Typography
+        variant="body2"
+        sx={{ width: 80, flexShrink: 0, fontWeight: isYou ? 'bold' : 'normal', color: isYou ? 'primary.main' : 'text.primary' }}
+      >
+        {item.label}
+      </Typography>
+      <Box sx={{ flex: 1 }}>
+        <LinearProgress
+          variant="determinate"
+          value={item.onTimePercent}
+          sx={{ height: 8, borderRadius: 4, bgcolor: 'action.hover', '& .MuiLinearProgress-bar': { bgcolor: isYou ? 'primary.main' : 'text.disabled' } }}
+        />
+      </Box>
+      <Typography variant="body2" sx={{ width: 44, textAlign: 'right', flexShrink: 0 }}>
+        {item.onTimePercent.toFixed(0)}%
+      </Typography>
+    </Box>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+export default function AnalyticsDashboardPage() {
+  const { stats, history, memberComparison, isLoading } = useAnalytics();
+
+  const roiColor = stats.roi >= 0 ? 'success.main' : 'error.main';
+
+  return (
+    <AppLayout title="Analytics" subtitle="Your contribution patterns and statistics">
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+
+        {/* Stats row */}
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr 1fr', md: 'repeat(4, 1fr)' }, gap: 2 }}>
+          <StatCard label="Total Contributed" value={`${stats.totalContributed.toLocaleString()} XLM`} isLoading={isLoading} />
+          <StatCard label="Total Received" value={`${stats.totalReceived.toLocaleString()} XLM`} isLoading={isLoading} />
+          <StatCard
+            label="ROI"
+            value={`${stats.roi >= 0 ? '+' : ''}${stats.roi.toFixed(1)}%`}
+            sub="vs. contributed"
+            isLoading={isLoading}
+          />
+          <StatCard label="On-Time Rate" value={`${stats.onTimePercent.toFixed(1)}%`} sub={`${stats.activeGroups} active groups`} isLoading={isLoading} />
+        </Box>
+
+        {/* ROI colour hint */}
+        {!isLoading && (
+          <Typography variant="body2" color={roiColor}>
+            {stats.roi >= 0
+              ? `You've received ${stats.roi.toFixed(1)}% more than you've contributed so far.`
+              : `You've contributed ${Math.abs(stats.roi).toFixed(1)}% more than you've received — payouts are still coming.`}
+          </Typography>
+        )}
+
+        {/* Contribution history chart */}
+        <Card variant="outlined">
+          <CardContent>
+            <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 2 }}>
+              Contribution History
+            </Typography>
+            {isLoading ? <Skeleton variant="rectangular" height={160} /> : <BarChart data={history} />}
+          </CardContent>
+        </Card>
+
+        {/* Member comparison */}
+        <Card variant="outlined">
+          <CardContent>
+            <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 2 }}>
+              On-Time Rate vs. Group Members
+            </Typography>
+            {isLoading ? (
+              [1, 2, 3, 4].map((i) => <Skeleton key={i} height={28} sx={{ mb: 1 }} />)
+            ) : (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+                {memberComparison.map((m) => (
+                  <MemberComparisonRow key={m.address} item={m} />
+                ))}
+              </Box>
+            )}
+          </CardContent>
+        </Card>
+
+      </Box>
+    </AppLayout>
+  );
+}

--- a/frontend/src/pages/TemplateGalleryPage.tsx
+++ b/frontend/src/pages/TemplateGalleryPage.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Box, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+import { AppLayout } from '../ui';
+import { TemplateCard } from '../components/templates/TemplateCard';
+import { TemplatePreviewModal } from '../components/templates/TemplatePreviewModal';
+import { GROUP_TEMPLATES } from '../types/template';
+import type { GroupTemplate } from '../types/template';
+import { ROUTES } from '../routing/constants';
+
+type CategoryFilter = 'all' | GroupTemplate['category'];
+
+export default function TemplateGalleryPage() {
+  const navigate = useNavigate();
+  const [preview, setPreview] = useState<GroupTemplate | null>(null);
+  const [filter, setFilter] = useState<CategoryFilter>('all');
+
+  const filtered = filter === 'all'
+    ? GROUP_TEMPLATES
+    : GROUP_TEMPLATES.filter((t) => t.category === filter);
+
+  const handleUse = (template: GroupTemplate) => {
+    navigate(ROUTES.GROUP_CREATE, { state: { templateId: template.id } });
+  };
+
+  return (
+    <AppLayout
+      title="Group Templates"
+      subtitle="Pick a template to quickly start a savings group"
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        <ToggleButtonGroup
+          value={filter}
+          exclusive
+          onChange={(_, v) => v && setFilter(v)}
+          size="small"
+          aria-label="Filter templates by duration"
+        >
+          {(['all', 'short', 'medium', 'long'] as const).map((cat) => (
+            <ToggleButton key={cat} value={cat} sx={{ textTransform: 'capitalize' }}>
+              {cat}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+
+        {filtered.length === 0 ? (
+          <Typography color="text.secondary">No templates match this filter.</Typography>
+        ) : (
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(3, 1fr)' },
+              gap: 2,
+            }}
+          >
+            {filtered.map((t) => (
+              <TemplateCard
+                key={t.id}
+                template={t}
+                onUse={handleUse}
+                onPreview={setPreview}
+              />
+            ))}
+          </Box>
+        )}
+      </Box>
+
+      <TemplatePreviewModal
+        template={preview}
+        onClose={() => setPreview(null)}
+        onUse={handleUse}
+      />
+    </AppLayout>
+  );
+}

--- a/frontend/src/routing/constants.ts
+++ b/frontend/src/routing/constants.ts
@@ -21,7 +21,8 @@ export const ROUTES = {
   GROUP_MEMBERS: "/groups/:groupId/members",
 
   LEADERBOARD: "/leaderboard",
-
+  TEMPLATES: "/templates",
+  ANALYTICS: "/analytics",
 } as const;
 
 /**

--- a/frontend/src/routing/routes.tsx
+++ b/frontend/src/routing/routes.tsx
@@ -21,6 +21,8 @@ const GroupComparisonPage = lazy(() => import("../pages/GroupComparisonPage"));
 
 const NotFoundPage = lazy(() => import("../pages/NotFoundPage"));
 const ErrorPage = lazy(() => import("../pages/ErrorPage"));
+const TemplateGalleryPage = lazy(() => import("../pages/TemplateGalleryPage"));
+const AnalyticsDashboardPage = lazy(() => import("../pages/AnalyticsDashboardPage"));
 /**
  * Centralized route configuration.
  * All application routes are defined here with their properties.
@@ -119,6 +121,20 @@ export const routeConfig: RouteConfig[] = [
     component: ErrorPage,
     protected: false,
     title: "Error - Stellar Save",
+  },
+  {
+    path: ROUTES.TEMPLATES,
+    component: TemplateGalleryPage,
+    protected: true,
+    title: "Group Templates - Stellar Save",
+    description: "Browse and use group templates",
+  },
+  {
+    path: ROUTES.ANALYTICS,
+    component: AnalyticsDashboardPage,
+    protected: true,
+    title: "Analytics - Stellar Save",
+    description: "Your contribution analytics and statistics",
   },
   {
     path: ROUTES.LEADERBOARD,

--- a/frontend/src/test/Analytics.test.tsx
+++ b/frontend/src/test/Analytics.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../ui', () => ({
+  AppLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../hooks/useAnalytics', () => ({
+  useAnalytics: () => ({
+    isLoading: false,
+    error: null,
+    stats: {
+      totalContributed: 8750,
+      totalReceived: 5000,
+      roi: -42.9,
+      onTimePercent: 91.7,
+      activeGroups: 3,
+      completedGroups: 1,
+    },
+    history: [
+      { month: 'Jan 2026', contributed: 1250, received: 0 },
+      { month: 'Feb 2026', contributed: 1250, received: 2400 },
+    ],
+    memberComparison: [
+      { address: 'GSELF...', label: 'You', onTimePercent: 91.7, totalContributed: 8750 },
+      { address: 'GABC1...', label: 'GABC1...', onTimePercent: 100, totalContributed: 9500 },
+    ],
+  }),
+}));
+
+import AnalyticsDashboardPage from '../pages/AnalyticsDashboardPage';
+
+describe('AnalyticsDashboardPage', () => {
+  function renderPage() {
+    return render(
+      <MemoryRouter>
+        <AnalyticsDashboardPage />
+      </MemoryRouter>
+    );
+  }
+
+  it('renders stat labels', () => {
+    renderPage();
+    expect(screen.getByText('Total Contributed')).toBeInTheDocument();
+    expect(screen.getByText('Total Received')).toBeInTheDocument();
+    expect(screen.getByText('ROI')).toBeInTheDocument();
+    expect(screen.getByText('On-Time Rate')).toBeInTheDocument();
+  });
+
+  it('renders stat values', () => {
+    renderPage();
+    expect(screen.getByText('8,750 XLM')).toBeInTheDocument();
+    expect(screen.getByText('5,000 XLM')).toBeInTheDocument();
+    expect(screen.getByText('-42.9%')).toBeInTheDocument();
+    expect(screen.getByText('91.7%')).toBeInTheDocument();
+  });
+
+  it('renders chart section heading', () => {
+    renderPage();
+    expect(screen.getByText('Contribution History')).toBeInTheDocument();
+  });
+
+  it('renders member comparison heading', () => {
+    renderPage();
+    expect(screen.getByText('On-Time Rate vs. Group Members')).toBeInTheDocument();
+  });
+
+  it('renders bar chart SVG', () => {
+    const { container } = renderPage();
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders "You" in member comparison', () => {
+    renderPage();
+    expect(screen.getByText('You')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/TemplateGallery.test.tsx
+++ b/frontend/src/test/TemplateGallery.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { TemplateCard } from '../components/templates/TemplateCard';
+import { GROUP_TEMPLATES } from '../types/template';
+import type { GroupTemplate } from '../types/template';
+
+const template: GroupTemplate = GROUP_TEMPLATES[0]; // Weekly Saver
+
+function renderCard(overrides?: Partial<{ onUse: (t: GroupTemplate) => void; onPreview: (t: GroupTemplate) => void }>) {
+  const onUse = overrides?.onUse ?? vi.fn();
+  const onPreview = overrides?.onPreview ?? vi.fn();
+  return { onUse, onPreview, ...render(<TemplateCard template={template} onUse={onUse} onPreview={onPreview} />) };
+}
+
+describe('TemplateCard', () => {
+  it('renders template name', () => {
+    renderCard();
+    expect(screen.getByText('Weekly Saver')).toBeInTheDocument();
+  });
+
+  it('renders cycle duration', () => {
+    renderCard();
+    expect(screen.getByText('7d')).toBeInTheDocument();
+  });
+
+  it('renders max members', () => {
+    renderCard();
+    expect(screen.getByText('up to 10')).toBeInTheDocument();
+  });
+
+  it('renders total duration', () => {
+    renderCard();
+    expect(screen.getByText('~10 weeks')).toBeInTheDocument();
+  });
+
+  it('calls onPreview when Preview is clicked', () => {
+    const { onPreview } = renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /preview/i }));
+    expect(onPreview).toHaveBeenCalledWith(template);
+  });
+
+  it('calls onUse when Use Template is clicked', () => {
+    const { onUse } = renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /use template/i }));
+    expect(onUse).toHaveBeenCalledWith(template);
+  });
+});
+
+describe('GROUP_TEMPLATES', () => {
+  it('has 5 templates', () => {
+    expect(GROUP_TEMPLATES).toHaveLength(5);
+  });
+
+  it('all templates have required fields', () => {
+    for (const t of GROUP_TEMPLATES) {
+      expect(t.id).toBeGreaterThan(0);
+      expect(t.name).toBeTruthy();
+      expect(t.cycleDuration).toBeGreaterThan(0);
+      expect(t.maxMembers).toBeGreaterThan(0);
+      expect(['short', 'medium', 'long']).toContain(t.category);
+    }
+  });
+
+  it('template ids are unique', () => {
+    const ids = GROUP_TEMPLATES.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+// ─── TemplateGalleryPage smoke test ──────────────────────────────────────────
+import TemplateGalleryPage from '../pages/TemplateGalleryPage';
+
+// Minimal AppLayout mock
+vi.mock('../ui', () => ({
+  AppLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe('TemplateGalleryPage', () => {
+  function renderPage() {
+    return render(
+      <MemoryRouter>
+        <TemplateGalleryPage />
+      </MemoryRouter>
+    );
+  }
+
+  it('renders all 5 templates by default', () => {
+    renderPage();
+    expect(screen.getAllByRole('button', { name: /use template/i })).toHaveLength(5);
+  });
+
+  it('filters to short templates', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /^short$/i }));
+    // Weekly Saver + Biweekly Saver = 2 short templates
+    expect(screen.getAllByRole('button', { name: /use template/i })).toHaveLength(2);
+  });
+
+  it('filters to long templates', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /^long$/i }));
+    expect(screen.getAllByRole('button', { name: /use template/i })).toHaveLength(1);
+  });
+
+  it('opens preview modal when Preview is clicked', () => {
+    renderPage();
+    fireEvent.click(screen.getAllByRole('button', { name: /preview/i })[0]);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/useAnalytics.test.ts
+++ b/frontend/src/test/useAnalytics.test.ts
@@ -1,0 +1,49 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useAnalytics } from '../hooks/useAnalytics';
+
+describe('useAnalytics', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('starts in loading state', () => {
+    const { result } = renderHook(() => useAnalytics());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('resolves with stats after timer fires', async () => {
+    const { result } = renderHook(() => useAnalytics());
+    await act(async () => { vi.runAllTimers(); });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.stats.totalContributed).toBeGreaterThan(0);
+    expect(result.current.stats.onTimePercent).toBeGreaterThanOrEqual(0);
+    expect(result.current.stats.onTimePercent).toBeLessThanOrEqual(100);
+  });
+
+  it('returns history data points', async () => {
+    const { result } = renderHook(() => useAnalytics());
+    await act(async () => { vi.runAllTimers(); });
+
+    expect(result.current.history.length).toBeGreaterThan(0);
+    for (const point of result.current.history) {
+      expect(point.month).toBeTruthy();
+      expect(typeof point.contributed).toBe('number');
+      expect(typeof point.received).toBe('number');
+    }
+  });
+
+  it('returns member comparison data including "You"', async () => {
+    const { result } = renderHook(() => useAnalytics());
+    await act(async () => { vi.runAllTimers(); });
+
+    expect(result.current.memberComparison.length).toBeGreaterThan(0);
+    expect(result.current.memberComparison.find((m) => m.label === 'You')).toBeDefined();
+  });
+
+  it('has no error', async () => {
+    const { result } = renderHook(() => useAnalytics());
+    await act(async () => { vi.runAllTimers(); });
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/frontend/src/test/useInstallPrompt.test.ts
+++ b/frontend/src/test/useInstallPrompt.test.ts
@@ -1,0 +1,76 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useInstallPrompt } from '../hooks/useInstallPrompt';
+
+function makePromptEvent(outcome: 'accepted' | 'dismissed') {
+  return Object.assign(new Event('beforeinstallprompt'), {
+    prompt: vi.fn().mockResolvedValue(undefined),
+    userChoice: Promise.resolve({ outcome }),
+  });
+}
+
+describe('useInstallPrompt', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'addEventListener');
+    vi.spyOn(window, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('canInstall is false initially', () => {
+    const { result } = renderHook(() => useInstallPrompt());
+    expect(result.current.canInstall).toBe(false);
+  });
+
+  it('canInstall becomes true when beforeinstallprompt fires', () => {
+    const { result } = renderHook(() => useInstallPrompt());
+    const event = makePromptEvent('accepted');
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(result.current.canInstall).toBe(true);
+  });
+
+  it('install calls prompt() and returns outcome', async () => {
+    const { result } = renderHook(() => useInstallPrompt());
+    const event = makePromptEvent('accepted');
+
+    act(() => { window.dispatchEvent(event); });
+
+    let outcome: string | null = null;
+    await act(async () => {
+      outcome = await result.current.install();
+    });
+
+    expect(event.prompt).toHaveBeenCalledTimes(1);
+    expect(outcome).toBe('accepted');
+    expect(result.current.canInstall).toBe(false); // cleared after install
+  });
+
+  it('install returns null when no prompt is available', async () => {
+    const { result } = renderHook(() => useInstallPrompt());
+    const outcome = await result.current.install();
+    expect(outcome).toBeNull();
+  });
+
+  it('dismiss clears the deferred prompt', () => {
+    const { result } = renderHook(() => useInstallPrompt());
+    const event = makePromptEvent('dismissed');
+
+    act(() => { window.dispatchEvent(event); });
+    expect(result.current.canInstall).toBe(true);
+
+    act(() => { result.current.dismiss(); });
+    expect(result.current.canInstall).toBe(false);
+  });
+
+  it('removes event listener on unmount', () => {
+    const { unmount } = renderHook(() => useInstallPrompt());
+    unmount();
+    expect(window.removeEventListener).toHaveBeenCalledWith('beforeinstallprompt', expect.any(Function));
+  });
+});

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -1,0 +1,29 @@
+export interface ContributionDataPoint {
+  month: string; // e.g. "Jan 2025"
+  contributed: number; // XLM
+  received: number; // XLM
+}
+
+export interface MemberComparisonItem {
+  address: string;
+  label: string; // shortened address or "You"
+  onTimePercent: number;
+  totalContributed: number;
+}
+
+export interface AnalyticsStats {
+  totalContributed: number;
+  totalReceived: number;
+  roi: number; // percentage
+  onTimePercent: number;
+  activeGroups: number;
+  completedGroups: number;
+}
+
+export interface AnalyticsData {
+  stats: AnalyticsStats;
+  history: ContributionDataPoint[];
+  memberComparison: MemberComparisonItem[];
+  isLoading: boolean;
+  error: string | null;
+}

--- a/frontend/src/types/template.ts
+++ b/frontend/src/types/template.ts
@@ -1,0 +1,57 @@
+export interface GroupTemplate {
+  id: number;
+  name: string;
+  description: string;
+  cycleDuration: number; // days
+  maxMembers: number;
+  totalDuration: string;
+  category: 'short' | 'medium' | 'long';
+}
+
+export const GROUP_TEMPLATES: GroupTemplate[] = [
+  {
+    id: 1,
+    name: 'Weekly Saver',
+    description: 'Frequent payouts for tight-knit groups with short commitment windows.',
+    cycleDuration: 7,
+    maxMembers: 10,
+    totalDuration: '~10 weeks',
+    category: 'short',
+  },
+  {
+    id: 2,
+    name: 'Biweekly Saver',
+    description: 'A middle ground with slightly larger pools and manageable cadence.',
+    cycleDuration: 14,
+    maxMembers: 8,
+    totalDuration: '~16 weeks',
+    category: 'short',
+  },
+  {
+    id: 3,
+    name: 'Monthly Pool',
+    description: 'The most common Ajo/Esusu pattern — 12 members, one payout per month.',
+    cycleDuration: 30,
+    maxMembers: 12,
+    totalDuration: '~12 months',
+    category: 'medium',
+  },
+  {
+    id: 4,
+    name: 'Quarterly Circle',
+    description: 'Larger contribution amounts with less frequent cycles.',
+    cycleDuration: 90,
+    maxMembers: 4,
+    totalDuration: '~12 months',
+    category: 'medium',
+  },
+  {
+    id: 5,
+    name: 'Annual Pool',
+    description: 'Long-term savings commitment ideal for capital accumulation.',
+    cycleDuration: 365,
+    maxMembers: 5,
+    totalDuration: '~5 years',
+    category: 'long',
+  },
+];


### PR DESCRIPTION
closes #542 
closes #543 
closes #544 


Summary
  
  #544 — Progressive Web App
  
  - Added manifest.json with app metadata, theme color, and home screen shortcuts
  - Enhanced sw.js with install/activate lifecycle and caching strategies (cache-first for
  static assets, network-first for navigation, offline fallback for API errors)
  - Added offline.html fallback page shown when the user has no connection
  - useInstallPrompt hook captures the beforeinstallprompt event and exposes canInstall,
  install(), and dismiss() for an in-app install banner
  - Service worker registered in main.tsx on page load
  
  #543 — Group Templates Gallery
  
  - GROUP_TEMPLATES constant with all 5 contract-defined templates (Weekly, Biweekly, Monthly,
  Quarterly, Annual)
  - TemplateCard component showing cycle duration, max members, total duration, and category
  - TemplatePreviewModal for full template details before committing
  - TemplateGalleryPage at /templates with category filter (all / short / medium / long); "Use
  Template" navigates to Create Group with the template ID pre-selected
  
  #542 — Contribution Analytics Dashboard
  
  - useAnalytics hook (mock data, ready to wire to real API)
  - AnalyticsDashboardPage at /analytics with:
    - Stat cards: total contributed, total received, ROI, on-time rate
    - SVG bar chart of monthly contribution vs. received history (no new dependencies)
    - Member on-time rate comparison with progress bars
  
  Testing
  
  30 new tests across 4 files — all passing:
  
  - useInstallPrompt.test.ts (6)
  - TemplateGallery.test.tsx (13)
  - useAnalytics.test.ts (5)
  - Analytics.test.tsx (6)
