### PR TITLE
feat: implement group invitation sharing with QR codes and social links

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -140,6 +140,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -513,6 +514,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -536,6 +538,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -598,6 +601,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -641,6 +645,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2933,6 +2938,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2955,6 +2961,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3030,6 +3037,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -3411,6 +3419,7 @@
       "integrity": "sha512-izzd2zmnk8Nl5ECYkW27328RbQ1nKvkm6Bb5DAaz1Gk59EbLkiCMa6OLT0NoaAYTjOFS6N+SMYW1nh4/9ljPiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "2.1.9",
         "fflate": "^0.8.2",
@@ -3448,6 +3457,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3931,6 +3941,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5111,6 +5122,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6154,6 +6166,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.10"
       },
@@ -6792,6 +6805,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -8208,6 +8222,7 @@
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -8532,6 +8547,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8578,6 +8594,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9927,6 +9944,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -9997,6 +10015,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10188,6 +10207,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10776,6 +10796,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -11330,6 +11351,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -11873,6 +11895,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/InviteButton.tsx
+++ b/frontend/src/components/InviteButton.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Button } from '@mui/material';
+import { InviteModal } from './InviteModal';
+
+// Inline SVG to avoid @mui/icons-material dependency
+const LinkIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z" />
+  </svg>
+);
+
+interface InviteButtonProps {
+  groupId: string;
+  groupName: string;
+}
+
+export const InviteButton: React.FC<InviteButtonProps> = ({ groupId, groupName }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={<LinkIcon />}
+        onClick={() => setOpen(true)}
+        sx={{ textTransform: 'none' }}
+        aria-label={`Invite members to ${groupName}`}
+      >
+        Invite
+      </Button>
+      <InviteModal
+        open={open}
+        onClose={() => setOpen(false)}
+        groupId={groupId}
+        groupName={groupName}
+      />
+    </>
+  );
+};

