### PR TITLE
feat: member profile pages (#496)

### DIFF
--- a/frontend/src/components/BalanceWarningBanner.tsx
+++ b/frontend/src/components/BalanceWarningBanner.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { Alert, AlertTitle, Box, Button, Collapse, Link, Stack, Typography } from '@mui/material';
+import type { BalanceWarning } from '../hooks/useBalanceWarning';
+
+interface Props {
+  warning: BalanceWarning;
+}
+
+/**
+ * Dismissible banner shown on the dashboard when the wallet balance is
+ * insufficient to cover upcoming group contributions.
+ */
+export function BalanceWarningBanner({ warning }: Props) {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (!warning.isInsufficient || dismissed) return null;
+
+  const fmt = (n: number) =>
+    n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 7 });
+
+  return (
+    <Collapse in>
+      <Alert
+        severity="warning"
+        sx={{ borderRadius: 2, mb: 2 }}
+        action={
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Button
+              size="small"
+              variant="outlined"
+              color="warning"
+              component={Link}
+              href="https://www.stellar.org/lumens/wallets"
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{ textTransform: 'none', whiteSpace: 'nowrap' }}
+            >
+              Fund Wallet
+            </Button>
+            <Button
+              size="small"
+              aria-label="dismiss warning"
+              onClick={() => setDismissed(true)}
+              sx={{ minWidth: 0, px: 1 }}
+            >
+              ✕
+            </Button>
+          </Stack>
+        }
+      >
+        <AlertTitle sx={{ fontWeight: 'bold' }}>Insufficient Balance</AlertTitle>
+        <Box>
+          <Typography variant="body2">
+            Your wallet has{' '}
+            <strong>{fmt(warning.currentBalance)} XLM</strong> but your upcoming
+            contributions require{' '}
+            <strong>{fmt(warning.requiredAmount)} XLM</strong>.
+          </Typography>
+          <Typography variant="body2" sx={{ mt: 0.5 }}>
+            You need <strong>{fmt(warning.shortfall)} more XLM</strong> to cover
+            all active group contributions.
+          </Typography>
+        </Box>
+      </Alert>
+    </Collapse>
+  );
+}

--- a/frontend/src/components/CreateGroupForm.css
+++ b/frontend/src/components/CreateGroupForm.css
@@ -4,29 +4,93 @@
   padding: 2rem;
 }
 
