### PR TITLE
feat: wallet balance warnings on dashboard (#494)

### DIFF
--- a/frontend/src/components/BalanceWarningBanner.tsx
+++ b/frontend/src/components/BalanceWarningBanner.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { Alert, AlertTitle, Box, Button, Collapse, Link, Stack, Typography } from '@mui/material';
+import type { BalanceWarning } from '../hooks/useBalanceWarning';
+
+interface Props {
+  warning: BalanceWarning;
+}
+
+/**
+ * Dismissible banner shown on the dashboard when the wallet balance is
+ * insufficient to cover upcoming group contributions.
+ */
+export function BalanceWarningBanner({ warning }: Props) {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (!warning.isInsufficient || dismissed) return null;
+
+  const fmt = (n: number) =>
+    n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 7 });
+
+  return (
+    <Collapse in>
+      <Alert
+        severity="warning"
+        sx={{ borderRadius: 2, mb: 2 }}
+        action={
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Button
+              size="small"
+              variant="outlined"
+              color="warning"
+              component={Link}
+              href="https://www.stellar.org/lumens/wallets"
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{ textTransform: 'none', whiteSpace: 'nowrap' }}
+            >
+              Fund Wallet
+            </Button>
+            <Button
+              size="small"
+              aria-label="dismiss warning"
+              onClick={() => setDismissed(true)}
+              sx={{ minWidth: 0, px: 1 }}
+            >
+              ✕
+            </Button>
+          </Stack>
+        }
+      >
+        <AlertTitle sx={{ fontWeight: 'bold' }}>Insufficient Balance</AlertTitle>
+        <Box>
+          <Typography variant="body2">
+            Your wallet has{' '}
+            <strong>{fmt(warning.currentBalance)} XLM</strong> but your upcoming
+            contributions require{' '}
+            <strong>{fmt(warning.requiredAmount)} XLM</strong>.
+          </Typography>
+          <Typography variant="body2" sx={{ mt: 0.5 }}>
+            You need <strong>{fmt(warning.shortfall)} more XLM</strong> to cover
+            all active group contributions.
+          </Typography>
+        </Box>
+      </Alert>
+    </Collapse>
+  );
+}