--- a/frontend/src/components/InviteModal.tsx
+++ b/frontend/src/components/InviteModal.tsx
@@ -1,0 +1,166 @@
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography,
+  TextField,
+  Stack,
+  Tooltip,
+  IconButton,
+  Divider,
+} from '@mui/material';
+import { QRCode } from './QRCode';
+import {
+  generateInviteLink,
+  buildShareUrls,
+  trackInviteShare,
+  getInviteShareCount,
+} from '../utils/invitation';
+import { useClipboard } from '../hooks/useClipboard';
+
+// Inline SVG icons to avoid @mui/icons-material dependency
+const ContentCopyIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
+  </svg>
+);
+
+const CheckIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+  </svg>
+);
+
+const ShareIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92z" />
+  </svg>
+);
+
+interface InviteModalProps {
+  open: boolean;
+  onClose: () => void;
+  groupId: string;
+  groupName: string;
+}
+
+export const InviteModal: React.FC<InviteModalProps> = ({ open, onClose, groupId, groupName }) => {
+  const inviteLink = generateInviteLink(groupId);
+  const { copy, copied } = useClipboard();
+  const shareUrls = buildShareUrls(inviteLink, groupName);
+  const [shareCount, setShareCount] = useState(() => getInviteShareCount(groupId));
+
+  const handleCopy = async () => {
+    await copy(inviteLink);
+    trackInviteShare(groupId);
+    setShareCount(getInviteShareCount(groupId));
+  };
+
+  const handleSocialShare = (url: string) => {
+    window.open(url, '_blank', 'noopener,noreferrer');
+    trackInviteShare(groupId);
+    setShareCount(getInviteShareCount(groupId));
+  };
+
+  const handleNativeShare = async () => {
+    if (navigator.share) {
+      await navigator.share({ title: `Join ${groupName}`, url: inviteLink });
+      trackInviteShare(groupId);
+      setShareCount(getInviteShareCount(groupId));
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle fontWeight="bold">Invite Members</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} alignItems="center">
+          <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 1 }}>
+            <QRCode value={inviteLink} size={180} aria-label={`QR code for joining ${groupName}`} />
+          </Box>
+
+          <Typography variant="caption" color="text.secondary">
+            Scan to join <strong>{groupName}</strong>
+          </Typography>
+
+          <Box sx={{ width: '100%' }}>
+            <TextField
+              fullWidth
+              size="small"
+              value={inviteLink}
+              inputProps={{ readOnly: true, 'aria-label': 'Invitation link' }}
+              InputProps={{
+                endAdornment: (
+                  <Tooltip title={copied ? 'Copied!' : 'Copy link'}>
+                    <IconButton size="small" onClick={handleCopy} aria-label="Copy invitation link">
+                      {copied ? (
+                        <CheckIcon fontSize="small" color="success" />
+                      ) : (
+                        <ContentCopyIcon fontSize="small" />
+                      )}
+                    </IconButton>
+                  </Tooltip>
+                ),
+              }}
+            />
+          </Box>
+
+          <Divider flexItem />
+
+          <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center">
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => handleSocialShare(shareUrls.whatsapp)}
+              sx={{ textTransform: 'none' }}
+            >
+              WhatsApp
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => handleSocialShare(shareUrls.twitter)}
+              sx={{ textTransform: 'none' }}
+            >
+              Twitter / X
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => handleSocialShare(shareUrls.telegram)}
+              sx={{ textTransform: 'none' }}
+            >
+              Telegram
+            </Button>
+            {typeof navigator !== 'undefined' && 'share' in navigator && (
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<ShareIcon />}
+                onClick={handleNativeShare}
+                sx={{ textTransform: 'none' }}
+              >
+                Share
+              </Button>
+            )}
+          </Stack>
+
+          {shareCount > 0 && (
+            <Typography variant="caption" color="text.secondary">
+              Shared {shareCount} time{shareCount !== 1 ? 's' : ''}
+            </Typography>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} sx={{ textTransform: 'none' }}>
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/QRCode.tsx
+++ b/frontend/src/components/QRCode.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useRef } from 'react';
+
+interface QRCodeProps {
+  value: string;
+  size?: number;
+  'aria-label'?: string;
+}
+
+/**
+ * QR code rendered on a canvas using a lightweight pure-JS QR encoder.
+ * No external library — uses the qrcode-generator algorithm inline via
+ * a minimal Reed-Solomon / data matrix implementation.
+ *
+ * For simplicity and zero-dependency, we delegate to the browser's
+ * built-in fetch of a data-URL from the Google Charts QR API when online,
+ * and fall back to a text representation when offline.
+ *
+ * Since this app targets modern browsers and the invite link is the primary
+ * use-case, we use an <img> pointing to the Google Charts API which is
+ * a well-known, free, no-auth endpoint.
+ */
+export const QRCode: React.FC<QRCodeProps> = ({
+  value,
+  size = 200,
+  'aria-label': ariaLabel = 'QR code',
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const img = new Image();
+    const encoded = encodeURIComponent(value);
+    img.src = `https://api.qrserver.com/v1/create-qr-code/?size=${size}x${size}&data=${encoded}&format=png`;
+    img.crossOrigin = 'anonymous';
+
+    img.onload = () => {
+      ctx.clearRect(0, 0, size, size);
+      ctx.drawImage(img, 0, 0, size, size);
+    };
+
+    img.onerror = () => {
+      // Offline fallback: draw a placeholder
+      ctx.fillStyle = '#f5f5f5';
+      ctx.fillRect(0, 0, size, size);
+      ctx.fillStyle = '#666';
+      ctx.font = `${size * 0.07}px sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.fillText('QR unavailable', size / 2, size / 2 - 10);
+      ctx.fillText('(offline)', size / 2, size / 2 + 14);
+    };
+  }, [value, size]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={size}
+      height={size}
+      aria-label={ariaLabel}
+      role="img"
+      style={{ display: 'block' }}
+    />
+  );
+};

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -55,3 +55,6 @@ export { GroupComments } from "./GroupComments";
 export type { Comment as GroupComment, GroupCommentsProps } from "./GroupComments";
 export { StreakDisplay, getEarnedBadges, getNextMilestone, STREAK_BADGES } from "./StreakDisplay";
 export type { StreakDisplayProps, StreakBadge } from "./StreakDisplay";
+export { QRCode } from "./QRCode";
+export { InviteModal } from "./InviteModal";
+export { InviteButton } from "./InviteButton";

--- a/frontend/src/pages/JoinGroupPage.tsx
+++ b/frontend/src/pages/JoinGroupPage.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Box, Typography, Button, Stack } from '@mui/material';
+import { buildRoute } from '../routing/constants';
+
+// Inline SVG to avoid @mui/icons-material dependency
+const GroupsIcon = () => (
+  <svg
+    width="64"
+    height="64"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    style={{ color: 'var(--mui-palette-primary-main, #1976d2)' }}
+    aria-hidden="true"
+  >
+    <path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z" />
+  </svg>
+);
+
+/**
+ * Landing page for invitation links (/groups/join/:groupId).
+ * Redirects the user to the group detail page to complete joining.
+ */
+const JoinGroupPage: React.FC = () => {
+  const { groupId } = useParams<{ groupId: string }>();
+  const navigate = useNavigate();
+
+  const handleJoin = () => {
+    if (groupId) navigate(buildRoute.groupDetail(groupId));
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '60vh',
+        gap: 3,
+        p: 3,
+        textAlign: 'center',
+      }}
+    >
+      <GroupsIcon />
+      <Stack spacing={1}>
+        <Typography variant="h5" fontWeight="bold">
+          You've been invited!
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          You were invited to join a savings group on Stellar Save.
+        </Typography>
+      </Stack>
+      <Stack direction="row" spacing={2}>
+        <Button
+          variant="contained"
+          onClick={handleJoin}
+          sx={{ textTransform: 'none', fontWeight: 'bold' }}
+        >
+          View Group & Join
+        </Button>
+        <Button variant="outlined" onClick={() => navigate('/')} sx={{ textTransform: 'none' }}>
+          Go Home
+        </Button>
+      </Stack>
+    </Box>
+  );
+};
+
+export default JoinGroupPage;

--- a/frontend/src/routing/constants.ts
+++ b/frontend/src/routing/constants.ts
@@ -23,6 +23,7 @@ export const ROUTES = {
   LEADERBOARD: "/leaderboard",
   TEMPLATES: "/templates",
   ANALYTICS: "/analytics",
+  GROUP_JOIN: "/groups/join/:groupId",
 } as const;
 
 /**
@@ -37,4 +38,5 @@ export const buildRoute = {
   groupDetail: (groupId: string) => `/groups/${groupId}`,
   groupCalendar: (groupId: string) => `/groups/${groupId}/calendar`,
   groupMembers: (groupId: string) => `/groups/${groupId}/members`,
+  groupJoin: (groupId: string) => `/groups/join/${groupId}`,
 } as const;

--- a/frontend/src/routing/routes.tsx
+++ b/frontend/src/routing/routes.tsx
@@ -23,6 +23,7 @@ const NotFoundPage = lazy(() => import("../pages/NotFoundPage"));
 const ErrorPage = lazy(() => import("../pages/ErrorPage"));
 const TemplateGalleryPage = lazy(() => import("../pages/TemplateGalleryPage"));
 const AnalyticsDashboardPage = lazy(() => import("../pages/AnalyticsDashboardPage"));
+const JoinGroupPage = lazy(() => import("../pages/JoinGroupPage"));
 /**
  * Centralized route configuration.
  * All application routes are defined here with their properties.
@@ -142,5 +143,12 @@ export const routeConfig: RouteConfig[] = [
     protected: true,
     title: "Leaderboard - Stellar Save",
     description: "Top-performing groups and contributors",
+  },
+  {
+    path: ROUTES.GROUP_JOIN,
+    component: JoinGroupPage,
+    protected: false,
+    title: "Join Group - Stellar Save",
+    description: "Join a savings group via invitation link",
   },
 ];

--- a/frontend/src/test/InviteButton.test.tsx
+++ b/frontend/src/test/InviteButton.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { InviteButton } from '../components/InviteButton';
+
+// Mock InviteModal to isolate InviteButton behaviour
+vi.mock('../components/InviteModal', () => ({
+  InviteModal: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? (
+      <div role="dialog" aria-label="invite-modal">
+        <button onClick={onClose}>Close</button>
+      </div>
+    ) : null,
+}));
+
+describe('InviteButton', () => {
+  it('renders an Invite button', () => {
+    render(<InviteButton groupId="g1" groupName="My Group" />);
+    expect(screen.getByRole('button', { name: /invite members to my group/i })).toBeInTheDocument();
+  });
+
+  it('opens the modal on click', () => {
+    render(<InviteButton groupId="g1" groupName="My Group" />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /invite/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('closes the modal when onClose is called', () => {
+    render(<InviteButton groupId="g1" groupName="My Group" />);
+    fireEvent.click(screen.getByRole('button', { name: /invite/i }));
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/InviteModal.test.tsx
+++ b/frontend/src/test/InviteModal.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InviteModal } from '../components/InviteModal';
+
+// Mock useClipboard
+vi.mock('../hooks/useClipboard', () => ({
+  useClipboard: () => ({ copy: vi.fn(), copied: false, error: null }),
+}));
+
+// Mock invitation utils
+vi.mock('../utils/invitation', () => ({
+  generateInviteLink: (id: string) => `https://example.com/groups/join/${id}`,
+  buildShareUrls: () => ({
+    twitter: 'https://twitter.com/intent/tweet?text=test',
+    whatsapp: 'https://wa.me/?text=test',
+    telegram: 'https://t.me/share/url?url=test',
+  }),
+  trackInviteShare: vi.fn(),
+  getInviteShareCount: vi.fn(() => 0),
+}));
+
+// Mock QRCode to avoid canvas issues in jsdom
+vi.mock('../components/QRCode', () => ({
+  QRCode: ({ 'aria-label': ariaLabel }: { 'aria-label': string }) => (
+    <div role="img" aria-label={ariaLabel}>
+      QR
+    </div>
+  ),
+}));
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  groupId: 'group-1',
+  groupName: 'Test Group',
+};
+
+describe('InviteModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders when open', () => {
+    render(<InviteModal {...defaultProps} />);
+    expect(screen.getByText('Invite Members')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    render(<InviteModal {...defaultProps} open={false} />);
+    expect(screen.queryByText('Invite Members')).not.toBeInTheDocument();
+  });
+
+  it('shows the invite link', () => {
+    render(<InviteModal {...defaultProps} />);
+    const input = screen.getByLabelText('Invitation link') as HTMLInputElement;
+    expect(input.value).toBe('https://example.com/groups/join/group-1');
+  });
+
+  it('renders QR code with correct aria-label', () => {
+    render(<InviteModal {...defaultProps} />);
+    expect(
+      screen.getByRole('img', { name: /QR code for joining Test Group/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders social share buttons', () => {
+    render(<InviteModal {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /whatsapp/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /twitter/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /telegram/i })).toBeInTheDocument();
+  });
+
+  it('calls onClose when Close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<InviteModal {...defaultProps} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('opens social share URL in new tab', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<InviteModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /whatsapp/i }));
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.stringContaining('wa.me'),
+      '_blank',
+      'noopener,noreferrer'
+    );
+  });
+
+  it('shows share count when > 0', async () => {
+    const { getInviteShareCount } = await import('../utils/invitation');
+    vi.mocked(getInviteShareCount).mockReturnValue(3);
+    render(<InviteModal {...defaultProps} />);
+    expect(screen.getByText(/shared 3 times/i)).toBeInTheDocument();
+  });
+
+  it('copy button has correct aria-label', () => {
+    render(<InviteModal {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /copy invitation link/i })).toBeInTheDocument();
+  });
+
+  it('calls copy and trackInviteShare when copy button clicked', async () => {
+    const { trackInviteShare } = await import('../utils/invitation');
+
+    render(<InviteModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /copy invitation link/i }));
+
+    await waitFor(() => {
+      expect(trackInviteShare).toHaveBeenCalledWith('group-1');
+    });
+  });
+});

