### PR TITLE
feat: add group metrics

### DIFF
--- a/frontend/src/components/GroupDetails.tsx
+++ b/frontend/src/components/GroupDetails.tsx
@@ -3,6 +3,7 @@ import './GroupDetails.css';
 import { Card } from './Card';
 import { Badge } from './Badge';
 import { Avatar } from './Avatar';
+import { GroupMetrics } from './GroupMetrics';
 import { Tabs, type Tab } from './Tabs';
 import type { DetailedGroup, GroupMember, GroupContribution, GroupCycle } from '../utils/groupApi';
 
@@ -30,9 +31,8 @@ export function GroupDetails({
   const [selectedTab, setSelectedTab] = useState<string>('overview');
 
   // Calculate progress percentage
-  const progressPercentage = group.targetAmount > 0
-    ? Math.min((group.currentAmount / group.targetAmount) * 100, 100)
-    : 0;
+  const progressPercentage =
+    group.targetAmount > 0 ? Math.min((group.currentAmount / group.targetAmount) * 100, 100) : 0;
 
   // Format currency
   const formatAmount = (amount: number) => {
@@ -117,6 +117,8 @@ export function GroupDetails({
           {progressPercentage.toFixed(1)}% Complete
         </span>
       </div>
+
+      <GroupMetrics group={group} contributions={contributions} cycles={cycles} />
     </div>
   );
 
@@ -132,7 +134,9 @@ export function GroupDetails({
             </Badge>
           </div>
           <div className="group-details-cycle-dates">
-            <span>{formatDate(currentCycle.startDate)} - {formatDate(currentCycle.endDate)}</span>
+            <span>
+              {formatDate(currentCycle.startDate)} - {formatDate(currentCycle.endDate)}
+            </span>
           </div>
           <div className="group-details-cycle-progress">
             <div className="group-details-progress-bar">
@@ -187,26 +191,19 @@ export function GroupDetails({
             className={`group-details-member-item ${onMemberClick ? 'group-details-member-clickable' : ''}`}
             onClick={() => onMemberClick?.(member)}
           >
-            <Avatar
-              name={member.name || member.address}
-              size="md"
-            />
+            <Avatar name={member.name || member.address} size="md" />
             <div className="group-details-member-info">
-              <div className="group-details-member-name">
-                {member.name || 'Anonymous'}
-              </div>
+              <div className="group-details-member-name">{member.name || 'Anonymous'}</div>
               <div className="group-details-member-address">
-                {member.address.substring(0, 8)}...{member.address.substring(member.address.length - 6)}
+                {member.address.substring(0, 8)}...
+                {member.address.substring(member.address.length - 6)}
               </div>
             </div>
             <div className="group-details-member-stats">
               <div className="group-details-member-contributions">
                 {formatAmount(member.totalContributions)}
               </div>
-              <Badge
-                variant={member.isActive ? 'success' : 'secondary'}
-                size="sm"
-              >
+              <Badge variant={member.isActive ? 'success' : 'secondary'} size="sm">
                 {member.isActive ? 'Active' : 'Inactive'}
               </Badge>
             </div>
@@ -230,10 +227,7 @@ export function GroupDetails({
             onClick={() => onContributionClick?.(contribution)}
           >
             <div className="group-details-contribution-main">
-              <Avatar
-                name={contribution.memberName || contribution.memberId}
-                size="sm"
-              />
+              <Avatar name={contribution.memberName || contribution.memberId} size="sm" />
               <div className="group-details-contribution-info">
                 <div className="group-details-contribution-member">
                   {contribution.memberName || 'Anonymous'}
@@ -290,18 +284,11 @@ export function GroupDetails({
         <div className="group-details-header">
           <div className="group-details-title-section">
             <h2 className="group-details-title">{group.name}</h2>
-            <Badge variant={getStatusVariant(group.status)}>
-              {group.status}
-            </Badge>
+            <Badge variant={getStatusVariant(group.status)}>{group.status}</Badge>
           </div>
         </div>
 
-        <Tabs
-          tabs={tabs}
-          defaultTab={selectedTab}
-          onChange={setSelectedTab}
-          variant="underline"
-        />
+        <Tabs tabs={tabs} defaultTab={selectedTab} onChange={setSelectedTab} variant="underline" />
       </Card>
     </div>
   );

--- a/frontend/src/components/GroupMetrics.css
+++ b/frontend/src/components/GroupMetrics.css
@@ -1,0 +1,71 @@
+.group-metrics {
+  width: 100%;
+  margin-top: 1rem;
+}
+
+.group-metrics-header h4 {
+  margin: 0 0 1rem 0;
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.87);
+}
+
+.group-metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.group-metric-item {
+  padding: 1rem;
+  border-radius: 8px;
+  background-color: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.group-metric-label {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.group-metric-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.group-metric-trend {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.group-metric-trend-improving {
+  color: #22c55e;
+}
+
+.group-metric-trend-declining {
+  color: #ef4444;
+}
+
+@media (prefers-color-scheme: light) {
+  .group-metrics-header h4 {
+    color: rgba(0, 0, 0, 0.87);
+  }
+
+  .group-metric-item {
+    background-color: rgba(0, 0, 0, 0.04);
+    border-color: rgba(0, 0, 0, 0.1);
+  }
+
+  .group-metric-label {
+    color: rgba(0, 0, 0, 0.6);
+  }
+
+  .group-metric-value {
+    color: rgba(0, 0, 0, 0.87);
+  }
+}

--- a/frontend/src/components/GroupMetrics.tsx
+++ b/frontend/src/components/GroupMetrics.tsx
@@ -1,0 +1,172 @@
+import './GroupMetrics.css';
+import { Card } from './Card';
+import type { DetailedGroup, GroupContribution, GroupCycle } from '../utils/groupApi';
+
+type Trend = 'improving' | 'declining';
+
+interface GroupMetricsProps {
+  group: DetailedGroup;
+  contributions: GroupContribution[];
+  cycles: GroupCycle[];
+  className?: string;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getCompletionRate(contributions: GroupContribution[]) {
+  if (contributions.length === 0) return 0;
+  const completedCount = contributions.filter((item) => item.status === 'completed').length;
+  return Math.round((completedCount / contributions.length) * 100);
+}
+
+function getAverageContributionTimeHours(contributions: GroupContribution[]) {
+  const completed = contributions
+    .filter((item) => item.status === 'completed')
+    .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+  if (completed.length < 2) {
+    return 0;
+  }
+
+  const intervals: number[] = [];
+  for (let i = 1; i < completed.length; i += 1) {
+    const previous = completed[i - 1].timestamp.getTime();
+    const current = completed[i].timestamp.getTime();
+    intervals.push((current - previous) / (1000 * 60 * 60));
+  }
+
+  const total = intervals.reduce((sum, value) => sum + value, 0);
+  return total / intervals.length;
+}
+
+function getCompletionTrend(cycles: GroupCycle[]): Trend {
+  if (cycles.length < 2) return 'improving';
+
+  const sorted = [...cycles].sort((a, b) => a.cycleNumber - b.cycleNumber);
+  const previousCycle = sorted[sorted.length - 2];
+  const latestCycle = sorted[sorted.length - 1];
+
+  const previousCompletion =
+    previousCycle.targetAmount > 0
+      ? (previousCycle.currentAmount / previousCycle.targetAmount) * 100
+      : 0;
+  const latestCompletion =
+    latestCycle.targetAmount > 0 ? (latestCycle.currentAmount / latestCycle.targetAmount) * 100 : 0;
+
+  return latestCompletion >= previousCompletion ? 'improving' : 'declining';
+}
+
+function getActivityTrend(contributions: GroupContribution[]): Trend {
+  if (contributions.length < 2) return 'improving';
+
+  const sorted = [...contributions].sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  const latestTimestamp = sorted[sorted.length - 1].timestamp.getTime();
+  const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+  const recentWindowStart = latestTimestamp - sevenDaysMs;
+  const previousWindowStart = recentWindowStart - sevenDaysMs;
+
+  const recentCount = sorted.filter((item) => item.timestamp.getTime() >= recentWindowStart).length;
+  const previousCount = sorted.filter((item) => {
+    const time = item.timestamp.getTime();
+    return time >= previousWindowStart && time < recentWindowStart;
+  }).length;
+
+  return recentCount >= previousCount ? 'improving' : 'declining';
+}
+
+function getAverageCycleCompletion(cycles: GroupCycle[]) {
+  if (cycles.length === 0) return 0;
+  const totalCompletion = cycles.reduce((sum, cycle) => {
+    if (cycle.targetAmount <= 0) return sum;
+    return sum + Math.min((cycle.currentAmount / cycle.targetAmount) * 100, 100);
+  }, 0);
+  return totalCompletion / cycles.length;
+}
+
+function getHealthScore(
+  completionRate: number,
+  averageCycleCompletion: number,
+  activityTrend: Trend,
+  groupProgress: number
+) {
+  const activityBonus = activityTrend === 'improving' ? 10 : 0;
+  return Math.round(
+    clamp(
+      completionRate * 0.5 + averageCycleCompletion * 0.2 + groupProgress * 0.2 + activityBonus,
+      0,
+      100
+    )
+  );
+}
+
+function formatAverageContributionTime(hours: number) {
+  if (hours <= 0) return '0 hours';
+  if (hours >= 24) {
+    return `${(hours / 24).toFixed(1)} days`;
+  }
+  return `${hours.toFixed(1)} hours`;
+}
+
+function getTrendLabel(trend: Trend) {
+  return trend === 'improving' ? 'Improving' : 'Declining';
+}
+
+export function GroupMetrics({ group, contributions, cycles, className = '' }: GroupMetricsProps) {
+  const completionRate = getCompletionRate(contributions);
+  const averageContributionTimeHours = getAverageContributionTimeHours(contributions);
+  const completionTrend = getCompletionTrend(cycles);
+  const activityTrend = getActivityTrend(contributions);
+  const averageCycleCompletion = getAverageCycleCompletion(cycles);
+  const groupProgress =
+    group.targetAmount > 0 ? Math.min((group.currentAmount / group.targetAmount) * 100, 100) : 0;
+  const healthScore = getHealthScore(
+    completionRate,
+    averageCycleCompletion,
+    activityTrend,
+    groupProgress
+  );
+  const healthTrend: Trend =
+    completionTrend === 'improving' && activityTrend === 'improving' ? 'improving' : 'declining';
+
+  return (
+    <Card className={`group-metrics ${className}`} variant="elevated">
+      <div className="group-metrics-header">
+        <h4>Performance Metrics</h4>
+      </div>
+
+      <div className="group-metrics-grid">
+        <div className="group-metric-item">
+          <div className="group-metric-label">Contribution Completion Rate</div>
+          <div className="group-metric-value" data-testid="completion-rate-value">
+            {completionRate}%
+          </div>
+          <div className={`group-metric-trend group-metric-trend-${completionTrend}`}>
+            {getTrendLabel(completionTrend)}
+          </div>
+        </div>
+
+        <div className="group-metric-item">
+          <div className="group-metric-label">Average Contribution Time</div>
+          <div className="group-metric-value" data-testid="average-time-value">
+            {formatAverageContributionTime(averageContributionTimeHours)}
+          </div>
+          <div className={`group-metric-trend group-metric-trend-${activityTrend}`}>
+            {getTrendLabel(activityTrend)}
+          </div>
+        </div>
+
+        <div className="group-metric-item">
+          <div className="group-metric-label">Group Health Score</div>
+          <div className="group-metric-value" data-testid="health-score-value">
+            {healthScore}/100
+          </div>
+          <div className={`group-metric-trend group-metric-trend-${healthTrend}`}>
+            {getTrendLabel(healthTrend)}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -25,6 +25,7 @@ export type { Group } from "./GroupList";
 export { GroupCard } from "./GroupCard";
 export { CreateGroupForm } from "./CreateGroupForm";
 export { GroupStats } from "./GroupStats";
+export { GroupMetrics } from "./GroupMetrics";
 export { GroupTimeline } from "./GroupTimeline";
 export type { TimelineEvent, TimelineEventType, GroupTimelineProps } from "./GroupTimeline";
 export { MemberList } from "./MemberList";

--- a/frontend/src/test/GroupMetrics.test.tsx
+++ b/frontend/src/test/GroupMetrics.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GroupMetrics } from '../components/GroupMetrics';
+import type { DetailedGroup, GroupContribution, GroupCycle } from '../utils/groupApi';
+
+function buildGroup(contributions: GroupContribution[], cycles: GroupCycle[]): DetailedGroup {
+  return {
+    id: 'g1',
+    name: 'Performance Group',
+    description: 'Metrics test group',
+    memberCount: 4,
+    contributionAmount: 100,
+    currency: 'XLM',
+    status: 'active',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    totalMembers: 4,
+    targetAmount: 1000,
+    currentAmount: 650,
+    contributionFrequency: 'weekly',
+    members: [],
+    contributions,
+    cycles,
+    currentCycle: cycles[cycles.length - 1],
+  };
+}
+
+describe('GroupMetrics', () => {
+  it('renders required metrics labels', () => {
+    const contributions: GroupContribution[] = [];
+    const cycles: GroupCycle[] = [];
+
+    render(
+      <GroupMetrics
+        group={buildGroup(contributions, cycles)}
+        contributions={contributions}
+        cycles={cycles}
+      />
+    );
+
+    expect(screen.getByText('Contribution Completion Rate')).toBeInTheDocument();
+    expect(screen.getByText('Average Contribution Time')).toBeInTheDocument();
+    expect(screen.getByText('Group Health Score')).toBeInTheDocument();
+  });
+
+  it('calculates completion rate, average contribution time, and health score', () => {
+    const contributions: GroupContribution[] = [
+      {
+        id: 'c1',
+        memberId: 'm1',
+        amount: 100,
+        timestamp: new Date('2026-01-01T00:00:00Z'),
+        transactionHash: 'tx1',
+        status: 'completed',
+      },
+      {
+        id: 'c2',
+        memberId: 'm2',
+        amount: 100,
+        timestamp: new Date('2026-01-03T00:00:00Z'),
+        transactionHash: 'tx2',
+        status: 'completed',
+      },
+      {
+        id: 'c3',
+        memberId: 'm3',
+        amount: 100,
+        timestamp: new Date('2026-01-06T00:00:00Z'),
+        transactionHash: 'tx3',
+        status: 'completed',
+      },
+      {
+        id: 'c4',
+        memberId: 'm4',
+        amount: 100,
+        timestamp: new Date('2026-01-07T00:00:00Z'),
+        transactionHash: 'tx4',
+        status: 'pending',
+      },
+    ];
+
+    const cycles: GroupCycle[] = [
+      {
+        cycleNumber: 1,
+        startDate: new Date('2026-01-01T00:00:00Z'),
+        endDate: new Date('2026-01-31T00:00:00Z'),
+        targetAmount: 1000,
+        currentAmount: 400,
+        status: 'completed',
+      },
+      {
+        cycleNumber: 2,
+        startDate: new Date('2026-02-01T00:00:00Z'),
+        endDate: new Date('2026-02-28T00:00:00Z'),
+        targetAmount: 1000,
+        currentAmount: 800,
+        status: 'active',
+      },
+    ];
+
+    render(
+      <GroupMetrics
+        group={buildGroup(contributions, cycles)}
+        contributions={contributions}
+        cycles={cycles}
+      />
+    );
+
+    expect(screen.getByTestId('completion-rate-value')).toHaveTextContent('75%');
+    expect(screen.getByTestId('average-time-value')).toHaveTextContent('2.5 days');
+    expect(screen.getByTestId('health-score-value')).toHaveTextContent('73/100');
+    expect(screen.getAllByText('Improving').length).toBeGreaterThan(0);
+  });
+
+  it('shows declining trend indicators when performance drops', () => {
+    const contributions: GroupContribution[] = [
+      {
+        id: 'c1',
+        memberId: 'm1',
+        amount: 100,
+        timestamp: new Date('2026-01-08T00:00:00Z'),
+        transactionHash: 'tx1',
+        status: 'completed',
+      },
+      {
+        id: 'c2',
+        memberId: 'm2',
+        amount: 100,
+        timestamp: new Date('2026-01-09T00:00:00Z'),
+        transactionHash: 'tx2',
+        status: 'completed',
+      },
+      {
+        id: 'c3',
+        memberId: 'm3',
+        amount: 100,
+        timestamp: new Date('2026-01-10T00:00:00Z'),
+        transactionHash: 'tx3',
+        status: 'completed',
+      },
+      {
+        id: 'c4',
+        memberId: 'm4',
+        amount: 100,
+        timestamp: new Date('2026-01-20T00:00:00Z'),
+        transactionHash: 'tx4',
+        status: 'completed',
+      },
+    ];
+
+    const cycles: GroupCycle[] = [
+      {
+        cycleNumber: 1,
+        startDate: new Date('2026-01-01T00:00:00Z'),
+        endDate: new Date('2026-01-31T00:00:00Z'),
+        targetAmount: 1000,
+        currentAmount: 900,
+        status: 'completed',
+      },
+      {
+        cycleNumber: 2,
+        startDate: new Date('2026-02-01T00:00:00Z'),
+        endDate: new Date('2026-02-28T00:00:00Z'),
+        targetAmount: 1000,
+        currentAmount: 600,
+        status: 'active',
+      },
+    ];
+
+    render(
+      <GroupMetrics
+        group={buildGroup(contributions, cycles)}
+        contributions={contributions}
+        cycles={cycles}
+      />
+    );
+
+    expect(screen.getAllByText('Declining').length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
### Summary
Implements group performance metrics in the frontend by adding a dedicated `GroupMetrics` component and integrating it into the group details overview.

### Changes
- Added `GroupMetrics` component to display:
  - Contribution completion rate
  - Average contribution time
  - Group health score
- Added trend indicators (`Improving` / `Declining`) for metrics.
- Integrated metrics into `GroupDetails` overview.
- Added `GroupMetrics` tests for:
  - Metric rendering
  - Calculation correctness
  - Trend state behavior

Closes #546 