--- a/frontend/src/hooks/useBalanceWarning.ts
+++ b/frontend/src/hooks/useBalanceWarning.ts
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { useBalance } from './useBalance';
+import type { DashboardGroup } from '../types/dashboard';
+
+export interface BalanceWarning {
+  /** True when the wallet balance is below the total upcoming contribution amount */
+  isInsufficient: boolean;
+  /** Current XLM balance as a number (0 when unknown) */
+  currentBalance: number;
+  /** Sum of contribution amounts for all active groups */
+  requiredAmount: number;
+  /** How much more XLM is needed */
+  shortfall: number;
+}
+
+/**
+ * Compares the live wallet balance against the total upcoming contribution
+ * amounts for the user's active groups.
+ */
+export function useBalanceWarning(activeGroups: DashboardGroup[]): BalanceWarning {
+  const { xlmBalance } = useBalance({ fetchOnMount: true });
+
+  return useMemo(() => {
+    const currentBalance = xlmBalance ? parseFloat(xlmBalance) : 0;
+    const requiredAmount = activeGroups
+      .filter((g) => g.status === 'active')
+      .reduce((sum, g) => sum + g.contributionAmount, 0);
+
+    const shortfall = Math.max(0, requiredAmount - currentBalance);
+
+    return {
+      isInsufficient: requiredAmount > 0 && currentBalance < requiredAmount,
+      currentBalance,
+      requiredAmount,
+      shortfall,
+    };
+  }, [xlmBalance, activeGroups]);
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -6,16 +6,22 @@ import { DashboardGroupCard } from '../components/dashboard/DashboardGroupCard';
 import { PayoutSchedule } from '../components/dashboard/PayoutSchedule';
 import { TransactionTable } from '../components/dashboard/TransactionTable';
 import { QuickActionSidebar } from '../components/dashboard/QuickActionSidebar';
+import { BalanceWarningBanner } from '../components/BalanceWarningBanner';
 import { useDashboard } from '../hooks/useDashboard';
+import { useBalanceWarning } from '../hooks/useBalanceWarning';
 
 function DashboardContent() {
   const { stats, groups, payouts, transactions, isLoading } = useDashboard();
+  const balanceWarning = useBalanceWarning(groups);
 
   return (
     <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', lg: '1fr 280px' }, gap: 3, alignItems: 'start' }}>
 
       {/* Left column */}
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+
+        {/* Balance warning banner */}
+        <BalanceWarningBanner warning={balanceWarning} />
 
         {/* 1. Overview hero */}
         <DashboardOverview stats={stats} isLoading={isLoading} />

--- a/frontend/src/test/BalanceWarningBanner.test.tsx
+++ b/frontend/src/test/BalanceWarningBanner.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BalanceWarningBanner } from '../components/BalanceWarningBanner';
+import type { BalanceWarning } from '../hooks/useBalanceWarning';
+
+const sufficientWarning: BalanceWarning = {
+  isInsufficient: false,
+  currentBalance: 1000,
+  requiredAmount: 500,
+  shortfall: 0,
+};
+
+const insufficientWarning: BalanceWarning = {
+  isInsufficient: true,
+  currentBalance: 200,
+  requiredAmount: 750,
+  shortfall: 550,
+};
+
+describe('BalanceWarningBanner', () => {
+  it('renders nothing when balance is sufficient', () => {
+    const { container } = render(<BalanceWarningBanner warning={sufficientWarning} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows warning when balance is insufficient', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText('Insufficient Balance')).toBeInTheDocument();
+  });
+
+  it('displays current balance', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText(/200\.00 XLM/)).toBeInTheDocument();
+  });
+
+  it('displays required amount', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText(/750\.00 XLM/)).toBeInTheDocument();
+  });
+
+  it('displays shortfall amount', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText(/550\.00 more XLM/)).toBeInTheDocument();
+  });
+
+  it('shows Fund Wallet button linking to stellar.org', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    const link = screen.getByRole('link', { name: /fund wallet/i });
+    expect(link).toHaveAttribute('href', 'https://www.stellar.org/lumens/wallets');
+  });
+
+  it('dismisses the banner when dismiss button is clicked', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText('Insufficient Balance')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /dismiss warning/i }));
+    expect(screen.queryByText('Insufficient Balance')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/useBalanceWarning.test.ts
+++ b/frontend/src/test/useBalanceWarning.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useBalanceWarning } from '../hooks/useBalanceWarning';
+import type { DashboardGroup } from '../types/dashboard';
+
+vi.mock('../hooks/useBalance', () => ({
+  useBalance: vi.fn(),
+}));
+
+import { useBalance } from '../hooks/useBalance';
+
+const mockUseBalance = useBalance as ReturnType<typeof vi.fn>;
+
+const activeGroups: DashboardGroup[] = [
+  { id: '1', name: 'Group A', currentCycle: 1, totalCycles: 5, contributionAmount: 300, currency: 'XLM', status: 'active' },
+  { id: '2', name: 'Group B', currentCycle: 2, totalCycles: 5, contributionAmount: 200, currency: 'XLM', status: 'active' },
+  { id: '3', name: 'Group C', currentCycle: 3, totalCycles: 5, contributionAmount: 100, currency: 'XLM', status: 'completed' },
+];
+
+describe('useBalanceWarning', () => {
+  it('returns isInsufficient=false when balance covers all active groups', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: '600' });
+    const { result } = renderHook(() => useBalanceWarning(activeGroups));
+    expect(result.current.isInsufficient).toBe(false);
+    expect(result.current.shortfall).toBe(0);
+  });
+
+  it('returns isInsufficient=true when balance is below required amount', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: '400' });
+    const { result } = renderHook(() => useBalanceWarning(activeGroups));
+    expect(result.current.isInsufficient).toBe(true);
+    expect(result.current.requiredAmount).toBe(500); // 300 + 200 (completed group excluded)
+    expect(result.current.shortfall).toBe(100);
+  });
+
+  it('treats null balance as 0', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: null });
+    const { result } = renderHook(() => useBalanceWarning(activeGroups));
+    expect(result.current.currentBalance).toBe(0);
+    expect(result.current.isInsufficient).toBe(true);
+    expect(result.current.shortfall).toBe(500);
+  });
+
+  it('returns isInsufficient=false when there are no active groups', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: '0' });
+    const { result } = renderHook(() => useBalanceWarning([]));
+    expect(result.current.isInsufficient).toBe(false);
+    expect(result.current.requiredAmount).toBe(0);
+  });
+
+  it('excludes completed and pending groups from required amount', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: '0' });
+    const groups: DashboardGroup[] = [
+      { id: '1', name: 'Done', currentCycle: 5, totalCycles: 5, contributionAmount: 999, currency: 'XLM', status: 'completed' },
+      { id: '2', name: 'Pending', currentCycle: 0, totalCycles: 5, contributionAmount: 999, currency: 'XLM', status: 'pending' },
+    ];
+    const { result } = renderHook(() => useBalanceWarning(groups));
+    expect(result.current.requiredAmount).toBe(0);
+    expect(result.current.isInsufficient).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #494  — wallet balance warnings on the dashboard.

## Changes

**`frontend/src/hooks/useBalanceWarning.ts`** (new)
- `useBalanceWarning(activeGroups)` hook: calls `useBalance` for the live XLM balance, sums contribution amounts for `active` groups only, and returns `{ isInsufficient, currentBalance, requiredAmount, shortfall }`

**`frontend/src/components/BalanceWarningBanner.tsx`** (new)
- Dismissible MUI `Alert` (severity=warning) rendered at the top of the dashboard left column
- Shows current balance, required amount, and exact shortfall
- "Fund Wallet" button links to `https://www.stellar.org/lumens/wallets`
- Dismiss button (✕) hides the banner for the session

**`frontend/src/pages/DashboardPage.tsx`** (modified)
- Imports `useBalanceWarning` and `BalanceWarningBanner`
- Renders `<BalanceWarningBanner>` above the overview hero in the left column

## Tests

- `src/test/useBalanceWarning.test.ts` — 5 tests
- `src/test/BalanceWarningBanner.test.tsx` — 7 tests

All 12 tests pass.