### PR TITLE
feat: add contribution success animation modal

### DIFF
--- a/frontend/src/components/ContributeButton.tsx
+++ b/frontend/src/components/ContributeButton.tsx
@@ -3,6 +3,7 @@ import type {
   TransactionStatus,
   ContributeButtonProps,
 } from "../types/contribution";
+import { ContributionSuccessModal } from "./ContributionSuccessModal";
 
 // ── Status helpers ──────────────────────────────────────────────────────────
 
@@ -303,6 +304,7 @@ export function ContributeButton({
   const [showConfirm, setShowConfirm] = useState(false);
   const [txHash, setTxHash] = useState<string>();
   const [errorMessage, setErrorMessage] = useState<string>();
+  const [showSuccess, setShowSuccess] = useState(false);
 
   const isLoading = ["confirming", "pending", "submitting"].includes(status);
   const isDisabled =
@@ -327,6 +329,7 @@ export function ContributeButton({
       await new Promise((r) => setTimeout(r, 800));
       setTxHash(hash);
       setStatus("success");
+      setShowSuccess(true);
       onSuccess?.(hash);
     } catch (err) {
       const error =
@@ -376,6 +379,17 @@ export function ContributeButton({
           onCancel={() => setShowConfirm(false)}
         />
       )}
+
+      <ContributionSuccessModal
+        open={showSuccess}
+        amount={amount}
+        cycleId={cycleId}
+        txHash={txHash}
+        onClose={() => {
+          setShowSuccess(false);
+          setStatus("idle");
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/components/ContributionFlow.tsx
+++ b/frontend/src/components/ContributionFlow.tsx
@@ -14,6 +14,7 @@ import {
   Chip,
 } from '@mui/material';
 import { Button } from './Button';
+import { ContributionSuccessModal } from './ContributionSuccessModal';
 import type { TransactionStatus } from '../types/contribution';
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -156,6 +157,7 @@ export function ContributionFlow({
   const [status, setStatus] = useState<TransactionStatus>('idle');
   const [txHash, setTxHash] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [showSuccess, setShowSuccess] = useState(false);
 
   const isProcessing = ['confirming', 'pending', 'submitting'].includes(status);
   const parsedAmount = parseFloat(amountInput);
@@ -180,6 +182,7 @@ export function ContributionFlow({
       await new Promise((r) => setTimeout(r, 500));
       setTxHash(hash);
       setStatus('success');
+      setShowSuccess(true);
       onSuccess?.(hash, parsedAmount);
     } catch (err) {
       const error = err instanceof Error ? err : new Error('Transaction failed');
@@ -201,6 +204,7 @@ export function ContributionFlow({
     setFieldError(null);
     setErrorMessage(null);
     setTxHash(null);
+    setShowSuccess(false);
   };
 
   const statusSeverity = STATUS_SEVERITY[status];
@@ -317,6 +321,15 @@ export function ContributionFlow({
         cycleId={cycleId}
         onConfirm={() => void handleConfirm()}
         onCancel={() => setConfirmOpen(false)}
+      />
+
+      {/* Success animation modal */}
+      <ContributionSuccessModal
+        open={showSuccess}
+        amount={parsedAmount || 0}
+        cycleId={cycleId}
+        txHash={txHash ?? undefined}
+        onClose={handleReset}
       />
     </Box>
   );

--- a/frontend/src/components/ContributionSuccessModal.css
+++ b/frontend/src/components/ContributionSuccessModal.css
@@ -1,0 +1,89 @@
+/* ── Confetti particles ─────────────────────────────────────────────────── */
+.confetti-container {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  border-radius: inherit;
+}
+
+.confetti-particle {
+  position: absolute;
+  top: -10px;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  animation: confetti-fall linear forwards;
+}
+
+@keyframes confetti-fall {
+  0% {
+    transform: translateY(0) rotate(0deg);
+    opacity: 1;
+  }
+  80% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(320px) rotate(720deg);
+    opacity: 0;
+  }
+}
+
+/* ── Checkmark animation ────────────────────────────────────────────────── */
+.checkmark-circle {
+  animation: scale-in 0.35s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+@keyframes scale-in {
+  from {
+    transform: scale(0);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.checkmark-path {
+  stroke-dasharray: 40;
+  stroke-dashoffset: 40;
+  animation: draw-check 0.4s ease-out 0.25s forwards;
+}
+
+@keyframes draw-check {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+/* ── Modal content fade-up ──────────────────────────────────────────────── */
+.success-modal-content {
+  animation: fade-up 0.3s ease-out forwards;
+}
+
+@keyframes fade-up {
+  from {
+    transform: translateY(16px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+/* ── Milestone pulse ────────────────────────────────────────────────────── */
+.milestone-badge {
+  animation: pulse-glow 1.2s ease-in-out infinite alternate;
+}
+
+@keyframes pulse-glow {
+  from {
+    box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.4);
+  }
+  to {
+    box-shadow: 0 0 0 8px rgba(99, 102, 241, 0);
+  }
+}

--- a/frontend/src/components/ContributionSuccessModal.tsx
+++ b/frontend/src/components/ContributionSuccessModal.tsx
@@ -1,0 +1,325 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import './ContributionSuccessModal.css';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ContributionSuccessModalProps {
+  open: boolean;
+  amount: number;
+  cycleId: number;
+  txHash?: string;
+  /** When total contributions hit a milestone (e.g. 5th, 10th), pass the label */
+  milestoneLabel?: string;
+  onClose: () => void;
+}
+
+// ── Confetti ─────────────────────────────────────────────────────────────────
+
+const COLORS = ['#6366f1', '#22c55e', '#f59e0b', '#ec4899', '#3b82f6', '#a855f7'];
+
+function Confetti() {
+  const particles = Array.from({ length: 28 }, (_, i) => {
+    const color = COLORS[i % COLORS.length];
+    const left = `${(i / 28) * 100}%`;
+    const duration = `${0.9 + (i % 5) * 0.18}s`;
+    const delay = `${(i % 7) * 0.07}s`;
+    return { color, left, duration, delay, rotate: i % 2 === 0 };
+  });
+
+  return (
+    <div className="confetti-container" aria-hidden="true">
+      {particles.map((p, i) => (
+        <div
+          key={i}
+          className="confetti-particle"
+          style={{
+            left: p.left,
+            backgroundColor: p.color,
+            borderRadius: p.rotate ? '50%' : '2px',
+            animationDuration: p.duration,
+            animationDelay: p.delay,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ── Animated checkmark ───────────────────────────────────────────────────────
+
+function AnimatedCheckmark() {
+  return (
+    <svg width="64" height="64" viewBox="0 0 64 64" fill="none" aria-hidden="true">
+      <circle className="checkmark-circle" cx="32" cy="32" r="30" fill="#22c55e" />
+      <polyline
+        className="checkmark-path"
+        points="18,33 27,43 46,22"
+        stroke="white"
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+}
+
+// ── Sound effect (Web Audio API — no external dep) ───────────────────────────
+
+function playSuccessSound() {
+  try {
+    const ctx = new AudioContext();
+    const notes = [523.25, 659.25, 783.99]; // C5, E5, G5
+    notes.forEach((freq, i) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.type = 'sine';
+      osc.frequency.value = freq;
+      const start = ctx.currentTime + i * 0.12;
+      gain.gain.setValueAtTime(0.18, start);
+      gain.gain.exponentialRampToValueAtTime(0.001, start + 0.35);
+      osc.start(start);
+      osc.stop(start + 0.35);
+    });
+  } catch {
+    // AudioContext not available (e.g. in tests) — silently ignore
+  }
+}
+
+// ── Social share ─────────────────────────────────────────────────────────────
+
+function buildShareText(amount: number, cycleId: number, milestone?: string) {
+  const base = `Just contributed ${amount} XLM to my savings circle (Cycle #${cycleId}) on @StellarSave! 🚀`;
+  return milestone ? `${base} ${milestone} 🎉` : base;
+}
+
+function ShareButton({
+  amount,
+  cycleId,
+  milestone,
+}: {
+  amount: number;
+  cycleId: number;
+  milestone?: string;
+}) {
+  const text = buildShareText(amount, cycleId, milestone);
+  const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`;
+
+  return (
+    <a
+      href={twitterUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: '8px 16px',
+        borderRadius: '8px',
+        background: '#1d9bf0',
+        color: '#fff',
+        fontSize: '13px',
+        fontWeight: 600,
+        textDecoration: 'none',
+        transition: 'background 0.15s',
+      }}
+      onMouseOver={(e) => ((e.currentTarget as HTMLAnchorElement).style.background = '#1a8cd8')}
+      onMouseOut={(e) => ((e.currentTarget as HTMLAnchorElement).style.background = '#1d9bf0')}
+    >
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+      </svg>
+      Share
+    </a>
+  );
+}
+
+// ── Main component ───────────────────────────────────────────────────────────
+
+export function ContributionSuccessModal({
+  open,
+  amount,
+  cycleId,
+  txHash,
+  milestoneLabel,
+  onClose,
+}: ContributionSuccessModalProps) {
+  const [muted, setMuted] = useLocalStorage('contribution-sound-muted', false);
+  const playedRef = useRef(false);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    if (!open) {
+      playedRef.current = false;
+      return;
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    if (!muted && !playedRef.current) {
+      playedRef.current = true;
+      playSuccessSound();
+    }
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, muted, handleKeyDown]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="success-modal-title"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.55)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1300,
+        padding: '16px',
+      }}
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div
+        className="success-modal-content"
+        style={{
+          position: 'relative',
+          background: '#fff',
+          borderRadius: '20px',
+          padding: '32px 28px 28px',
+          maxWidth: '360px',
+          width: '100%',
+          textAlign: 'center',
+          overflow: 'hidden',
+        }}
+      >
+        <Confetti />
+
+        {/* Mute toggle */}
+        <button
+          onClick={() => setMuted((v) => !v)}
+          aria-label={muted ? 'Unmute sound' : 'Mute sound'}
+          title={muted ? 'Unmute sound' : 'Mute sound'}
+          style={{
+            position: 'absolute',
+            top: '12px',
+            right: '44px',
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '4px',
+            color: '#9ca3af',
+            fontSize: '18px',
+            lineHeight: 1,
+          }}
+        >
+          {muted ? '🔇' : '🔊'}
+        </button>
+
+        {/* Close button */}
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          style={{
+            position: 'absolute',
+            top: '12px',
+            right: '12px',
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '4px',
+            color: '#9ca3af',
+            fontSize: '18px',
+            lineHeight: 1,
+          }}
+        >
+          ✕
+        </button>
+
+        {/* Checkmark */}
+        <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '16px' }}>
+          <AnimatedCheckmark />
+        </div>
+
+        <h2
+          id="success-modal-title"
+          style={{ margin: '0 0 4px', fontSize: '20px', fontWeight: 700, color: '#111827' }}
+        >
+          Contribution Successful!
+        </h2>
+        <p style={{ margin: '0 0 16px', color: '#6b7280', fontSize: '14px' }}>
+          {amount} XLM · Cycle #{cycleId}
+        </p>
+
+        {/* Milestone badge */}
+        {milestoneLabel && (
+          <div
+            className="milestone-badge"
+            style={{
+              display: 'inline-block',
+              background: '#eef2ff',
+              color: '#4f46e5',
+              borderRadius: '999px',
+              padding: '4px 14px',
+              fontSize: '13px',
+              fontWeight: 600,
+              marginBottom: '16px',
+            }}
+          >
+            🏆 {milestoneLabel}
+          </div>
+        )}
+
+        {/* Explorer link */}
+        {txHash && (
+          <p style={{ margin: '0 0 20px', fontSize: '12px' }}>
+            <a
+              href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: '#6366f1', textDecoration: 'none' }}
+            >
+              View on Stellar Explorer →
+            </a>
+          </p>
+        )}
+
+        {/* Actions */}
+        <div style={{ display: 'flex', gap: '10px', justifyContent: 'center', flexWrap: 'wrap' }}>
+          <ShareButton amount={amount} cycleId={cycleId} milestone={milestoneLabel} />
+          <button
+            onClick={onClose}
+            style={{
+              padding: '8px 20px',
+              borderRadius: '8px',
+              border: '1px solid #e5e7eb',
+              background: '#fff',
+              color: '#374151',
+              fontSize: '13px',
+              fontWeight: 600,
+              cursor: 'pointer',
+              transition: 'background 0.15s',
+            }}
+            onMouseOver={(e) =>
+              ((e.currentTarget as HTMLButtonElement).style.background = '#f9fafb')
+            }
+            onMouseOut={(e) => ((e.currentTarget as HTMLButtonElement).style.background = '#fff')}
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ContributionSuccessModal;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -46,6 +46,8 @@ export { ReminderPreferencesSection } from "./ReminderPreferencesSection";
 export { DebounceDemo } from "./DebounceDemo";
 export { ContributionFlow } from "./ContributionFlow";
 export type { ContributionFlowProps } from "./ContributionFlow";
+export { ContributionSuccessModal } from "./ContributionSuccessModal";
+export type { ContributionSuccessModalProps } from "./ContributionSuccessModal";
 export { WalletIntegration } from "./WalletIntegration";
 export { ActivityFeed } from "./ActivityFeed/ActivityFeed";
 export type { ActivityFeedProps } from "./ActivityFeed/ActivityFeed";

--- a/frontend/src/test/ContributionSuccessModal.test.tsx
+++ b/frontend/src/test/ContributionSuccessModal.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ContributionSuccessModal } from '../components/ContributionSuccessModal';
+
+// AudioContext is not available in jsdom — mock it
+beforeEach(() => {
+  Object.defineProperty(window, 'AudioContext', {
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      createOscillator: () => ({
+        connect: vi.fn(),
+        type: '',
+        frequency: { value: 0 },
+        start: vi.fn(),
+        stop: vi.fn(),
+      }),
+      createGain: () => ({
+        connect: vi.fn(),
+        gain: { setValueAtTime: vi.fn(), exponentialRampToValueAtTime: vi.fn() },
+      }),
+      destination: {},
+      currentTime: 0,
+    })),
+  });
+});
+
+describe('ContributionSuccessModal', () => {
+  const baseProps = {
+    open: true,
+    amount: 50,
+    cycleId: 3,
+    onClose: vi.fn(),
+  };
+
+  it('renders nothing when closed', () => {
+    const { container } = render(<ContributionSuccessModal {...baseProps} open={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows amount and cycle when open', () => {
+    render(<ContributionSuccessModal {...baseProps} />);
+    expect(screen.getByText(/50 XLM/)).toBeInTheDocument();
+    expect(screen.getByText(/Cycle #3/)).toBeInTheDocument();
+  });
+
+  it('shows success heading', () => {
+    render(<ContributionSuccessModal {...baseProps} />);
+    expect(screen.getByRole('heading', { name: /Contribution Successful/i })).toBeInTheDocument();
+  });
+
+  it('calls onClose when Done button is clicked', () => {
+    const onClose = vi.fn();
+    render(<ContributionSuccessModal {...baseProps} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /done/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when close (✕) button is clicked', () => {
+    const onClose = vi.fn();
+    render(<ContributionSuccessModal {...baseProps} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when backdrop is clicked', () => {
+    const onClose = vi.fn();
+    render(<ContributionSuccessModal {...baseProps} onClose={onClose} />);
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(dialog);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose on Escape key', () => {
+    const onClose = vi.fn();
+    render(<ContributionSuccessModal {...baseProps} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows milestone badge when milestoneLabel is provided', () => {
+    render(<ContributionSuccessModal {...baseProps} milestoneLabel="5th Contribution!" />);
+    expect(screen.getByText(/5th Contribution!/)).toBeInTheDocument();
+  });
+
+  it('does not show milestone badge when milestoneLabel is absent', () => {
+    render(<ContributionSuccessModal {...baseProps} />);
+    expect(screen.queryByText(/🏆/)).not.toBeInTheDocument();
+  });
+
+  it('shows explorer link when txHash is provided', () => {
+    render(<ContributionSuccessModal {...baseProps} txHash="abc123" />);
+    const link = screen.getByRole('link', { name: /View on Stellar Explorer/i });
+    expect(link).toHaveAttribute('href', expect.stringContaining('abc123'));
+  });
+
+  it('does not show explorer link when txHash is absent', () => {
+    render(<ContributionSuccessModal {...baseProps} />);
+    expect(
+      screen.queryByRole('link', { name: /View on Stellar Explorer/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a Share button linking to Twitter', () => {
+    render(<ContributionSuccessModal {...baseProps} />);
+    const shareLink = screen.getByRole('link', { name: /share/i });
+    expect(shareLink).toHaveAttribute('href', expect.stringContaining('twitter.com'));
+  });
+
+  it('renders mute toggle button', () => {
+    render(<ContributionSuccessModal {...baseProps} />);
+    expect(screen.getByRole('button', { name: /mute sound/i })).toBeInTheDocument();
+  });
+
+  it('toggles mute label when mute button is clicked', () => {
+    render(<ContributionSuccessModal {...baseProps} />);
+    const muteBtn = screen.getByRole('button', { name: /mute sound/i });
+    fireEvent.click(muteBtn);
+    expect(screen.getByRole('button', { name: /unmute sound/i })).toBeInTheDocument();
+  });
+
+  it('has accessible dialog role and aria-modal', () => {
+    render(<ContributionSuccessModal {...baseProps} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'success-modal-title');
+  });
+});


### PR DESCRIPTION
close #537 


What's in this PR

- ContributionSuccessModal — full-screen overlay modal with:
  - Confetti burst (28 CSS-animated particles)
  - Animated SVG checkmark (circle scale-in + stroke draw)
  - Web Audio API success chord (C5/E5/G5) — no external dependency
  - Mute toggle persisted to localStorage
  - Milestone badge with pulse-glow animation for special contributions
  - Twitter share button pre-filled with contribution details
  - Stellar Explorer link when a txHash is available
  - Keyboard (Escape) and backdrop click to dismiss
- ContributionSuccessModal.css — all animations (confetti-fall, scale-in, draw-check, fade-up, pulse-glow)
- Wired into both ContributeButton and ContributionFlow
- Exported from components/index.ts

Tests

15 tests covering: render when open/closed, amount/cycle display, onClose via Done button / ✕ button / backdrop / Escape key, milestone badge presence, explorer link, Twitter share link, mute toggle, and ARIA attributes.

CI

- All 15 new tests pass
- Pre-existing failures (unrelated: groupApi, TransactionConfirmModal, OnboardingTutorial, etc.) confirmed present on main before this branch
