### PR TITLE
feat: transaction history export (#497)

### DIFF
--- a/frontend/src/components/BalanceWarningBanner.tsx
+++ b/frontend/src/components/BalanceWarningBanner.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { Alert, AlertTitle, Box, Button, Collapse, Link, Stack, Typography } from '@mui/material';
+import type { BalanceWarning } from '../hooks/useBalanceWarning';
+
+interface Props {
+  warning: BalanceWarning;
+}
+
+/**
+ * Dismissible banner shown on the dashboard when the wallet balance is
+ * insufficient to cover upcoming group contributions.
+ */
+export function BalanceWarningBanner({ warning }: Props) {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (!warning.isInsufficient || dismissed) return null;
+
+  const fmt = (n: number) =>
+    n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 7 });
+
+  return (
+    <Collapse in>
+      <Alert
+        severity="warning"
+        sx={{ borderRadius: 2, mb: 2 }}
+        action={
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Button
+              size="small"
+              variant="outlined"
+              color="warning"
+              component={Link}
+              href="https://www.stellar.org/lumens/wallets"
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{ textTransform: 'none', whiteSpace: 'nowrap' }}
+            >
+              Fund Wallet
+            </Button>
+            <Button
+              size="small"
+              aria-label="dismiss warning"
+              onClick={() => setDismissed(true)}
+              sx={{ minWidth: 0, px: 1 }}
+            >
+              ✕
+            </Button>
+          </Stack>
+        }
+      >
+        <AlertTitle sx={{ fontWeight: 'bold' }}>Insufficient Balance</AlertTitle>
+        <Box>
+          <Typography variant="body2">
+            Your wallet has{' '}
+            <strong>{fmt(warning.currentBalance)} XLM</strong> but your upcoming
+            contributions require{' '}
+            <strong>{fmt(warning.requiredAmount)} XLM</strong>.
+          </Typography>
+          <Typography variant="body2" sx={{ mt: 0.5 }}>
+            You need <strong>{fmt(warning.shortfall)} more XLM</strong> to cover
+            all active group contributions.
+          </Typography>
+        </Box>
+      </Alert>
+    </Collapse>
+  );
+}

--- a/frontend/src/components/CreateGroupForm.css
+++ b/frontend/src/components/CreateGroupForm.css
@@ -4,29 +4,93 @@
   padding: 2rem;
 }
 