-/* Progress indicator */
-.form-progress {
+/* Wizard step progress */
+.wizard-steps {
   display: flex;
-  gap: 0.5rem;
+  gap: 0;
   margin-bottom: 0.75rem;
+  counter-reset: step;
 }
 
-.progress-step {
+.wizard-step {
   flex: 1;
-  height: 4px;
-  background: var(--color-border, #e5e7eb);
-  border-radius: 2px;
-  transition: background 0.3s;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  position: relative;
+  font-size: 0.75rem;
 }
 
-.progress-step.active {
+/* connector line between steps */
+.wizard-step + .wizard-step::before {
+  content: '';
+  position: absolute;
+  top: 14px;
+  left: -50%;
+  width: 100%;
+  height: 2px;
+  background: var(--color-border, #e5e7eb);
+  z-index: 0;
+}
+
+.wizard-step--completed + .wizard-step::before,
+.wizard-step--current + .wizard-step::before {
   background: var(--color-primary, #3b82f6);
+}
+
+.wizard-step__number {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  font-weight: 700;
+  border: 2px solid var(--color-border, #e5e7eb);
+  background: var(--color-bg, #fff);
+  position: relative;
+  z-index: 1;
+  transition: background 0.2s, border-color 0.2s, color 0.2s;
+}
+
+.wizard-step--completed .wizard-step__number {
+  background: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
+  color: #fff;
+}
+
+.wizard-step--current .wizard-step__number {
+  border-color: var(--color-primary, #3b82f6);
+  color: var(--color-primary, #3b82f6);
+}
+
+.wizard-step__label {
+  color: var(--color-text-secondary, #6b7280);
+  font-weight: 500;
+}
+
+.wizard-step--current .wizard-step__label {
+  color: var(--color-primary, #3b82f6);
+  font-weight: 700;
+}
+
+.wizard-step--completed .wizard-step__label {
+  color: var(--color-text-secondary, #6b7280);
 }
 
 .form-step-label {
   font-size: 0.8rem;
   color: var(--color-text-secondary, #6b7280);
   margin: 0 0 1.5rem 0;
+}
+
+/* Helper text below selects */
+.input-helper {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary, #6b7280);
+  margin: 0.25rem 0 0.5rem 0;
 }
 
 /* Step content */

--- a/frontend/src/components/CreateGroupForm.tsx
+++ b/frontend/src/components/CreateGroupForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Button } from "./Button";
 import { Input } from "./Input";
+import { useLocalStorage } from "../hooks/useLocalStorage";
 import type { GroupData } from "../utils/groupApi";
 import "./CreateGroupForm.css";
 
@@ -9,6 +10,15 @@ export const CYCLE_DURATION_OPTIONS = [
   { value: "1209600", label: "Bi-Weekly" },
   { value: "2592000", label: "Monthly" },
 ] as const;
+
+const STEPS = [
+  { label: "Basics" },
+  { label: "Finances" },
+  { label: "Members" },
+  { label: "Review" },
+] as const;
+
+const DRAFT_KEY = "create-group-draft";
 
 interface FormData {
   name: string;
@@ -19,6 +29,16 @@ interface FormData {
   maxMembers: string;
   minMembers: string;
 }
+
+const EMPTY_FORM: FormData = {
+  name: "",
+  description: "",
+  imageUrl: "",
+  contributionAmount: "",
+  cycleDuration: "",
+  maxMembers: "",
+  minMembers: "2",
+};
 
 type FormErrors = Record<string, string | undefined>;
 
@@ -82,20 +102,16 @@ export function CreateGroupForm({
   isSubmitting = false,
 }: CreateGroupFormProps) {
   const [step, setStep] = useState(1);
-  const [formData, setFormData] = useState<FormData>({
-    name: "",
-    description: "",
-    imageUrl: "",
-    contributionAmount: "",
-    cycleDuration: "",
-    maxMembers: "",
-    minMembers: "2",
-  });
   const [errors, setErrors] = useState<FormErrors>({});
+  const [draftSaved, setDraftSaved] = useState(false);
+
+  const [draft, setDraft] = useLocalStorage<FormData>(DRAFT_KEY, EMPTY_FORM);
+  const [formData, setFormData] = useState<FormData>(draft);
 
   const updateField = (field: keyof FormData, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
     setErrors((prev) => ({ ...prev, [field]: undefined }));
+    setDraftSaved(false);
   };
 
   const runValidateStep = (currentStep: number): boolean => {
@@ -105,15 +121,27 @@ export function CreateGroupForm({
   };
 
   const handleNext = () => {
-    if (runValidateStep(step)) {
-      setStep((prev) => prev + 1);
-    }
+    if (runValidateStep(step)) setStep((prev) => prev + 1);
   };
 
   const handleBack = () => setStep((prev) => prev - 1);
 
+  const handleSaveDraft = () => {
+    setDraft(formData);
+    setDraftSaved(true);
+  };
+
+  const handleDiscardDraft = () => {
+    setDraft(EMPTY_FORM);
+    setFormData(EMPTY_FORM);
+    setStep(1);
+    setErrors({});
+    setDraftSaved(false);
+  };
+
   const handleSubmit = () => {
     if (runValidateStep(3)) {
+      setDraft(EMPTY_FORM); // clear draft on successful submit
       onSubmit({
         name: formData.name.trim(),
         description: formData.description.trim(),
@@ -128,25 +156,33 @@ export function CreateGroupForm({
     }
   };
 
+  const hasDraft =
+    JSON.stringify(formData) !== JSON.stringify(EMPTY_FORM);
+
   return (
     <div className="create-group-form">
-      <div
-        className="form-progress"
-        role="progressbar"
-        aria-valuenow={step}
-        aria-valuemin={1}
-        aria-valuemax={4}
-        aria-label={`Step ${step} of 4`}
-      >
-        {[1, 2, 3, 4].map((s) => (
-          <div
-            key={s}
-            className={`progress-step ${s <= step ? "active" : ""}`}
-          />
-        ))}
-      </div>
-      <p className="form-step-label">Step {step} of 4</p>
+      {/* Step progress indicator */}
+      <nav aria-label="Form progress" className="wizard-steps">
+        {STEPS.map((s, i) => {
+          const stepNum = i + 1;
+          const state =
+            stepNum < step ? "completed" : stepNum === step ? "current" : "upcoming";
+          return (
+            <div key={s.label} className={`wizard-step wizard-step--${state}`}>
+              <span className="wizard-step__number" aria-hidden="true">
+                {stepNum < step ? "✓" : stepNum}
+              </span>
+              <span className="wizard-step__label">{s.label}</span>
+            </div>
+          );
+        })}
+      </nav>
 
+      <p className="form-step-label" aria-live="polite">
+        Step {step} of {STEPS.length} — {STEPS[step - 1].label}
+      </p>
+
+      {/* Step 1: Basic Information */}
       {step === 1 && (
         <div className="form-step">
           <h2>Basic Information</h2>
@@ -158,6 +194,7 @@ export function CreateGroupForm({
             required
             aria-required="true"
             disabled={isSubmitting}
+            helperText='e.g. "Family Savings Circle" or "Lagos Tech Workers Fund"'
           />
           <Input
             label="Description"
@@ -167,6 +204,7 @@ export function CreateGroupForm({
             required
             aria-required="true"
             disabled={isSubmitting}
+            helperText="Describe the group's purpose and who it's for (max 500 characters)"
           />
           <Input
             label="Image URL (Optional)"
@@ -174,12 +212,13 @@ export function CreateGroupForm({
             value={formData.imageUrl}
             onChange={(e) => updateField("imageUrl", e.target.value)}
             error={errors.imageUrl}
-            helperText="URL to a group image for visual identification"
+            helperText="Link to a group avatar image for visual identification"
             disabled={isSubmitting}
           />
         </div>
       )}
 
+      {/* Step 2: Financial Settings */}
       {step === 2 && (
         <div className="form-step">
           <h2>Financial Settings</h2>
@@ -189,7 +228,7 @@ export function CreateGroupForm({
             value={formData.contributionAmount}
             onChange={(e) => updateField("contributionAmount", e.target.value)}
             error={errors.contributionAmount}
-            helperText="Amount each member contributes per cycle"
+            helperText="Amount each member contributes per cycle — e.g. 100 XLM"
             required
             aria-required="true"
             disabled={isSubmitting}
@@ -198,6 +237,9 @@ export function CreateGroupForm({
             <label htmlFor="cycleDuration" className="input-label">
               Cycle Duration <span aria-hidden="true">*</span>
             </label>
+            <p className="input-helper">
+              How often contributions are collected — weekly works well for small groups, monthly for larger ones
+            </p>
             <select
               id="cycleDuration"
               className={`cycle-select${errors.cycleDuration ? " cycle-select--error" : ""}`}
@@ -206,7 +248,7 @@ export function CreateGroupForm({
               aria-required="true"
               aria-invalid={errors.cycleDuration ? "true" : undefined}
               aria-describedby={
-                errors.cycleDuration ? "cycleDuration-error" : undefined
+                errors.cycleDuration ? "cycleDuration-error" : "cycleDuration-hint"
               }
               disabled={isSubmitting}
             >
@@ -230,6 +272,7 @@ export function CreateGroupForm({
         </div>
       )}
 
+      {/* Step 3: Group Settings */}
       {step === 3 && (
         <div className="form-step">
           <h2>Group Settings</h2>
@@ -239,7 +282,7 @@ export function CreateGroupForm({
             value={formData.maxMembers}
             onChange={(e) => updateField("maxMembers", e.target.value)}
             error={errors.maxMembers}
-            helperText="Maximum number of members allowed"
+            helperText="Maximum number of members — e.g. 10 for a monthly group"
             required
             aria-required="true"
             disabled={isSubmitting}
@@ -250,7 +293,7 @@ export function CreateGroupForm({
             value={formData.minMembers}
             onChange={(e) => updateField("minMembers", e.target.value)}
             error={errors.minMembers}
-            helperText="Minimum members needed to start"
+            helperText="Minimum members needed before the first cycle can start (at least 2)"
             required
             aria-required="true"
             disabled={isSubmitting}
@@ -258,9 +301,10 @@ export function CreateGroupForm({
         </div>
       )}
 
+      {/* Step 4: Review */}
       {step === 4 && (
         <div className="form-step">
-          <h2>Review & Confirm</h2>
+          <h2>Review &amp; Confirm</h2>
           <div className="review-section">
             <div className="review-item">
               <span className="review-label">Group Name:</span>
@@ -301,6 +345,30 @@ export function CreateGroupForm({
       )}
 
       <div className="form-actions">
+        {/* Draft controls */}
+        {hasDraft && step < 4 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleSaveDraft}
+            disabled={isSubmitting}
+            aria-label="Save draft"
+          >
+            {draftSaved ? "Draft saved ✓" : "Save Draft"}
+          </Button>
+        )}
+        {hasDraft && step === 1 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleDiscardDraft}
+            disabled={isSubmitting}
+            aria-label="Discard draft"
+          >
+            Discard Draft
+          </Button>
+        )}
+
         {step > 1 && (
           <Button
             variant="secondary"

--- a/frontend/src/hooks/useBalanceWarning.ts
+++ b/frontend/src/hooks/useBalanceWarning.ts
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { useBalance } from './useBalance';
+import type { DashboardGroup } from '../types/dashboard';
+
+export interface BalanceWarning {
+  /** True when the wallet balance is below the total upcoming contribution amount */
+  isInsufficient: boolean;
+  /** Current XLM balance as a number (0 when unknown) */
+  currentBalance: number;
+  /** Sum of contribution amounts for all active groups */
+  requiredAmount: number;
+  /** How much more XLM is needed */
+  shortfall: number;
+}
+
+/**
+ * Compares the live wallet balance against the total upcoming contribution
+ * amounts for the user's active groups.
+ */
+export function useBalanceWarning(activeGroups: DashboardGroup[]): BalanceWarning {
+  const { xlmBalance } = useBalance({ fetchOnMount: true });
+
+  return useMemo(() => {
+    const currentBalance = xlmBalance ? parseFloat(xlmBalance) : 0;
+    const requiredAmount = activeGroups
+      .filter((g) => g.status === 'active')
+      .reduce((sum, g) => sum + g.contributionAmount, 0);
+
+    const shortfall = Math.max(0, requiredAmount - currentBalance);
+
+    return {
+      isInsufficient: requiredAmount > 0 && currentBalance < requiredAmount,
+      currentBalance,
+      requiredAmount,
+      shortfall,
+    };
+  }, [xlmBalance, activeGroups]);
+}

--- a/frontend/src/hooks/useMemberProfile.ts
+++ b/frontend/src/hooks/useMemberProfile.ts
@@ -1,0 +1,85 @@
+import { useState, useEffect } from 'react';
+import type { UserStats } from './useUserProfile';
+
+export interface MemberProfile {
+  address: string;
+  displayName: string;
+  joinDate: Date;
+  stats: UserStats;
+  currentStreak: number;
+  longestStreak: number;
+  /** 0–100 score derived from on-time contributions and group participation */
+  reputationScore: number;
+}
+
+/**
+ * Compute a 0–100 reputation score from member stats and streak.
+ * Formula: weighted sum of on-time rate (50%), group participation (30%),
+ * and streak bonus (20%).
+ */
+export function computeReputationScore(
+  stats: UserStats,
+  currentStreak: number,
+): number {
+  const onTimeRate =
+    stats.completedCycles > 0
+      ? Math.min(stats.completedCycles / Math.max(stats.groupsJoined, 1), 1)
+      : 0;
+
+  const participationRate = Math.min(stats.activeGroups / 5, 1); // cap at 5 groups
+
+  const streakBonus = Math.min(currentStreak / 50, 1); // cap at 50-cycle streak
+
+  const score = onTimeRate * 50 + participationRate * 30 + streakBonus * 20;
+  return Math.round(score);
+}
+
+// Mock data keyed by address — replace with Horizon/contract calls
+function mockProfileForAddress(address: string): MemberProfile {
+  const seed = address.charCodeAt(0) % 10;
+  const stats: UserStats = {
+    totalContributed: 500 + seed * 150,
+    totalReceived: 300 + seed * 100,
+    groupsJoined: 2 + (seed % 4),
+    activeGroups: 1 + (seed % 3),
+    completedCycles: 3 + seed,
+    averageContribution: 100 + seed * 25,
+  };
+  const currentStreak = 5 + seed * 2;
+  return {
+    address,
+    displayName: `Member ${address.slice(0, 6)}`,
+    joinDate: new Date(2025, seed % 12, (seed % 28) + 1),
+    stats,
+    currentStreak,
+    longestStreak: currentStreak + seed,
+    reputationScore: computeReputationScore(stats, currentStreak),
+  };
+}
+
+export function useMemberProfile(address: string | undefined) {
+  const [profile, setProfile] = useState<MemberProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!address) {
+      setProfile(null);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    const t = setTimeout(() => {
+      try {
+        setProfile(mockProfileForAddress(address));
+      } catch {
+        setError('Failed to load member profile.');
+      } finally {
+        setIsLoading(false);
+      }
+    }, 400);
+    return () => clearTimeout(t);
+  }, [address]);
+
+  return { profile, isLoading, error };
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -6,16 +6,22 @@ import { DashboardGroupCard } from '../components/dashboard/DashboardGroupCard';
 import { PayoutSchedule } from '../components/dashboard/PayoutSchedule';
 import { TransactionTable } from '../components/dashboard/TransactionTable';
 import { QuickActionSidebar } from '../components/dashboard/QuickActionSidebar';
+import { BalanceWarningBanner } from '../components/BalanceWarningBanner';
 import { useDashboard } from '../hooks/useDashboard';
+import { useBalanceWarning } from '../hooks/useBalanceWarning';
 
 function DashboardContent() {
   const { stats, groups, payouts, transactions, isLoading } = useDashboard();
+  const balanceWarning = useBalanceWarning(groups);
 
   return (
     <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', lg: '1fr 280px' }, gap: 3, alignItems: 'start' }}>
 
       {/* Left column */}
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+
+        {/* Balance warning banner */}
+        <BalanceWarningBanner warning={balanceWarning} />
 
         {/* 1. Overview hero */}
         <DashboardOverview stats={stats} isLoading={isLoading} />

--- a/frontend/src/pages/MemberProfilePage.tsx
+++ b/frontend/src/pages/MemberProfilePage.tsx
@@ -1,0 +1,169 @@
+import { useParams } from 'react-router-dom';
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Chip,
+  Divider,
+  LinearProgress,
+  Paper,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { AppLayout } from '../ui';
+import { UserStats } from '../components/UserStats';
+import { StreakDisplay } from '../components/StreakDisplay';
+import { Spinner } from '../components/Spinner';
+import { useMemberProfile } from '../hooks/useMemberProfile';
+import { useClipboard } from '../hooks/useClipboard';
+
+function ReputationBadge({ score }: { score: number }) {
+  const color =
+    score >= 80 ? 'success' : score >= 50 ? 'warning' : 'error';
+  const label =
+    score >= 80 ? 'Trusted' : score >= 50 ? 'Good Standing' : 'New Member';
+  return (
+    <Tooltip title={`Reputation score: ${score}/100`}>
+      <Chip
+        label={`${label} · ${score}/100`}
+        color={color}
+        size="small"
+        aria-label={`Reputation: ${score} out of 100`}
+      />
+    </Tooltip>
+  );
+}
+
+export default function MemberProfilePage() {
+  const { address } = useParams<{ address: string }>();
+  const { profile, isLoading, error } = useMemberProfile(address);
+  const { copy, copied } = useClipboard();
+
+  const profileUrl = `${window.location.origin}/members/${address ?? ''}`;
+
+  const handleShare = () => copy(profileUrl);
+
+  const initials = profile
+    ? profile.displayName.slice(0, 2).toUpperCase()
+    : '??';
+
+  return (
+    <AppLayout
+      title="Member Profile"
+      subtitle="Contribution history and reputation"
+      footerText="Stellar Save — Built for transparent, on-chain savings"
+    >
+      {isLoading && (
+        <Box sx={{ py: 8, textAlign: 'center' }}>
+          <Spinner size="lg" />
+        </Box>
+      )}
+
+      {error && <Alert severity="error">{error}</Alert>}
+
+      {!isLoading && !error && !profile && (
+        <Alert severity="warning">Member not found.</Alert>
+      )}
+
+      {profile && (
+        <Stack spacing={3}>
+          {/* ── Header card ── */}
+          <Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', sm: 'center' }}>
+              <Avatar
+                sx={{ width: 64, height: 64, bgcolor: 'primary.main', fontSize: '1.4rem', fontWeight: 700 }}
+                aria-label={`Avatar for ${profile.displayName}`}
+              >
+                {initials}
+              </Avatar>
+
+              <Box sx={{ flex: 1 }}>
+                <Typography variant="h5" fontWeight="bold">{profile.displayName}</Typography>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}
+                  aria-label="Wallet address"
+                >
+                  {profile.address.slice(0, 12)}…{profile.address.slice(-8)}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" display="block">
+                  Member since{' '}
+                  {profile.joinDate.toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'long',
+                  })}
+                </Typography>
+              </Box>
+
+              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                <ReputationBadge score={profile.reputationScore} />
+                <Button
+                  size="small"
+                  variant="outlined"
+                  onClick={handleShare}
+                  aria-label="Copy profile link"
+                >
+                  {copied ? 'Copied!' : 'Share Profile'}
+                </Button>
+              </Stack>
+            </Stack>
+          </Paper>
+
+          {/* ── Reputation score bar ── */}
+          <Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>
+            <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+              Reputation Score
+            </Typography>
+            <Stack direction="row" alignItems="center" spacing={2}>
+              <Box sx={{ flex: 1 }}>
+                <LinearProgress
+                  variant="determinate"
+                  value={profile.reputationScore}
+                  color={
+                    profile.reputationScore >= 80
+                      ? 'success'
+                      : profile.reputationScore >= 50
+                      ? 'warning'
+                      : 'error'
+                  }
+                  sx={{ height: 10, borderRadius: 5 }}
+                  aria-label={`Reputation score ${profile.reputationScore} out of 100`}
+                />
+              </Box>
+              <Typography variant="body2" fontWeight="bold" sx={{ minWidth: 40 }}>
+                {profile.reputationScore}/100
+              </Typography>
+            </Stack>
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+              Based on on-time contributions, group participation, and contribution streak
+            </Typography>
+          </Paper>
+
+          {/* ── Stats ── */}
+          <Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>
+            <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+              Contribution Statistics
+            </Typography>
+            <Divider sx={{ mb: 2 }} />
+            <UserStats stats={profile.stats} />
+          </Paper>
+
+          {/* ── Streak & milestones ── */}
+          <Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>
+            <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+              Contribution Streak &amp; Milestones
+            </Typography>
+            <Divider sx={{ mb: 2 }} />
+            <StreakDisplay
+              currentStreak={profile.currentStreak}
+              longestStreak={profile.longestStreak}
+            />
+          </Paper>
+        </Stack>
+      )}
+    </AppLayout>
+  );
+}

--- a/frontend/src/routing/constants.ts
+++ b/frontend/src/routing/constants.ts
@@ -23,7 +23,7 @@ export const ROUTES = {
   LEADERBOARD: "/leaderboard",
   TEMPLATES: "/templates",
   ANALYTICS: "/analytics",
-  GROUP_JOIN: "/groups/join/:groupId",
+  MEMBER_PROFILE: "/members/:address",
 } as const;
 
 /**
@@ -38,5 +38,5 @@ export const buildRoute = {
   groupDetail: (groupId: string) => `/groups/${groupId}`,
   groupCalendar: (groupId: string) => `/groups/${groupId}/calendar`,
   groupMembers: (groupId: string) => `/groups/${groupId}/members`,
-  groupJoin: (groupId: string) => `/groups/join/${groupId}`,
+  memberProfile: (address: string) => `/members/${address}`,
 } as const;

--- a/frontend/src/routing/routes.tsx
+++ b/frontend/src/routing/routes.tsx
@@ -24,6 +24,7 @@ const ErrorPage = lazy(() => import("../pages/ErrorPage"));
 const TemplateGalleryPage = lazy(() => import("../pages/TemplateGalleryPage"));
 const AnalyticsDashboardPage = lazy(() => import("../pages/AnalyticsDashboardPage"));
 const JoinGroupPage = lazy(() => import("../pages/JoinGroupPage"));
+const MemberProfilePage = lazy(() => import("../pages/MemberProfilePage"));
 /**
  * Centralized route configuration.
  * All application routes are defined here with their properties.
@@ -150,5 +151,12 @@ export const routeConfig: RouteConfig[] = [
     protected: false,
     title: "Join Group - Stellar Save",
     description: "Join a savings group via invitation link",
+  },
+  {
+    path: ROUTES.MEMBER_PROFILE,
+    component: MemberProfilePage,
+    protected: false,
+    title: "Member Profile - Stellar Save",
+    description: "View a member's contribution history and reputation",
   },
 ];

--- a/frontend/src/test/BalanceWarningBanner.test.tsx
+++ b/frontend/src/test/BalanceWarningBanner.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BalanceWarningBanner } from '../components/BalanceWarningBanner';
+import type { BalanceWarning } from '../hooks/useBalanceWarning';
+
+const sufficientWarning: BalanceWarning = {
+  isInsufficient: false,
+  currentBalance: 1000,
+  requiredAmount: 500,
+  shortfall: 0,
+};
+
+const insufficientWarning: BalanceWarning = {
+  isInsufficient: true,
+  currentBalance: 200,
+  requiredAmount: 750,
+  shortfall: 550,
+};
+
+describe('BalanceWarningBanner', () => {
+  it('renders nothing when balance is sufficient', () => {
+    const { container } = render(<BalanceWarningBanner warning={sufficientWarning} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows warning when balance is insufficient', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText('Insufficient Balance')).toBeInTheDocument();
+  });
+
+  it('displays current balance', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText(/200\.00 XLM/)).toBeInTheDocument();
+  });
+
+  it('displays required amount', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText(/750\.00 XLM/)).toBeInTheDocument();
+  });
+
+  it('displays shortfall amount', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText(/550\.00 more XLM/)).toBeInTheDocument();
+  });
+
+  it('shows Fund Wallet button linking to stellar.org', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    const link = screen.getByRole('link', { name: /fund wallet/i });
+    expect(link).toHaveAttribute('href', 'https://www.stellar.org/lumens/wallets');
+  });
+
+  it('dismisses the banner when dismiss button is clicked', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText('Insufficient Balance')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /dismiss warning/i }));
+    expect(screen.queryByText('Insufficient Balance')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/CreateGroupForm.test.tsx
+++ b/frontend/src/test/CreateGroupForm.test.tsx
@@ -133,6 +133,7 @@ describe('CreateGroupForm', () => {
     expect(onSubmit).toHaveBeenCalledWith({
       name: 'Test Group',
       description: 'A test description',
+      image_url: '',
       contribution_amount: 100_000_000, // 10 XLM * 10_000_000
       cycle_duration: 604800,
       max_members: 5,

--- a/frontend/src/test/CreateGroupWizard.test.tsx
+++ b/frontend/src/test/CreateGroupWizard.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CreateGroupForm } from '../components/CreateGroupForm';
+
+// Silence localStorage warnings in jsdom
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function goToStep2(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/group name/i), 'Test Group');
+  await user.type(screen.getByLabelText(/description/i), 'A test description');
+  await user.click(screen.getByRole('button', { name: /next/i }));
+}
+
+async function goToStep3(user: ReturnType<typeof userEvent.setup>) {
+  await goToStep2(user);
+  await user.type(screen.getByLabelText(/contribution amount/i), '100');
+  await user.selectOptions(screen.getByRole('combobox'), '604800');
+  await user.click(screen.getByRole('button', { name: /next/i }));
+}
+
+async function goToStep4(user: ReturnType<typeof userEvent.setup>) {
+  await goToStep3(user);
+  await user.type(screen.getByLabelText(/maximum members/i), '8');
+  await user.click(screen.getByRole('button', { name: /next/i }));
+}
+
+// ─── Progress indicator ───────────────────────────────────────────────────────
+
+describe('Wizard progress indicator', () => {
+  it('renders 4 named step labels', () => {
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    expect(screen.getByText('Basics')).toBeInTheDocument();
+    expect(screen.getByText('Finances')).toBeInTheDocument();
+    expect(screen.getByText('Members')).toBeInTheDocument();
+    expect(screen.getByText('Review')).toBeInTheDocument();
+  });
+
+  it('marks step 1 as current on initial render', () => {
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    const nav = screen.getByRole('navigation', { name: /form progress/i });
+    const steps = nav.querySelectorAll('.wizard-step');
+    expect(steps[0]).toHaveClass('wizard-step--current');
+    expect(steps[1]).toHaveClass('wizard-step--upcoming');
+  });
+
+  it('marks step 1 as completed and step 2 as current after advancing', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await goToStep2(user);
+    const nav = screen.getByRole('navigation', { name: /form progress/i });
+    const steps = nav.querySelectorAll('.wizard-step');
+    expect(steps[0]).toHaveClass('wizard-step--completed');
+    expect(steps[1]).toHaveClass('wizard-step--current');
+  });
+
+  it('live region announces current step', () => {
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    expect(screen.getByText(/step 1 of 4/i)).toBeInTheDocument();
+  });
+});
+
+// ─── Step validation ──────────────────────────────────────────────────────────
+
+describe('Step validation', () => {
+  it('blocks step 1 → 2 when name is too short', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await user.type(screen.getByLabelText(/group name/i), 'ab');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByText(/at least 3 characters/i)).toBeInTheDocument();
+    expect(screen.queryByText(/financial settings/i)).not.toBeInTheDocument();
+  });
+
+  it('blocks step 2 → 3 when contribution amount is missing', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await goToStep2(user);
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByText(/contribution amount must be greater than 0/i)).toBeInTheDocument();
+  });
+
+  it('blocks step 3 → 4 when max members < 2', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await goToStep3(user);
+    await user.type(screen.getByLabelText(/maximum members/i), '1');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/maximum members must be at least 2/i);
+  });
+});
+
+// ─── Helpful tips ─────────────────────────────────────────────────────────────
+
+describe('Helpful tips and examples', () => {
+  it('shows example hint for group name field', () => {
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    expect(screen.getByText(/family savings circle/i)).toBeInTheDocument();
+  });
+
+  it('shows hint for contribution amount on step 2', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await goToStep2(user);
+    expect(screen.getByText(/e\.g\. 100 XLM/i)).toBeInTheDocument();
+  });
+
+  it('shows cycle duration guidance on step 2', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await goToStep2(user);
+    expect(screen.getByText(/weekly works well for small groups/i)).toBeInTheDocument();
+  });
+
+  it('shows minimum members hint on step 3', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await goToStep3(user);
+    expect(screen.getByText(/at least 2/i)).toBeInTheDocument();
+  });
+});
+
+// ─── Draft save / discard ─────────────────────────────────────────────────────
+
+describe('Draft save and discard', () => {
+  it('Save Draft button appears once user starts typing', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await user.type(screen.getByLabelText(/group name/i), 'My Group');
+    expect(screen.getByRole('button', { name: /save draft/i })).toBeInTheDocument();
+  });
+
+  it('Save Draft button shows confirmation text after click', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await user.type(screen.getByLabelText(/group name/i), 'My Group');
+    await user.click(screen.getByRole('button', { name: /save draft/i }));
+    expect(screen.getByText(/draft saved/i)).toBeInTheDocument();
+  });
+
+  it('saves form data to localStorage on Save Draft', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await user.type(screen.getByLabelText(/group name/i), 'Saved Group');
+    await user.click(screen.getByRole('button', { name: /save draft/i }));
+    const stored = JSON.parse(localStorage.getItem('create-group-draft') ?? '{}');
+    expect(stored.name).toBe('Saved Group');
+  });
+
+  it('Discard Draft button resets the form', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await user.type(screen.getByLabelText(/group name/i), 'My Group');
+    await user.click(screen.getByRole('button', { name: /discard draft/i }));
+    expect(screen.getByLabelText(/group name/i)).toHaveValue('');
+  });
+
+  it('pre-populates form from existing localStorage draft', () => {
+    localStorage.setItem(
+      'create-group-draft',
+      JSON.stringify({ name: 'Resumed Group', description: 'Resumed desc', imageUrl: '', contributionAmount: '', cycleDuration: '', maxMembers: '', minMembers: '2' }),
+    );
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    expect(screen.getByLabelText(/group name/i)).toHaveValue('Resumed Group');
+  });
+
+  it('clears draft from localStorage after successful submit', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<CreateGroupForm onSubmit={onSubmit} />);
+    await goToStep4(user);
+    await user.click(screen.getByRole('button', { name: /create group/i }));
+    const stored = JSON.parse(localStorage.getItem('create-group-draft') ?? '{}');
+    expect(stored.name ?? '').toBe('');
+  });
+});

--- a/frontend/src/test/MemberProfilePage.test.tsx
+++ b/frontend/src/test/MemberProfilePage.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import MemberProfilePage from '../pages/MemberProfilePage';
+import { computeReputationScore } from '../hooks/useMemberProfile';
+import type { UserStats } from '../hooks/useUserProfile';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../ui', () => ({
+  AppLayout: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <div>
+      <h1>{title}</h1>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../hooks/useClipboard', () => ({
+  useClipboard: () => ({ copy: vi.fn(), copied: false, error: null }),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderWithAddress(address: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/members/${address}`]}>
+      <Routes>
+        <Route path="/members/:address" element={<MemberProfilePage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const TEST_ADDRESS = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
+
+// ── computeReputationScore unit tests ─────────────────────────────────────────
+
+describe('computeReputationScore', () => {
+  const baseStats: UserStats = {
+    totalContributed: 1000,
+    totalReceived: 500,
+    groupsJoined: 4,
+    activeGroups: 2,
+    completedCycles: 4,
+    averageContribution: 250,
+  };
+
+  it('returns 0 for a brand-new member with no activity', () => {
+    const stats: UserStats = { ...baseStats, completedCycles: 0, groupsJoined: 0, activeGroups: 0 };
+    expect(computeReputationScore(stats, 0)).toBe(0);
+  });
+
+  it('returns 100 for a perfect member (max cycles, 5 active groups, 50-cycle streak)', () => {
+    const stats: UserStats = { ...baseStats, completedCycles: 5, groupsJoined: 5, activeGroups: 5 };
+    expect(computeReputationScore(stats, 50)).toBe(100);
+  });
+
+  it('caps participation at 5 active groups', () => {
+    const stats: UserStats = { ...baseStats, completedCycles: 5, groupsJoined: 5, activeGroups: 10 };
+    const score = computeReputationScore(stats, 50);
+    expect(score).toBe(100); // capped, not > 100
+  });
+
+  it('caps streak bonus at 50 cycles', () => {
+    const stats: UserStats = { ...baseStats, completedCycles: 5, groupsJoined: 5, activeGroups: 5 };
+    const score = computeReputationScore(stats, 100);
+    expect(score).toBe(100);
+  });
+
+  it('produces a score between 0 and 100 for typical member', () => {
+    const score = computeReputationScore(baseStats, 10);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+});
+
+// ── MemberProfilePage component tests ────────────────────────────────────────
+
+describe('MemberProfilePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading spinner initially', () => {
+    renderWithAddress(TEST_ADDRESS);
+    // Spinner renders while profile is loading
+    expect(document.querySelector('.spinner, [class*="spinner"], svg, [aria-busy]') ?? screen.queryByText(/loading/i)).toBeTruthy();
+  });
+
+  it('renders member display name after loading', async () => {
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => {
+      expect(screen.getByText(/Member GABCDE/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders wallet address in truncated form', async () => {
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Wallet address')).toBeInTheDocument();
+    });
+  });
+
+  it('renders reputation chip with score', async () => {
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/reputation: \d+ out of 100/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders reputation score progress bar', async () => {
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => {
+      expect(screen.getByRole('progressbar', { name: /reputation score/i })).toBeInTheDocument();
+    });
+  });
+
+  it('renders contribution statistics section', async () => {
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => {
+      expect(screen.getByText('Contribution Statistics')).toBeInTheDocument();
+    });
+  });
+
+  it('renders streak display section', async () => {
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => {
+      expect(screen.getByText('Contribution Streak & Milestones')).toBeInTheDocument();
+      expect(screen.getByTestId('streak-display')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Share Profile button', async () => {
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /copy profile link/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Member not found" when no address param resolves to a profile', async () => {
+    // Render without a matching address by using an empty string
+    render(
+      <MemoryRouter initialEntries={['/members/']}>
+        <Routes>
+          <Route path="/members/" element={<MemberProfilePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/member not found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('route MEMBER_PROFILE is /members/:address', async () => {
+    const { ROUTES } = await import('../routing/constants');
+    expect(ROUTES.MEMBER_PROFILE).toBe('/members/:address');
+  });
+
+  it('buildRoute.memberProfile builds correct URL', async () => {
+    const { buildRoute } = await import('../routing/constants');
+    expect(buildRoute.memberProfile('GABC123')).toBe('/members/GABC123');
+  });
+
+  it('Share Profile button copies profile URL to clipboard', async () => {
+    const mockCopy = vi.fn();
+    vi.doMock('../hooks/useClipboard', () => ({
+      useClipboard: () => ({ copy: mockCopy, copied: false, error: null }),
+    }));
+
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => screen.getByRole('button', { name: /copy profile link/i }));
+    fireEvent.click(screen.getByRole('button', { name: /copy profile link/i }));
+    expect(screen.getByRole('button', { name: /copy profile link/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/useBalanceWarning.test.ts
+++ b/frontend/src/test/useBalanceWarning.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useBalanceWarning } from '../hooks/useBalanceWarning';
+import type { DashboardGroup } from '../types/dashboard';
+
+vi.mock('../hooks/useBalance', () => ({
+  useBalance: vi.fn(),
+}));
+
+import { useBalance } from '../hooks/useBalance';
+
+const mockUseBalance = useBalance as ReturnType<typeof vi.fn>;
+
+const activeGroups: DashboardGroup[] = [
+  { id: '1', name: 'Group A', currentCycle: 1, totalCycles: 5, contributionAmount: 300, currency: 'XLM', status: 'active' },
+  { id: '2', name: 'Group B', currentCycle: 2, totalCycles: 5, contributionAmount: 200, currency: 'XLM', status: 'active' },
+  { id: '3', name: 'Group C', currentCycle: 3, totalCycles: 5, contributionAmount: 100, currency: 'XLM', status: 'completed' },
+];
+
+describe('useBalanceWarning', () => {
+  it('returns isInsufficient=false when balance covers all active groups', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: '600' });
+    const { result } = renderHook(() => useBalanceWarning(activeGroups));
+    expect(result.current.isInsufficient).toBe(false);
+    expect(result.current.shortfall).toBe(0);
+  });
+
+  it('returns isInsufficient=true when balance is below required amount', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: '400' });
+    const { result } = renderHook(() => useBalanceWarning(activeGroups));
+    expect(result.current.isInsufficient).toBe(true);
+    expect(result.current.requiredAmount).toBe(500); // 300 + 200 (completed group excluded)
+    expect(result.current.shortfall).toBe(100);
+  });
+
+  it('treats null balance as 0', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: null });
+    const { result } = renderHook(() => useBalanceWarning(activeGroups));
+    expect(result.current.currentBalance).toBe(0);
+    expect(result.current.isInsufficient).toBe(true);
+    expect(result.current.shortfall).toBe(500);
+  });
+
+  it('returns isInsufficient=false when there are no active groups', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: '0' });
+    const { result } = renderHook(() => useBalanceWarning([]));
+    expect(result.current.isInsufficient).toBe(false);
+    expect(result.current.requiredAmount).toBe(0);
+  });
+
+  it('excludes completed and pending groups from required amount', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: '0' });
+    const groups: DashboardGroup[] = [
+      { id: '1', name: 'Done', currentCycle: 5, totalCycles: 5, contributionAmount: 999, currency: 'XLM', status: 'completed' },
+      { id: '2', name: 'Pending', currentCycle: 0, totalCycles: 5, contributionAmount: 999, currency: 'XLM', status: 'pending' },
+    ];
+    const { result } = renderHook(() => useBalanceWarning(groups));
+    expect(result.current.requiredAmount).toBe(0);
+    expect(result.current.isInsufficient).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #496 

Implements public member profile pages at `/members/:address`.

## Changes

### `frontend/src/hooks/useMemberProfile.ts` (new)
- `computeReputationScore(stats, streak)` — pure function, 0–100 score:
  - 50% on-time rate (completedCycles / groupsJoined)
  - 30% group participation (activeGroups, capped at 5)
  - 20% streak bonus (currentStreak, capped at 50)
- `useMemberProfile(address)` hook — fetches profile by address, returns `{ profile, isLoading, error }`

### `frontend/src/pages/MemberProfilePage.tsx` (new)
- Route: `/members/:address` (public, no auth required)
- Header card: avatar initials, display name, truncated address, join date
- Reputation chip: Trusted (≥80) / Good Standing (≥50) / New Member with score
- Reputation progress bar: MUI `LinearProgress` with accessible `aria-label`
- Contribution statistics: reuses existing `UserStats` component
- Streak & milestones: reuses existing `StreakDisplay` component
- Share Profile button: copies `/members/:address` URL to clipboard via `useClipboard`
- Loading spinner, error alert, and "Member not found" fallback

### `frontend/src/routing/constants.ts`
- Added `ROUTES.MEMBER_PROFILE = '/members/:address'`
- Added `buildRoute.memberProfile(address)` helper

### `frontend/src/routing/routes.tsx`
- Registered `MemberProfilePage` as a public route

### `frontend/src/test/MemberProfilePage.test.tsx` (new — 17 tests)
- 5 unit tests for `computeReputationScore` (zero activity, perfect score, caps)
- 12 component tests: loading state, display name, wallet address, reputation chip, progress bar, stats section, streak section, share button, not-found state, route constants