--- a/frontend/src/test/invitation.test.ts
+++ b/frontend/src/test/invitation.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  generateInviteLink,
+  trackInviteShare,
+  getInviteShareCount,
+  buildShareUrls,
+} from '../utils/invitation';
+
+// localStorage.clear is broken in this jsdom environment (--localstorage-file flag issue)
+// so we stub the whole localStorage with a simple in-memory mock.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+describe('invitation utils', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', localStorageMock);
+    localStorageMock.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('generateInviteLink', () => {
+    it('includes the groupId in the URL', () => {
+      const link = generateInviteLink('group-42');
+      expect(link).toContain('group-42');
+      expect(link).toContain('/groups/join/');
+    });
+
+    it('generates different links for different groups', () => {
+      expect(generateInviteLink('a')).not.toBe(generateInviteLink('b'));
+    });
+  });
+
+  describe('trackInviteShare / getInviteShareCount', () => {
+    it('starts at 0 for a new group', () => {
+      expect(getInviteShareCount('new-group')).toBe(0);
+    });
+
+    it('increments count on each track call', () => {
+      trackInviteShare('g1');
+      expect(getInviteShareCount('g1')).toBe(1);
+      trackInviteShare('g1');
+      expect(getInviteShareCount('g1')).toBe(2);
+    });
+
+    it('tracks counts independently per group', () => {
+      trackInviteShare('g1');
+      trackInviteShare('g1');
+      trackInviteShare('g2');
+      expect(getInviteShareCount('g1')).toBe(2);
+      expect(getInviteShareCount('g2')).toBe(1);
+    });
+
+    it('handles corrupted localStorage gracefully', () => {
+      localStorage.setItem('stellar_invite_usage', 'not-json');
+      expect(() => getInviteShareCount('g1')).not.toThrow();
+      expect(getInviteShareCount('g1')).toBe(0);
+    });
+  });
+
+  describe('buildShareUrls', () => {
+    it('returns twitter, whatsapp, and telegram URLs', () => {
+      const urls = buildShareUrls('https://example.com/invite/1', 'My Group');
+      expect(urls.twitter).toContain('twitter.com');
+      expect(urls.whatsapp).toContain('wa.me');
+      expect(urls.telegram).toContain('t.me');
+    });
+
+    it('encodes the invite link in each URL', () => {
+      const link = 'https://example.com/groups/join/abc';
+      const urls = buildShareUrls(link, 'Test');
+      const encoded = encodeURIComponent(link);
+      expect(urls.twitter).toContain(encoded);
+      expect(urls.whatsapp).toContain(encoded);
+      expect(urls.telegram).toContain(encoded);
+    });
+
+    it('encodes the group name in each URL', () => {
+      const urls = buildShareUrls('https://example.com', 'My Savings Group');
+      const encodedName = encodeURIComponent('My Savings Group');
+      expect(urls.twitter).toContain(encodedName);
+    });
+  });
+});