-/* Progress indicator */
-.form-progress {
+/* Wizard step progress */
+.wizard-steps {
   display: flex;
-  gap: 0.5rem;
+  gap: 0;
   margin-bottom: 0.75rem;
+  counter-reset: step;
 }
 
-.progress-step {
+.wizard-step {
   flex: 1;
-  height: 4px;
-  background: var(--color-border, #e5e7eb);
-  border-radius: 2px;
-  transition: background 0.3s;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  position: relative;
+  font-size: 0.75rem;
 }
 
-.progress-step.active {
+/* connector line between steps */
+.wizard-step + .wizard-step::before {
+  content: '';
+  position: absolute;
+  top: 14px;
+  left: -50%;
+  width: 100%;
+  height: 2px;
+  background: var(--color-border, #e5e7eb);
+  z-index: 0;
+}
+
+.wizard-step--completed + .wizard-step::before,
+.wizard-step--current + .wizard-step::before {
   background: var(--color-primary, #3b82f6);
+}
+
+.wizard-step__number {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  font-weight: 700;
+  border: 2px solid var(--color-border, #e5e7eb);
+  background: var(--color-bg, #fff);
+  position: relative;
+  z-index: 1;
+  transition: background 0.2s, border-color 0.2s, color 0.2s;
+}
+
+.wizard-step--completed .wizard-step__number {
+  background: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
+  color: #fff;
+}
+
+.wizard-step--current .wizard-step__number {
+  border-color: var(--color-primary, #3b82f6);
+  color: var(--color-primary, #3b82f6);
+}
+
+.wizard-step__label {
+  color: var(--color-text-secondary, #6b7280);
+  font-weight: 500;
+}
+
+.wizard-step--current .wizard-step__label {
+  color: var(--color-primary, #3b82f6);
+  font-weight: 700;
+}
+
+.wizard-step--completed .wizard-step__label {
+  color: var(--color-text-secondary, #6b7280);
 }
 
 .form-step-label {
   font-size: 0.8rem;
   color: var(--color-text-secondary, #6b7280);
   margin: 0 0 1.5rem 0;
+}
+
+/* Helper text below selects */
+.input-helper {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary, #6b7280);
+  margin: 0.25rem 0 0.5rem 0;
 }
 
 /* Step content */

--- a/frontend/src/components/CreateGroupForm.tsx
+++ b/frontend/src/components/CreateGroupForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Button } from "./Button";
 import { Input } from "./Input";
+import { useLocalStorage } from "../hooks/useLocalStorage";
 import type { GroupData } from "../utils/groupApi";
 import "./CreateGroupForm.css";
 
@@ -9,6 +10,15 @@ export const CYCLE_DURATION_OPTIONS = [
   { value: "1209600", label: "Bi-Weekly" },
   { value: "2592000", label: "Monthly" },
 ] as const;
+
+const STEPS = [
+  { label: "Basics" },
+  { label: "Finances" },
+  { label: "Members" },
+  { label: "Review" },
+] as const;
+
+const DRAFT_KEY = "create-group-draft";
 
 interface FormData {
   name: string;
@@ -19,6 +29,16 @@ interface FormData {
   maxMembers: string;
   minMembers: string;
 }
+
+const EMPTY_FORM: FormData = {
+  name: "",
+  description: "",
+  imageUrl: "",
+  contributionAmount: "",
+  cycleDuration: "",
+  maxMembers: "",
+  minMembers: "2",
+};
 
 type FormErrors = Record<string, string | undefined>;
 
@@ -82,20 +102,16 @@ export function CreateGroupForm({
   isSubmitting = false,
 }: CreateGroupFormProps) {
   const [step, setStep] = useState(1);
-  const [formData, setFormData] = useState<FormData>({
-    name: "",
-    description: "",
-    imageUrl: "",
-    contributionAmount: "",
-    cycleDuration: "",
-    maxMembers: "",
-    minMembers: "2",
-  });
   const [errors, setErrors] = useState<FormErrors>({});
+  const [draftSaved, setDraftSaved] = useState(false);
+
+  const [draft, setDraft] = useLocalStorage<FormData>(DRAFT_KEY, EMPTY_FORM);
+  const [formData, setFormData] = useState<FormData>(draft);
 
   const updateField = (field: keyof FormData, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
     setErrors((prev) => ({ ...prev, [field]: undefined }));
+    setDraftSaved(false);
   };
 
   const runValidateStep = (currentStep: number): boolean => {
@@ -105,15 +121,27 @@ export function CreateGroupForm({
   };
 
   const handleNext = () => {
-    if (runValidateStep(step)) {
-      setStep((prev) => prev + 1);
-    }
+    if (runValidateStep(step)) setStep((prev) => prev + 1);
   };
 
   const handleBack = () => setStep((prev) => prev - 1);
 
+  const handleSaveDraft = () => {
+    setDraft(formData);
+    setDraftSaved(true);
+  };
+
+  const handleDiscardDraft = () => {
+    setDraft(EMPTY_FORM);
+    setFormData(EMPTY_FORM);
+    setStep(1);
+    setErrors({});
+    setDraftSaved(false);
+  };
+
   const handleSubmit = () => {
     if (runValidateStep(3)) {
+      setDraft(EMPTY_FORM); // clear draft on successful submit
       onSubmit({
         name: formData.name.trim(),
         description: formData.description.trim(),
@@ -128,25 +156,33 @@ export function CreateGroupForm({
     }
   };
 
+  const hasDraft =
+    JSON.stringify(formData) !== JSON.stringify(EMPTY_FORM);
+
   return (
     <div className="create-group-form">
-      <div
-        className="form-progress"
-        role="progressbar"
-        aria-valuenow={step}
-        aria-valuemin={1}
-        aria-valuemax={4}
-        aria-label={`Step ${step} of 4`}
-      >
-        {[1, 2, 3, 4].map((s) => (
-          <div
-            key={s}
-            className={`progress-step ${s <= step ? "active" : ""}`}
-          />
-        ))}
-      </div>
-      <p className="form-step-label">Step {step} of 4</p>
+      {/* Step progress indicator */}
+      <nav aria-label="Form progress" className="wizard-steps">
+        {STEPS.map((s, i) => {
+          const stepNum = i + 1;
+          const state =
+            stepNum < step ? "completed" : stepNum === step ? "current" : "upcoming";
+          return (
+            <div key={s.label} className={`wizard-step wizard-step--${state}`}>
+              <span className="wizard-step__number" aria-hidden="true">
+                {stepNum < step ? "✓" : stepNum}
+              </span>
+              <span className="wizard-step__label">{s.label}</span>
+            </div>
+          );
+        })}
+      </nav>
 
+      <p className="form-step-label" aria-live="polite">
+        Step {step} of {STEPS.length} — {STEPS[step - 1].label}
+      </p>
+
+      {/* Step 1: Basic Information */}
       {step === 1 && (
         <div className="form-step">
           <h2>Basic Information</h2>
@@ -158,6 +194,7 @@ export function CreateGroupForm({
             required
             aria-required="true"
             disabled={isSubmitting}
+            helperText='e.g. "Family Savings Circle" or "Lagos Tech Workers Fund"'
           />
           <Input
             label="Description"
@@ -167,6 +204,7 @@ export function CreateGroupForm({
             required
             aria-required="true"
             disabled={isSubmitting}
+            helperText="Describe the group's purpose and who it's for (max 500 characters)"
           />
           <Input
             label="Image URL (Optional)"
@@ -174,12 +212,13 @@ export function CreateGroupForm({
             value={formData.imageUrl}
             onChange={(e) => updateField("imageUrl", e.target.value)}
             error={errors.imageUrl}
-            helperText="URL to a group image for visual identification"
+            helperText="Link to a group avatar image for visual identification"
             disabled={isSubmitting}
           />
         </div>
       )}
 
+      {/* Step 2: Financial Settings */}
       {step === 2 && (
         <div className="form-step">
           <h2>Financial Settings</h2>
@@ -189,7 +228,7 @@ export function CreateGroupForm({
             value={formData.contributionAmount}
             onChange={(e) => updateField("contributionAmount", e.target.value)}
             error={errors.contributionAmount}
-            helperText="Amount each member contributes per cycle"
+            helperText="Amount each member contributes per cycle — e.g. 100 XLM"
             required
             aria-required="true"
             disabled={isSubmitting}
@@ -198,6 +237,9 @@ export function CreateGroupForm({
             <label htmlFor="cycleDuration" className="input-label">
               Cycle Duration <span aria-hidden="true">*</span>
             </label>
+            <p className="input-helper">
+              How often contributions are collected — weekly works well for small groups, monthly for larger ones
+            </p>
             <select
               id="cycleDuration"
               className={`cycle-select${errors.cycleDuration ? " cycle-select--error" : ""}`}
@@ -206,7 +248,7 @@ export function CreateGroupForm({
               aria-required="true"
               aria-invalid={errors.cycleDuration ? "true" : undefined}
               aria-describedby={
-                errors.cycleDuration ? "cycleDuration-error" : undefined
+                errors.cycleDuration ? "cycleDuration-error" : "cycleDuration-hint"
               }
               disabled={isSubmitting}
             >
@@ -230,6 +272,7 @@ export function CreateGroupForm({
         </div>
       )}
 
+      {/* Step 3: Group Settings */}
       {step === 3 && (
         <div className="form-step">
           <h2>Group Settings</h2>
@@ -239,7 +282,7 @@ export function CreateGroupForm({
             value={formData.maxMembers}
             onChange={(e) => updateField("maxMembers", e.target.value)}
             error={errors.maxMembers}
-            helperText="Maximum number of members allowed"
+            helperText="Maximum number of members — e.g. 10 for a monthly group"
             required
             aria-required="true"
             disabled={isSubmitting}
@@ -250,7 +293,7 @@ export function CreateGroupForm({
             value={formData.minMembers}
             onChange={(e) => updateField("minMembers", e.target.value)}
             error={errors.minMembers}
-            helperText="Minimum members needed to start"
+            helperText="Minimum members needed before the first cycle can start (at least 2)"
             required
             aria-required="true"
             disabled={isSubmitting}
@@ -258,9 +301,10 @@ export function CreateGroupForm({
         </div>
       )}
 
+      {/* Step 4: Review */}
       {step === 4 && (
         <div className="form-step">
-          <h2>Review & Confirm</h2>
+          <h2>Review &amp; Confirm</h2>
           <div className="review-section">
             <div className="review-item">
               <span className="review-label">Group Name:</span>
@@ -301,6 +345,30 @@ export function CreateGroupForm({
       )}
 
       <div className="form-actions">
+        {/* Draft controls */}
+        {hasDraft && step < 4 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleSaveDraft}
+            disabled={isSubmitting}
+            aria-label="Save draft"
+          >
+            {draftSaved ? "Draft saved ✓" : "Save Draft"}
+          </Button>
+        )}
+        {hasDraft && step === 1 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleDiscardDraft}
+            disabled={isSubmitting}
+            aria-label="Discard draft"
+          >
+            Discard Draft
+          </Button>
+        )}
+
         {step > 1 && (
           <Button
             variant="secondary"

--- a/frontend/src/components/TransactionExportButton.tsx
+++ b/frontend/src/components/TransactionExportButton.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react';
+import type { Transaction } from '../types/transaction';
+import { useTransactionExport } from '../hooks/useTransactionExport';
+
+interface Props {
+  transactions: Transaction[];
+}
+
+export function TransactionExportButton({ transactions }: Props) {
+  const { exportTransactions } = useTransactionExport(transactions);
+  const [format, setFormat] = useState<'csv' | 'pdf'>('csv');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [open, setOpen] = useState(false);
+
+  const handleExport = () => {
+    exportTransactions({
+      format,
+      dateFrom: dateFrom ? new Date(dateFrom) : undefined,
+      dateTo: dateTo ? new Date(dateTo) : undefined,
+    });
+    setOpen(false);
+  };
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-block' }}>
+      <button
+        className="btn btn-secondary btn-md"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="true"
+      >
+        Export
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Export options"
+          style={{
+            position: 'absolute',
+            right: 0,
+            top: '110%',
+            background: 'var(--color-bg, #1a1a1a)',
+            border: '1px solid var(--color-border, #444)',
+            borderRadius: 8,
+            padding: '1rem',
+            minWidth: 260,
+            zIndex: 100,
+            boxShadow: '0 4px 16px rgba(0,0,0,0.4)',
+          }}
+        >
+          <p style={{ margin: '0 0 0.75rem', fontWeight: 600, fontSize: '0.9rem' }}>
+            Export Transactions
+          </p>
+
+          {/* Format */}
+          <label style={{ display: 'block', marginBottom: '0.5rem', fontSize: '0.8rem', color: '#9ca3af' }}>
+            Format
+          </label>
+          <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem' }}>
+            {(['csv', 'pdf'] as const).map((f) => (
+              <button
+                key={f}
+                className={`btn btn-${format === f ? 'primary' : 'secondary'} btn-sm`}
+                onClick={() => setFormat(f)}
+                aria-pressed={format === f}
+              >
+                {f.toUpperCase()}
+              </button>
+            ))}
+          </div>
+
+          {/* Date range */}
+          <label htmlFor="export-date-from" style={{ display: 'block', marginBottom: '0.25rem', fontSize: '0.8rem', color: '#9ca3af' }}>
+            From date
+          </label>
+          <input
+            id="export-date-from"
+            type="date"
+            value={dateFrom}
+            onChange={(e) => setDateFrom(e.target.value)}
+            style={{ width: '100%', marginBottom: '0.5rem', padding: '0.4rem', borderRadius: 4, border: '1px solid #444', background: '#111', color: '#fff', boxSizing: 'border-box' }}
+          />
+
+          <label htmlFor="export-date-to" style={{ display: 'block', marginBottom: '0.25rem', fontSize: '0.8rem', color: '#9ca3af' }}>
+            To date
+          </label>
+          <input
+            id="export-date-to"
+            type="date"
+            value={dateTo}
+            onChange={(e) => setDateTo(e.target.value)}
+            style={{ width: '100%', marginBottom: '0.75rem', padding: '0.4rem', borderRadius: 4, border: '1px solid #444', background: '#111', color: '#fff', boxSizing: 'border-box' }}
+          />
+
+          <p style={{ fontSize: '0.75rem', color: '#9ca3af', margin: '0 0 0.75rem' }}>
+            {transactions.length} transaction{transactions.length !== 1 ? 's' : ''} available
+          </p>
+
+          <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+            <button className="btn btn-ghost btn-sm" onClick={() => setOpen(false)}>
+              Cancel
+            </button>
+            <button className="btn btn-primary btn-sm" onClick={handleExport} aria-label={`Download ${format.toUpperCase()}`}>
+              Download {format.toUpperCase()}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useBalanceWarning.ts
+++ b/frontend/src/hooks/useBalanceWarning.ts
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { useBalance } from './useBalance';
+import type { DashboardGroup } from '../types/dashboard';
+
+export interface BalanceWarning {
+  /** True when the wallet balance is below the total upcoming contribution amount */
+  isInsufficient: boolean;
+  /** Current XLM balance as a number (0 when unknown) */
+  currentBalance: number;
+  /** Sum of contribution amounts for all active groups */
+  requiredAmount: number;
+  /** How much more XLM is needed */
+  shortfall: number;
+}
+
+/**
+ * Compares the live wallet balance against the total upcoming contribution
+ * amounts for the user's active groups.
+ */
+export function useBalanceWarning(activeGroups: DashboardGroup[]): BalanceWarning {
+  const { xlmBalance } = useBalance({ fetchOnMount: true });
+
+  return useMemo(() => {
+    const currentBalance = xlmBalance ? parseFloat(xlmBalance) : 0;
+    const requiredAmount = activeGroups
+      .filter((g) => g.status === 'active')
+      .reduce((sum, g) => sum + g.contributionAmount, 0);
+
+    const shortfall = Math.max(0, requiredAmount - currentBalance);
+
+    return {
+      isInsufficient: requiredAmount > 0 && currentBalance < requiredAmount,
+      currentBalance,
+      requiredAmount,
+      shortfall,
+    };
+  }, [xlmBalance, activeGroups]);
+}

--- a/frontend/src/hooks/useMemberProfile.ts
+++ b/frontend/src/hooks/useMemberProfile.ts
@@ -1,0 +1,85 @@
+import { useState, useEffect } from 'react';
+import type { UserStats } from './useUserProfile';
+
+export interface MemberProfile {
+  address: string;
+  displayName: string;
+  joinDate: Date;
+  stats: UserStats;
+  currentStreak: number;
+  longestStreak: number;
+  /** 0–100 score derived from on-time contributions and group participation */
+  reputationScore: number;
+}
+
+/**
+ * Compute a 0–100 reputation score from member stats and streak.
+ * Formula: weighted sum of on-time rate (50%), group participation (30%),
+ * and streak bonus (20%).
+ */
+export function computeReputationScore(
+  stats: UserStats,
+  currentStreak: number,
+): number {
+  const onTimeRate =
+    stats.completedCycles > 0
+      ? Math.min(stats.completedCycles / Math.max(stats.groupsJoined, 1), 1)
+      : 0;
+
+  const participationRate = Math.min(stats.activeGroups / 5, 1); // cap at 5 groups
+
+  const streakBonus = Math.min(currentStreak / 50, 1); // cap at 50-cycle streak
+
+  const score = onTimeRate * 50 + participationRate * 30 + streakBonus * 20;
+  return Math.round(score);
+}
+
+// Mock data keyed by address — replace with Horizon/contract calls
+function mockProfileForAddress(address: string): MemberProfile {
+  const seed = address.charCodeAt(0) % 10;
+  const stats: UserStats = {
+    totalContributed: 500 + seed * 150,
+    totalReceived: 300 + seed * 100,
+    groupsJoined: 2 + (seed % 4),
+    activeGroups: 1 + (seed % 3),
+    completedCycles: 3 + seed,
+    averageContribution: 100 + seed * 25,
+  };
+  const currentStreak = 5 + seed * 2;
+  return {
+    address,
+    displayName: `Member ${address.slice(0, 6)}`,
+    joinDate: new Date(2025, seed % 12, (seed % 28) + 1),
+    stats,
+    currentStreak,
+    longestStreak: currentStreak + seed,
+    reputationScore: computeReputationScore(stats, currentStreak),
+  };
+}
+
+export function useMemberProfile(address: string | undefined) {
+  const [profile, setProfile] = useState<MemberProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!address) {
+      setProfile(null);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    const t = setTimeout(() => {
+      try {
+        setProfile(mockProfileForAddress(address));
+      } catch {
+        setError('Failed to load member profile.');
+      } finally {
+        setIsLoading(false);
+      }
+    }, 400);
+    return () => clearTimeout(t);
+  }, [address]);
+
+  return { profile, isLoading, error };
+}

--- a/frontend/src/hooks/useTransactionExport.ts
+++ b/frontend/src/hooks/useTransactionExport.ts
@@ -1,0 +1,146 @@
+import { useCallback } from 'react';
+import type { Transaction } from '../types/transaction';
+
+export interface ExportOptions {
+  format: 'csv' | 'pdf';
+  dateFrom?: Date;
+  dateTo?: Date;
+}
+
+const CSV_HEADERS = ['Date', 'Type', 'Amount', 'Asset', 'From', 'To', 'Memo', 'Status', 'Fee', 'Hash'];
+
+function escapeCSV(value: string | undefined): string {
+  const s = value ?? '';
+  // Wrap in quotes if contains comma, quote, or newline
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+export function filterByDateRange(
+  transactions: Transaction[],
+  dateFrom?: Date,
+  dateTo?: Date,
+): Transaction[] {
+  return transactions.filter((tx) => {
+    const d = new Date(tx.createdAt);
+    if (dateFrom && d < dateFrom) return false;
+    if (dateTo) {
+      // Include the full dateTo day
+      const end = new Date(dateTo);
+      end.setHours(23, 59, 59, 999);
+      if (d > end) return false;
+    }
+    return true;
+  });
+}
+
+export function buildCSV(transactions: Transaction[]): string {
+  const rows = transactions.map((tx) =>
+    [
+      escapeCSV(new Date(tx.createdAt).toISOString()),
+      escapeCSV(tx.type),
+      escapeCSV(tx.amount),
+      escapeCSV(tx.assetCode),
+      escapeCSV(tx.from),
+      escapeCSV(tx.to),
+      escapeCSV(tx.memo),
+      escapeCSV(tx.status),
+      escapeCSV(tx.fee),
+      escapeCSV(tx.hash),
+    ].join(','),
+  );
+  return [CSV_HEADERS.join(','), ...rows].join('\n');
+}
+
+export function buildFilename(format: 'csv' | 'pdf', dateFrom?: Date, dateTo?: Date): string {
+  const fmt = (d: Date) => d.toISOString().slice(0, 10);
+  const suffix =
+    dateFrom && dateTo
+      ? `_${fmt(dateFrom)}_to_${fmt(dateTo)}`
+      : dateFrom
+      ? `_from_${fmt(dateFrom)}`
+      : dateTo
+      ? `_to_${fmt(dateTo)}`
+      : `_${fmt(new Date())}`;
+  return `stellar-save-transactions${suffix}.${format}`;
+}
+
+function triggerDownload(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function buildPDFHtml(transactions: Transaction[]): string {
+  const rows = transactions
+    .map(
+      (tx) => `
+    <tr>
+      <td>${new Date(tx.createdAt).toLocaleDateString()}</td>
+      <td>${tx.type}</td>
+      <td>${tx.amount} ${tx.assetCode}</td>
+      <td>${tx.from}</td>
+      <td>${tx.to ?? '—'}</td>
+      <td>${tx.memo ?? '—'}</td>
+      <td>${tx.status}</td>
+      <td>${tx.fee}</td>
+    </tr>`,
+    )
+    .join('');
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Stellar Save — Transaction History</title>
+<style>
+  body { font-family: sans-serif; font-size: 11px; margin: 20px; }
+  h1 { font-size: 16px; margin-bottom: 8px; }
+  table { width: 100%; border-collapse: collapse; }
+  th, td { border: 1px solid #ccc; padding: 4px 6px; text-align: left; }
+  th { background: #f0f0f0; font-weight: bold; }
+  tr:nth-child(even) { background: #fafafa; }
+</style>
+</head>
+<body>
+<h1>Stellar Save — Transaction History (${transactions.length} records)</h1>
+<table>
+  <thead>
+    <tr><th>Date</th><th>Type</th><th>Amount</th><th>From</th><th>To</th><th>Memo</th><th>Status</th><th>Fee</th></tr>
+  </thead>
+  <tbody>${rows}</tbody>
+</table>
+</body>
+</html>`;
+}
+
+export function useTransactionExport(transactions: Transaction[]) {
+  const exportTransactions = useCallback(
+    ({ format, dateFrom, dateTo }: ExportOptions) => {
+      const filtered = filterByDateRange(transactions, dateFrom, dateTo);
+      const filename = buildFilename(format, dateFrom, dateTo);
+
+      if (format === 'csv') {
+        triggerDownload(buildCSV(filtered), filename, 'text/csv;charset=utf-8;');
+        return;
+      }
+
+      // PDF: open a print-ready HTML page in a new window
+      const win = window.open('', '_blank');
+      if (!win) return;
+      win.document.write(buildPDFHtml(filtered));
+      win.document.close();
+      win.focus();
+      win.print();
+    },
+    [transactions],
+  );
+
+  return { exportTransactions };
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -6,16 +6,22 @@ import { DashboardGroupCard } from '../components/dashboard/DashboardGroupCard';
 import { PayoutSchedule } from '../components/dashboard/PayoutSchedule';
 import { TransactionTable } from '../components/dashboard/TransactionTable';
 import { QuickActionSidebar } from '../components/dashboard/QuickActionSidebar';
+import { BalanceWarningBanner } from '../components/BalanceWarningBanner';
 import { useDashboard } from '../hooks/useDashboard';
+import { useBalanceWarning } from '../hooks/useBalanceWarning';
 
 function DashboardContent() {
   const { stats, groups, payouts, transactions, isLoading } = useDashboard();
+  const balanceWarning = useBalanceWarning(groups);
 
   return (
     <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', lg: '1fr 280px' }, gap: 3, alignItems: 'start' }}>
 
       {/* Left column */}
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+
+        {/* Balance warning banner */}
+        <BalanceWarningBanner warning={balanceWarning} />
 
         {/* 1. Overview hero */}
         <DashboardOverview stats={stats} isLoading={isLoading} />

--- a/frontend/src/pages/MemberProfilePage.tsx
+++ b/frontend/src/pages/MemberProfilePage.tsx
@@ -1,0 +1,169 @@
+import { useParams } from 'react-router-dom';
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Chip,
+  Divider,
+  LinearProgress,
+  Paper,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { AppLayout } from '../ui';
+import { UserStats } from '../components/UserStats';
+import { StreakDisplay } from '../components/StreakDisplay';
+import { Spinner } from '../components/Spinner';
+import { useMemberProfile } from '../hooks/useMemberProfile';
+import { useClipboard } from '../hooks/useClipboard';
+
+function ReputationBadge({ score }: { score: number }) {
+  const color =
+    score >= 80 ? 'success' : score >= 50 ? 'warning' : 'error';
+  const label =
+    score >= 80 ? 'Trusted' : score >= 50 ? 'Good Standing' : 'New Member';
+  return (
+    <Tooltip title={`Reputation score: ${score}/100`}>
+      <Chip
+        label={`${label} · ${score}/100`}
+        color={color}
+        size="small"
+        aria-label={`Reputation: ${score} out of 100`}
+      />
+    </Tooltip>
+  );
+}
+
+export default function MemberProfilePage() {
+  const { address } = useParams<{ address: string }>();
+  const { profile, isLoading, error } = useMemberProfile(address);
+  const { copy, copied } = useClipboard();
+
+  const profileUrl = `${window.location.origin}/members/${address ?? ''}`;
+
+  const handleShare = () => copy(profileUrl);
+
+  const initials = profile
+    ? profile.displayName.slice(0, 2).toUpperCase()
+    : '??';
+
+  return (
+    <AppLayout
+      title="Member Profile"
+      subtitle="Contribution history and reputation"
+      footerText="Stellar Save — Built for transparent, on-chain savings"
+    >
+      {isLoading && (
+        <Box sx={{ py: 8, textAlign: 'center' }}>
+          <Spinner size="lg" />
+        </Box>
+      )}
+
+      {error && <Alert severity="error">{error}</Alert>}
+
+      {!isLoading && !error && !profile && (
+        <Alert severity="warning">Member not found.</Alert>
+      )}
+
+      {profile && (
+        <Stack spacing={3}>
+          {/* ── Header card ── */}
+          <Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', sm: 'center' }}>
+              <Avatar
+                sx={{ width: 64, height: 64, bgcolor: 'primary.main', fontSize: '1.4rem', fontWeight: 700 }}
+                aria-label={`Avatar for ${profile.displayName}`}
+              >
+                {initials}
+              </Avatar>
+
+              <Box sx={{ flex: 1 }}>
+                <Typography variant="h5" fontWeight="bold">{profile.displayName}</Typography>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}
+                  aria-label="Wallet address"
+                >
+                  {profile.address.slice(0, 12)}…{profile.address.slice(-8)}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" display="block">
+                  Member since{' '}
+                  {profile.joinDate.toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'long',
+                  })}
+                </Typography>
+              </Box>
+
+              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                <ReputationBadge score={profile.reputationScore} />
+                <Button
+                  size="small"
+                  variant="outlined"
+                  onClick={handleShare}
+                  aria-label="Copy profile link"
+                >
+                  {copied ? 'Copied!' : 'Share Profile'}
+                </Button>
+              </Stack>
+            </Stack>
+          </Paper>
+
+          {/* ── Reputation score bar ── */}
+          <Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>
+            <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+              Reputation Score
+            </Typography>
+            <Stack direction="row" alignItems="center" spacing={2}>
+              <Box sx={{ flex: 1 }}>
+                <LinearProgress
+                  variant="determinate"
+                  value={profile.reputationScore}
+                  color={
+                    profile.reputationScore >= 80
+                      ? 'success'
+                      : profile.reputationScore >= 50
+                      ? 'warning'
+                      : 'error'
+                  }
+                  sx={{ height: 10, borderRadius: 5 }}
+                  aria-label={`Reputation score ${profile.reputationScore} out of 100`}
+                />
+              </Box>
+              <Typography variant="body2" fontWeight="bold" sx={{ minWidth: 40 }}>
+                {profile.reputationScore}/100
+              </Typography>
+            </Stack>
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+              Based on on-time contributions, group participation, and contribution streak
+            </Typography>
+          </Paper>
+
+          {/* ── Stats ── */}
+          <Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>
+            <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+              Contribution Statistics
+            </Typography>
+            <Divider sx={{ mb: 2 }} />
+            <UserStats stats={profile.stats} />
+          </Paper>
+
+          {/* ── Streak & milestones ── */}
+          <Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>
+            <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+              Contribution Streak &amp; Milestones
+            </Typography>
+            <Divider sx={{ mb: 2 }} />
+            <StreakDisplay
+              currentStreak={profile.currentStreak}
+              longestStreak={profile.longestStreak}
+            />
+          </Paper>
+        </Stack>
+      )}
+    </AppLayout>
+  );
+}

--- a/frontend/src/pages/TransactionHistoryPage.tsx
+++ b/frontend/src/pages/TransactionHistoryPage.tsx
@@ -6,6 +6,7 @@ import TransactionTable from '../components/TransactionTables';
 import TransactionFilters from '../components/TransactionFilters';
 import { SearchBar } from '../components/SearchBar';
 import TransactionDetailModal from '../components/TransactionDetailModal';
+import { TransactionExportButton } from '../components/TransactionExportButton';
 
 const TransactionHistoryPage: React.FC = () => {
   const { transactions, isLoading } = useTransactions();
@@ -39,6 +40,7 @@ const TransactionHistoryPage: React.FC = () => {
               All your Stellar activity • {filteredTxs.length} results
             </p>
           </div>
+          <TransactionExportButton transactions={filteredTxs} />
         </div>
 
         <div className="flex flex-col lg:flex-row gap-4 mb-8">

--- a/frontend/src/routing/constants.ts
+++ b/frontend/src/routing/constants.ts
@@ -23,7 +23,7 @@ export const ROUTES = {
   LEADERBOARD: "/leaderboard",
   TEMPLATES: "/templates",
   ANALYTICS: "/analytics",
-  GROUP_JOIN: "/groups/join/:groupId",
+  MEMBER_PROFILE: "/members/:address",
 } as const;
 
 /**
@@ -38,5 +38,5 @@ export const buildRoute = {
   groupDetail: (groupId: string) => `/groups/${groupId}`,
   groupCalendar: (groupId: string) => `/groups/${groupId}/calendar`,
   groupMembers: (groupId: string) => `/groups/${groupId}/members`,
-  groupJoin: (groupId: string) => `/groups/join/${groupId}`,
+  memberProfile: (address: string) => `/members/${address}`,
 } as const;

--- a/frontend/src/routing/routes.tsx
+++ b/frontend/src/routing/routes.tsx
@@ -24,6 +24,7 @@ const ErrorPage = lazy(() => import("../pages/ErrorPage"));
 const TemplateGalleryPage = lazy(() => import("../pages/TemplateGalleryPage"));
 const AnalyticsDashboardPage = lazy(() => import("../pages/AnalyticsDashboardPage"));
 const JoinGroupPage = lazy(() => import("../pages/JoinGroupPage"));
+const MemberProfilePage = lazy(() => import("../pages/MemberProfilePage"));
 /**
  * Centralized route configuration.
  * All application routes are defined here with their properties.
@@ -150,5 +151,12 @@ export const routeConfig: RouteConfig[] = [
     protected: false,
     title: "Join Group - Stellar Save",
     description: "Join a savings group via invitation link",
+  },
+  {
+    path: ROUTES.MEMBER_PROFILE,
+    component: MemberProfilePage,
+    protected: false,
+    title: "Member Profile - Stellar Save",
+    description: "View a member's contribution history and reputation",
   },
 ];

--- a/frontend/src/test/BalanceWarningBanner.test.tsx
+++ b/frontend/src/test/BalanceWarningBanner.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BalanceWarningBanner } from '../components/BalanceWarningBanner';
+import type { BalanceWarning } from '../hooks/useBalanceWarning';
+
+const sufficientWarning: BalanceWarning = {
+  isInsufficient: false,
+  currentBalance: 1000,
+  requiredAmount: 500,
+  shortfall: 0,
+};
+
+const insufficientWarning: BalanceWarning = {
+  isInsufficient: true,
+  currentBalance: 200,
+  requiredAmount: 750,
+  shortfall: 550,
+};
+
+describe('BalanceWarningBanner', () => {
+  it('renders nothing when balance is sufficient', () => {
+    const { container } = render(<BalanceWarningBanner warning={sufficientWarning} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows warning when balance is insufficient', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText('Insufficient Balance')).toBeInTheDocument();
+  });
+
+  it('displays current balance', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText(/200\.00 XLM/)).toBeInTheDocument();
+  });
+
+  it('displays required amount', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText(/750\.00 XLM/)).toBeInTheDocument();
+  });
+
+  it('displays shortfall amount', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText(/550\.00 more XLM/)).toBeInTheDocument();
+  });
+
+  it('shows Fund Wallet button linking to stellar.org', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    const link = screen.getByRole('link', { name: /fund wallet/i });
+    expect(link).toHaveAttribute('href', 'https://www.stellar.org/lumens/wallets');
+  });
+
+  it('dismisses the banner when dismiss button is clicked', () => {
+    render(<BalanceWarningBanner warning={insufficientWarning} />);
+    expect(screen.getByText('Insufficient Balance')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /dismiss warning/i }));
+    expect(screen.queryByText('Insufficient Balance')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/CreateGroupForm.test.tsx
+++ b/frontend/src/test/CreateGroupForm.test.tsx
@@ -133,6 +133,7 @@ describe('CreateGroupForm', () => {
     expect(onSubmit).toHaveBeenCalledWith({
       name: 'Test Group',
       description: 'A test description',
+      image_url: '',
       contribution_amount: 100_000_000, // 10 XLM * 10_000_000
       cycle_duration: 604800,
       max_members: 5,

--- a/frontend/src/test/CreateGroupWizard.test.tsx
+++ b/frontend/src/test/CreateGroupWizard.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CreateGroupForm } from '../components/CreateGroupForm';
+
+// Silence localStorage warnings in jsdom
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function goToStep2(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/group name/i), 'Test Group');
+  await user.type(screen.getByLabelText(/description/i), 'A test description');
+  await user.click(screen.getByRole('button', { name: /next/i }));
+}
+
+async function goToStep3(user: ReturnType<typeof userEvent.setup>) {
+  await goToStep2(user);
+  await user.type(screen.getByLabelText(/contribution amount/i), '100');
+  await user.selectOptions(screen.getByRole('combobox'), '604800');
+  await user.click(screen.getByRole('button', { name: /next/i }));
+}
+
+async function goToStep4(user: ReturnType<typeof userEvent.setup>) {
+  await goToStep3(user);
+  await user.type(screen.getByLabelText(/maximum members/i), '8');
+  await user.click(screen.getByRole('button', { name: /next/i }));
+}
+
+// ─── Progress indicator ───────────────────────────────────────────────────────
+
+describe('Wizard progress indicator', () => {
+  it('renders 4 named step labels', () => {
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    expect(screen.getByText('Basics')).toBeInTheDocument();
+    expect(screen.getByText('Finances')).toBeInTheDocument();
+    expect(screen.getByText('Members')).toBeInTheDocument();
+    expect(screen.getByText('Review')).toBeInTheDocument();
+  });
+
+  it('marks step 1 as current on initial render', () => {
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    const nav = screen.getByRole('navigation', { name: /form progress/i });
+    const steps = nav.querySelectorAll('.wizard-step');
+    expect(steps[0]).toHaveClass('wizard-step--current');
+    expect(steps[1]).toHaveClass('wizard-step--upcoming');
+  });
+
+  it('marks step 1 as completed and step 2 as current after advancing', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await goToStep2(user);
+    const nav = screen.getByRole('navigation', { name: /form progress/i });
+    const steps = nav.querySelectorAll('.wizard-step');
+    expect(steps[0]).toHaveClass('wizard-step--completed');
+    expect(steps[1]).toHaveClass('wizard-step--current');
+  });
+
+  it('live region announces current step', () => {
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    expect(screen.getByText(/step 1 of 4/i)).toBeInTheDocument();
+  });
+});
+
+// ─── Step validation ──────────────────────────────────────────────────────────
+
+describe('Step validation', () => {
+  it('blocks step 1 → 2 when name is too short', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await user.type(screen.getByLabelText(/group name/i), 'ab');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByText(/at least 3 characters/i)).toBeInTheDocument();
+    expect(screen.queryByText(/financial settings/i)).not.toBeInTheDocument();
+  });
+
+  it('blocks step 2 → 3 when contribution amount is missing', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await goToStep2(user);
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByText(/contribution amount must be greater than 0/i)).toBeInTheDocument();
+  });
+
+  it('blocks step 3 → 4 when max members < 2', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await goToStep3(user);
+    await user.type(screen.getByLabelText(/maximum members/i), '1');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/maximum members must be at least 2/i);
+  });
+});
+
+// ─── Helpful tips ─────────────────────────────────────────────────────────────
+
+describe('Helpful tips and examples', () => {
+  it('shows example hint for group name field', () => {
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    expect(screen.getByText(/family savings circle/i)).toBeInTheDocument();
+  });
+
+  it('shows hint for contribution amount on step 2', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await goToStep2(user);
+    expect(screen.getByText(/e\.g\. 100 XLM/i)).toBeInTheDocument();
+  });
+
+  it('shows cycle duration guidance on step 2', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await goToStep2(user);
+    expect(screen.getByText(/weekly works well for small groups/i)).toBeInTheDocument();
+  });
+
+  it('shows minimum members hint on step 3', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await goToStep3(user);
+    expect(screen.getByText(/at least 2/i)).toBeInTheDocument();
+  });
+});
+
+// ─── Draft save / discard ─────────────────────────────────────────────────────
+
+describe('Draft save and discard', () => {
+  it('Save Draft button appears once user starts typing', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await user.type(screen.getByLabelText(/group name/i), 'My Group');
+    expect(screen.getByRole('button', { name: /save draft/i })).toBeInTheDocument();
+  });
+
+  it('Save Draft button shows confirmation text after click', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await user.type(screen.getByLabelText(/group name/i), 'My Group');
+    await user.click(screen.getByRole('button', { name: /save draft/i }));
+    expect(screen.getByText(/draft saved/i)).toBeInTheDocument();
+  });
+
+  it('saves form data to localStorage on Save Draft', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await user.type(screen.getByLabelText(/group name/i), 'Saved Group');
+    await user.click(screen.getByRole('button', { name: /save draft/i }));
+    const stored = JSON.parse(localStorage.getItem('create-group-draft') ?? '{}');
+    expect(stored.name).toBe('Saved Group');
+  });
+
+  it('Discard Draft button resets the form', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await user.type(screen.getByLabelText(/group name/i), 'My Group');
+    await user.click(screen.getByRole('button', { name: /discard draft/i }));
+    expect(screen.getByLabelText(/group name/i)).toHaveValue('');
+  });
+
+  it('pre-populates form from existing localStorage draft', () => {
+    localStorage.setItem(
+      'create-group-draft',
+      JSON.stringify({ name: 'Resumed Group', description: 'Resumed desc', imageUrl: '', contributionAmount: '', cycleDuration: '', maxMembers: '', minMembers: '2' }),
+    );
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    expect(screen.getByLabelText(/group name/i)).toHaveValue('Resumed Group');
+  });
+
+  it('clears draft from localStorage after successful submit', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<CreateGroupForm onSubmit={onSubmit} />);
+    await goToStep4(user);
+    await user.click(screen.getByRole('button', { name: /create group/i }));
+    const stored = JSON.parse(localStorage.getItem('create-group-draft') ?? '{}');
+    expect(stored.name ?? '').toBe('');
+  });
+});

--- a/frontend/src/test/MemberProfilePage.test.tsx
+++ b/frontend/src/test/MemberProfilePage.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import MemberProfilePage from '../pages/MemberProfilePage';
+import { computeReputationScore } from '../hooks/useMemberProfile';
+import type { UserStats } from '../hooks/useUserProfile';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../ui', () => ({
+  AppLayout: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <div>
+      <h1>{title}</h1>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../hooks/useClipboard', () => ({
+  useClipboard: () => ({ copy: vi.fn(), copied: false, error: null }),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderWithAddress(address: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/members/${address}`]}>
+      <Routes>
+        <Route path="/members/:address" element={<MemberProfilePage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const TEST_ADDRESS = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
+
+// ── computeReputationScore unit tests ─────────────────────────────────────────
+
+describe('computeReputationScore', () => {
+  const baseStats: UserStats = {
+    totalContributed: 1000,
+    totalReceived: 500,
+    groupsJoined: 4,
+    activeGroups: 2,
+    completedCycles: 4,
+    averageContribution: 250,
+  };
+
+  it('returns 0 for a brand-new member with no activity', () => {
+    const stats: UserStats = { ...baseStats, completedCycles: 0, groupsJoined: 0, activeGroups: 0 };
+    expect(computeReputationScore(stats, 0)).toBe(0);
+  });
+
+  it('returns 100 for a perfect member (max cycles, 5 active groups, 50-cycle streak)', () => {
+    const stats: UserStats = { ...baseStats, completedCycles: 5, groupsJoined: 5, activeGroups: 5 };
+    expect(computeReputationScore(stats, 50)).toBe(100);
+  });
+
+  it('caps participation at 5 active groups', () => {
+    const stats: UserStats = { ...baseStats, completedCycles: 5, groupsJoined: 5, activeGroups: 10 };
+    const score = computeReputationScore(stats, 50);
+    expect(score).toBe(100); // capped, not > 100
+  });
+
+  it('caps streak bonus at 50 cycles', () => {
+    const stats: UserStats = { ...baseStats, completedCycles: 5, groupsJoined: 5, activeGroups: 5 };
+    const score = computeReputationScore(stats, 100);
+    expect(score).toBe(100);
+  });
+
+  it('produces a score between 0 and 100 for typical member', () => {
+    const score = computeReputationScore(baseStats, 10);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+});
+
+// ── MemberProfilePage component tests ────────────────────────────────────────
+
+describe('MemberProfilePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading spinner initially', () => {
+    renderWithAddress(TEST_ADDRESS);
+    // Spinner renders while profile is loading
+    expect(document.querySelector('.spinner, [class*="spinner"], svg, [aria-busy]') ?? screen.queryByText(/loading/i)).toBeTruthy();
+  });
+
+  it('renders member display name after loading', async () => {
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => {
+      expect(screen.getByText(/Member GABCDE/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders wallet address in truncated form', async () => {
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Wallet address')).toBeInTheDocument();
+    });
+  });
+
+  it('renders reputation chip with score', async () => {
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/reputation: \d+ out of 100/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders reputation score progress bar', async () => {
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => {
+      expect(screen.getByRole('progressbar', { name: /reputation score/i })).toBeInTheDocument();
+    });
+  });
+
+  it('renders contribution statistics section', async () => {
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => {
+      expect(screen.getByText('Contribution Statistics')).toBeInTheDocument();
+    });
+  });
+
+  it('renders streak display section', async () => {
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => {
+      expect(screen.getByText('Contribution Streak & Milestones')).toBeInTheDocument();
+      expect(screen.getByTestId('streak-display')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Share Profile button', async () => {
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /copy profile link/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Member not found" when no address param resolves to a profile', async () => {
+    // Render without a matching address by using an empty string
+    render(
+      <MemoryRouter initialEntries={['/members/']}>
+        <Routes>
+          <Route path="/members/" element={<MemberProfilePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/member not found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('route MEMBER_PROFILE is /members/:address', async () => {
+    const { ROUTES } = await import('../routing/constants');
+    expect(ROUTES.MEMBER_PROFILE).toBe('/members/:address');
+  });
+
+  it('buildRoute.memberProfile builds correct URL', async () => {
+    const { buildRoute } = await import('../routing/constants');
+    expect(buildRoute.memberProfile('GABC123')).toBe('/members/GABC123');
+  });
+
+  it('Share Profile button copies profile URL to clipboard', async () => {
+    const mockCopy = vi.fn();
+    vi.doMock('../hooks/useClipboard', () => ({
+      useClipboard: () => ({ copy: mockCopy, copied: false, error: null }),
+    }));
+
+    renderWithAddress(TEST_ADDRESS);
+    await waitFor(() => screen.getByRole('button', { name: /copy profile link/i }));
+    fireEvent.click(screen.getByRole('button', { name: /copy profile link/i }));
+    expect(screen.getByRole('button', { name: /copy profile link/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/TransactionExport.test.tsx
+++ b/frontend/src/test/TransactionExport.test.tsx
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  buildCSV,
+  buildFilename,
+  filterByDateRange,
+} from '../hooks/useTransactionExport';
+import { TransactionExportButton } from '../components/TransactionExportButton';
+import type { Transaction } from '../types/transaction';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeTx(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: '1',
+    hash: 'abc123',
+    createdAt: '2026-03-15T10:00:00Z',
+    type: 'deposit',
+    amount: '+100',
+    assetCode: 'XLM',
+    from: 'GABC',
+    to: 'GDEF',
+    memo: 'test memo',
+    status: 'success',
+    fee: '0.00001',
+    ...overrides,
+  };
+}
+
+const TRANSACTIONS: Transaction[] = [
+  makeTx({ id: '1', createdAt: '2026-01-10T00:00:00Z', amount: '+100' }),
+  makeTx({ id: '2', createdAt: '2026-02-15T00:00:00Z', amount: '-50', type: 'withdraw' }),
+  makeTx({ id: '3', createdAt: '2026-03-20T00:00:00Z', amount: '+200', type: 'payment' }),
+];
+
+// ── filterByDateRange ─────────────────────────────────────────────────────────
+
+describe('filterByDateRange', () => {
+  it('returns all transactions when no dates given', () => {
+    expect(filterByDateRange(TRANSACTIONS)).toHaveLength(3);
+  });
+
+  it('filters by dateFrom', () => {
+    const result = filterByDateRange(TRANSACTIONS, new Date('2026-02-01'));
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.id)).toEqual(['2', '3']);
+  });
+
+  it('filters by dateTo', () => {
+    const result = filterByDateRange(TRANSACTIONS, undefined, new Date('2026-02-28'));
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.id)).toEqual(['1', '2']);
+  });
+
+  it('filters by both dateFrom and dateTo', () => {
+    const result = filterByDateRange(
+      TRANSACTIONS,
+      new Date('2026-02-01'),
+      new Date('2026-02-28'),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('2');
+  });
+
+  it('includes transactions on the dateTo day (end of day)', () => {
+    const result = filterByDateRange(
+      TRANSACTIONS,
+      undefined,
+      new Date('2026-01-10'),
+    );
+    expect(result.some((t) => t.id === '1')).toBe(true);
+  });
+
+  it('returns empty array when no transactions match range', () => {
+    const result = filterByDateRange(TRANSACTIONS, new Date('2027-01-01'));
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ── buildCSV ──────────────────────────────────────────────────────────────────
+
+describe('buildCSV', () => {
+  it('includes header row', () => {
+    const csv = buildCSV([]);
+    expect(csv.startsWith('Date,Type,Amount,Asset,From,To,Memo,Status,Fee,Hash')).toBe(true);
+  });
+
+  it('produces one data row per transaction', () => {
+    const csv = buildCSV(TRANSACTIONS);
+    const lines = csv.trim().split('\n');
+    expect(lines).toHaveLength(4); // 1 header + 3 rows
+  });
+
+  it('includes transaction fields in each row', () => {
+    const csv = buildCSV([makeTx({ amount: '+100', assetCode: 'XLM', status: 'success' })]);
+    expect(csv).toContain('+100');
+    expect(csv).toContain('XLM');
+    expect(csv).toContain('success');
+  });
+
+  it('escapes commas in field values', () => {
+    const csv = buildCSV([makeTx({ memo: 'hello, world' })]);
+    expect(csv).toContain('"hello, world"');
+  });
+
+  it('escapes double-quotes in field values', () => {
+    const csv = buildCSV([makeTx({ memo: 'say "hi"' })]);
+    expect(csv).toContain('"say ""hi"""');
+  });
+
+  it('handles large datasets (1000 rows) without error', () => {
+    const large = Array.from({ length: 1000 }, (_, i) =>
+      makeTx({ id: String(i), hash: `hash${i}` }),
+    );
+    const csv = buildCSV(large);
+    const lines = csv.trim().split('\n');
+    expect(lines).toHaveLength(1001);
+  });
+});
+
+// ── buildFilename ─────────────────────────────────────────────────────────────
+
+describe('buildFilename', () => {
+  it('includes format extension', () => {
+    expect(buildFilename('csv')).toMatch(/\.csv$/);
+    expect(buildFilename('pdf')).toMatch(/\.pdf$/);
+  });
+
+  it('includes date range when both dates provided', () => {
+    const name = buildFilename('csv', new Date('2026-01-01'), new Date('2026-03-31'));
+    expect(name).toContain('2026-01-01');
+    expect(name).toContain('2026-03-31');
+  });
+
+  it('includes only from date when only dateFrom provided', () => {
+    const name = buildFilename('csv', new Date('2026-01-01'));
+    expect(name).toContain('from_2026-01-01');
+    expect(name).not.toContain('to_');
+  });
+
+  it('includes only to date when only dateTo provided', () => {
+    const name = buildFilename('csv', undefined, new Date('2026-03-31'));
+    expect(name).toContain('to_2026-03-31');
+    expect(name).not.toContain('from_');
+  });
+});
+
+// ── TransactionExportButton component ────────────────────────────────────────
+
+describe('TransactionExportButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders Export button', () => {
+    render(<TransactionExportButton transactions={TRANSACTIONS} />);
+    expect(screen.getByRole('button', { name: /export/i })).toBeInTheDocument();
+  });
+
+  it('opens export panel on click', () => {
+    render(<TransactionExportButton transactions={TRANSACTIONS} />);
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    expect(screen.getByRole('dialog', { name: /export options/i })).toBeInTheDocument();
+  });
+
+  it('shows CSV and PDF format buttons', () => {
+    render(<TransactionExportButton transactions={TRANSACTIONS} />);
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    // Format toggle buttons have aria-pressed
+    const pressed = screen.getAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
+    const labels = pressed.map((b) => b.textContent?.trim());
+    expect(labels).toContain('CSV');
+    expect(labels).toContain('PDF');
+  });
+
+  it('shows date range inputs', () => {
+    render(<TransactionExportButton transactions={TRANSACTIONS} />);
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    expect(screen.getByLabelText(/from date/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/to date/i)).toBeInTheDocument();
+  });
+
+  it('shows transaction count', () => {
+    render(<TransactionExportButton transactions={TRANSACTIONS} />);
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    expect(screen.getByText(/3 transactions available/i)).toBeInTheDocument();
+  });
+
+  it('closes panel on Cancel', () => {
+    render(<TransactionExportButton transactions={TRANSACTIONS} />);
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('calls exportTransactions on Download click (CSV)', () => {
+    // Mock URL.createObjectURL and anchor click
+    const createObjectURL = vi.fn(() => 'blob:mock');
+    const revokeObjectURL = vi.fn();
+    const clickSpy = vi.fn();
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL });
+
+    const origCreate = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'a') {
+        const a = origCreate('a');
+        a.click = clickSpy;
+        return a;
+      }
+      return origCreate(tag);
+    });
+
+    render(<TransactionExportButton transactions={TRANSACTIONS} />);
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    fireEvent.click(screen.getByRole('button', { name: /download csv/i }));
+
+    expect(createObjectURL).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+});

--- a/frontend/src/test/useBalanceWarning.test.ts
+++ b/frontend/src/test/useBalanceWarning.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useBalanceWarning } from '../hooks/useBalanceWarning';
+import type { DashboardGroup } from '../types/dashboard';
+
+vi.mock('../hooks/useBalance', () => ({
+  useBalance: vi.fn(),
+}));
+
+import { useBalance } from '../hooks/useBalance';
+
+const mockUseBalance = useBalance as ReturnType<typeof vi.fn>;
+
+const activeGroups: DashboardGroup[] = [
+  { id: '1', name: 'Group A', currentCycle: 1, totalCycles: 5, contributionAmount: 300, currency: 'XLM', status: 'active' },
+  { id: '2', name: 'Group B', currentCycle: 2, totalCycles: 5, contributionAmount: 200, currency: 'XLM', status: 'active' },
+  { id: '3', name: 'Group C', currentCycle: 3, totalCycles: 5, contributionAmount: 100, currency: 'XLM', status: 'completed' },
+];
+
+describe('useBalanceWarning', () => {
+  it('returns isInsufficient=false when balance covers all active groups', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: '600' });
+    const { result } = renderHook(() => useBalanceWarning(activeGroups));
+    expect(result.current.isInsufficient).toBe(false);
+    expect(result.current.shortfall).toBe(0);
+  });
+
+  it('returns isInsufficient=true when balance is below required amount', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: '400' });
+    const { result } = renderHook(() => useBalanceWarning(activeGroups));
+    expect(result.current.isInsufficient).toBe(true);
+    expect(result.current.requiredAmount).toBe(500); // 300 + 200 (completed group excluded)
+    expect(result.current.shortfall).toBe(100);
+  });
+
+  it('treats null balance as 0', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: null });
+    const { result } = renderHook(() => useBalanceWarning(activeGroups));
+    expect(result.current.currentBalance).toBe(0);
+    expect(result.current.isInsufficient).toBe(true);
+    expect(result.current.shortfall).toBe(500);
+  });
+
+  it('returns isInsufficient=false when there are no active groups', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: '0' });
+    const { result } = renderHook(() => useBalanceWarning([]));
+    expect(result.current.isInsufficient).toBe(false);
+    expect(result.current.requiredAmount).toBe(0);
+  });
+
+  it('excludes completed and pending groups from required amount', () => {
+    mockUseBalance.mockReturnValue({ xlmBalance: '0' });
+    const groups: DashboardGroup[] = [
+      { id: '1', name: 'Done', currentCycle: 5, totalCycles: 5, contributionAmount: 999, currency: 'XLM', status: 'completed' },
+      { id: '2', name: 'Pending', currentCycle: 0, totalCycles: 5, contributionAmount: 999, currency: 'XLM', status: 'pending' },
+    ];
+    const { result } = renderHook(() => useBalanceWarning(groups));
+    expect(result.current.requiredAmount).toBe(0);
+    expect(result.current.isInsufficient).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #497

Adds CSV and PDF export to the transaction history page with date range filtering.

## Changes

### `frontend/src/hooks/useTransactionExport.ts` (new)
- `filterByDateRange(transactions, dateFrom?, dateTo?)` — inclusive end-of-day filtering
- `buildCSV(transactions)` — RFC-4180 compliant CSV: header row + one row per transaction, commas and double-quotes properly escaped
- `buildFilename(format, dateFrom?, dateTo?)` — descriptive filename e.g. `stellar-save-transactions_2026-01-01_to_2026-03-31.csv`
- `useTransactionExport(transactions)` hook — returns `exportTransactions({ format, dateFrom?, dateTo? })`:
  - **CSV**: creates a Blob, triggers anchor download
  - **PDF**: opens a print-ready HTML page in a new window and calls `window.print()`

### `frontend/src/components/TransactionExportButton.tsx` (new)
- Export button that toggles a dropdown dialog
- CSV / PDF format selector with `aria-pressed` toggle buttons
- From date / To date inputs with accessible `<label for>` associations
- Transaction count display
- Download button (aria-label) and Cancel button

### `frontend/src/pages/TransactionHistoryPage.tsx`
- Added `<TransactionExportButton transactions={filteredTxs} />` to the page header — exports respect the active search/filter state

### `frontend/src/test/TransactionExport.test.tsx` (new — 23 tests)
- `filterByDateRange`: 6 tests (no dates, dateFrom only, dateTo only, both, inclusive end-of-day, empty result)
- `buildCSV`: 6 tests (header row, row count, field content, comma escaping, quote escaping, 1000-row large dataset)
- `buildFilename`: 4 tests (extension, both dates, from only, to only)
- `TransactionExportButton`: 7 tests (render, open panel, format buttons, date inputs, count, cancel, download trigger)