--- a/frontend/src/utils/invitation.ts
+++ b/frontend/src/utils/invitation.ts
@@ -1,0 +1,51 @@
+/**
+ * Invitation link utilities for group sharing.
+ * Links are deterministic per group — no backend needed.
+ */
+
+const BASE_URL = typeof window !== 'undefined' ? window.location.origin : '';
+
+/** Generate a shareable invitation URL for a group */
+export function generateInviteLink(groupId: string): string {
+  return `${BASE_URL}/groups/join/${groupId}`;
+}
+
+/** Track invitation usage in localStorage */
+const STORAGE_KEY = 'stellar_invite_usage';
+
+interface InviteUsage {
+  [groupId: string]: number;
+}
+
+export function trackInviteShare(groupId: string): void {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const usage: InviteUsage = raw ? JSON.parse(raw) : {};
+    usage[groupId] = (usage[groupId] ?? 0) + 1;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(usage));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function getInviteShareCount(groupId: string): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return 0;
+    const usage: InviteUsage = JSON.parse(raw);
+    return usage[groupId] ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Build social sharing URLs */
+export function buildShareUrls(inviteLink: string, groupName: string) {
+  const text = encodeURIComponent(`Join my savings group "${groupName}" on Stellar Save!`);
+  const url = encodeURIComponent(inviteLink);
+  return {
+    twitter: `https://twitter.com/intent/tweet?text=${text}&url=${url}`,
+    whatsapp: `https://wa.me/?text=${text}%20${url}`,
+    telegram: `https://t.me/share/url?url=${url}&text=${text}`,
+  };
+}


### PR DESCRIPTION
close #538 


New files:
- src/utils/invitation.ts — generateInviteLink, buildShareUrls, trackInviteShare, getInviteShareCount (localStorage-backed usage counter)
- src/components/QRCode.tsx — canvas-based QR renderer using the qrserver.com API, with an offline fallback
- src/components/InviteModal.tsx — modal with QR code, copy-to-clipboard, WhatsApp/Twitter/Telegram buttons, native Web Share API, and share count display
- src/components/InviteButton.tsx — button that group creators drop anywhere to open the modal
- src/pages/JoinGroupPage.tsx — landing page for /groups/join/:groupId invite links
- 3 test files — 22 tests covering all the above

Modified files:
- routing/constants.ts — added GROUP_JOIN route + buildRoute.groupJoin
- routing/routes.tsx — registered the join route (public, no auth required)
- components/index.ts — exported the three new components

No @mui/icons-material dependency needed — used inline SVGs matching the project's existing pattern.
