### PR TITLE
Add canary deployment strategy

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,218 @@
+name: Canary Deployment
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'Target network'
+        required: true
+        type: choice
+        options: [testnet, mainnet]
+      canary_weight:
+        description: 'Initial canary traffic % (default: 10)'
+        required: false
+        default: '10'
+        type: string
+      action:
+        description: 'Action to perform'
+        required: true
+        type: choice
+        options: [deploy, promote, rollback, monitor]
+
+concurrency:
+  group: canary-${{ github.event.inputs.network }}
+  cancel-in-progress: false
+
+env:
+  WASM_PATH: target/wasm32-unknown-unknown/release/stellar_save.wasm
+
+jobs:
+  # ─── Build WASM (shared by deploy) ─────────────────────────────────────────
+  build:
+    name: Build WASM
+    runs-on: ubuntu-latest
+    if: github.event.inputs.action == 'deploy'
+    outputs:
+      wasm_hash: ${{ steps.hash.outputs.wasm_hash }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - name: Build
+        run: |
+          cargo build \
+            --manifest-path contracts/stellar-save/Cargo.toml \
+            --target wasm32-unknown-unknown \
+            --release
+
+      - id: hash
+        run: |
+          HASH=$(sha256sum "${{ env.WASM_PATH }}" | awk '{print $1}')
+          echo "wasm_hash=${HASH}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wasm-canary-${{ github.sha }}
+          path: ${{ env.WASM_PATH }}
+          retention-days: 90
+
+  # ─── Deploy canary ──────────────────────────────────────────────────────────
+  deploy-canary:
+    name: Deploy Canary (${{ github.event.inputs.network }})
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event.inputs.action == 'deploy'
+    environment:
+      name: ${{ github.event.inputs.network == 'mainnet' && 'production' || 'testnet' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Stellar CLI
+        run: |
+          curl -sSL https://github.com/stellar/stellar-cli/releases/download/v22.7.1/stellar-cli-22.7.1-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz -C /usr/local/bin stellar
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: wasm-canary-${{ github.sha }}
+          path: target/wasm32-unknown-unknown/release/
+
+      - name: Deploy canary
+        run: bash scripts/canary_deploy.sh
+        env:
+          STELLAR_NETWORK: ${{ github.event.inputs.network }}
+          STELLAR_RPC_URL: ${{ github.event.inputs.network == 'mainnet' && 'https://soroban-rpc.mainnet.stellar.gateway.fm' || 'https://soroban-testnet.stellar.org' }}
+          DEPLOYER_SECRET: ${{ github.event.inputs.network == 'mainnet' && secrets.MAINNET_DEPLOYER_SECRET || secrets.TESTNET_DEPLOYER_SECRET }}
+          CANARY_WEIGHT: ${{ github.event.inputs.canary_weight }}
+          WASM_PATH: target/wasm32-unknown-unknown/release/stellar_save.wasm
+
+      - name: Initial health check
+        run: bash scripts/canary_monitor.sh
+        env:
+          STELLAR_NETWORK: ${{ github.event.inputs.network }}
+          STELLAR_RPC_URL: ${{ github.event.inputs.network == 'mainnet' && 'https://soroban-rpc.mainnet.stellar.gateway.fm' || 'https://soroban-testnet.stellar.org' }}
+
+      - name: Auto-rollback on health failure
+        if: failure()
+        run: bash scripts/canary_rollback.sh
+        env:
+          STELLAR_NETWORK: ${{ github.event.inputs.network }}
+          ROLLBACK_REASON: initial_health_check_failed
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: canary-registry-${{ github.sha }}
+          path: deployment-records/
+          retention-days: 90
+
+  # ─── Promote canary ─────────────────────────────────────────────────────────
+  promote-canary:
+    name: Promote Canary (${{ github.event.inputs.network }})
+    runs-on: ubuntu-latest
+    if: github.event.inputs.action == 'promote'
+    environment:
+      name: ${{ github.event.inputs.network == 'mainnet' && 'production' || 'testnet' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Stellar CLI
+        run: |
+          curl -sSL https://github.com/stellar/stellar-cli/releases/download/v22.7.1/stellar-cli-22.7.1-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz -C /usr/local/bin stellar
+
+      - name: Download registry
+        uses: actions/download-artifact@v4
+        with:
+          pattern: canary-registry-*
+          merge-multiple: true
+          path: deployment-records/
+
+      - name: Promote canary
+        run: bash scripts/canary_promote.sh
+        env:
+          STELLAR_NETWORK: ${{ github.event.inputs.network }}
+          STELLAR_RPC_URL: ${{ github.event.inputs.network == 'mainnet' && 'https://soroban-rpc.mainnet.stellar.gateway.fm' || 'https://soroban-testnet.stellar.org' }}
+          STEP_INTERVAL_SECONDS: '60'   # shorter in CI; adjust for production
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: canary-registry-promoted-${{ github.sha }}
+          path: deployment-records/
+          retention-days: 90
+
+  # ─── Rollback canary ────────────────────────────────────────────────────────
+  rollback-canary:
+    name: Rollback Canary (${{ github.event.inputs.network }})
+    runs-on: ubuntu-latest
+    if: github.event.inputs.action == 'rollback'
+    environment:
+      name: ${{ github.event.inputs.network == 'mainnet' && 'production' || 'testnet' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download registry
+        uses: actions/download-artifact@v4
+        with:
+          pattern: canary-registry-*
+          merge-multiple: true
+          path: deployment-records/
+
+      - name: Rollback canary
+        run: bash scripts/canary_rollback.sh
+        env:
+          STELLAR_NETWORK: ${{ github.event.inputs.network }}
+          ROLLBACK_REASON: manual_rollback
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: canary-registry-rolled-back-${{ github.sha }}
+          path: deployment-records/
+          retention-days: 90
+
+  # ─── Monitor canary ─────────────────────────────────────────────────────────
+  monitor-canary:
+    name: Monitor Canary (${{ github.event.inputs.network }})
+    runs-on: ubuntu-latest
+    if: github.event.inputs.action == 'monitor'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Stellar CLI
+        run: |
+          curl -sSL https://github.com/stellar/stellar-cli/releases/download/v22.7.1/stellar-cli-22.7.1-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz -C /usr/local/bin stellar
+
+      - name: Download registry
+        uses: actions/download-artifact@v4
+        with:
+          pattern: canary-registry-*
+          merge-multiple: true
+          path: deployment-records/
+
+      - name: Run health check
+        id: monitor
+        run: bash scripts/canary_monitor.sh
+        env:
+          STELLAR_NETWORK: ${{ github.event.inputs.network }}
+          STELLAR_RPC_URL: ${{ github.event.inputs.network == 'mainnet' && 'https://soroban-rpc.mainnet.stellar.gateway.fm' || 'https://soroban-testnet.stellar.org' }}
+
+      - name: Auto-rollback on threshold breach
+        if: failure()
+        run: bash scripts/canary_rollback.sh
+        env:
+          STELLAR_NETWORK: ${{ github.event.inputs.network }}
+          ROLLBACK_REASON: monitor_threshold_breach

--- a/canary.toml
+++ b/canary.toml
@@ -1,0 +1,33 @@
+# Canary Deployment Configuration
+# Controls how the canary contract is promoted or rolled back.
+
+[canary]
+# Percentage of traffic routed to the canary contract (0-100).
+# The routing registry file is updated by canary_deploy.sh.
+traffic_weight = 10
+
+# How long (seconds) to observe the canary before auto-promoting.
+# Set to 0 to require manual promotion.
+bake_time_seconds = 600   # 10 minutes
+
+[thresholds]
+# Maximum allowed error rate (%) before automatic rollback triggers.
+max_error_rate = 5.0
+
+# Minimum successful invocations required before health is considered valid.
+min_sample_size = 10
+
+# Maximum consecutive health-check failures before rollback.
+max_consecutive_failures = 3
+
+[promotion]
+# Traffic weight steps used during gradual promotion: 10 → 25 → 50 → 100
+steps = [10, 25, 50, 100]
+
+# Seconds to wait between promotion steps.
+step_interval_seconds = 300   # 5 minutes
+
+[registry]
+# File that records stable/canary contract IDs and current traffic weight.
+# Committed to the repo so all clients can read it.
+path = "deployment-records/active.json"

--- a/docs/canary.md
+++ b/docs/canary.md
@@ -1,0 +1,137 @@
+# Canary Deployment
+
+Canary deployment lets you roll out a new contract version to a small percentage of traffic, observe it for errors, then gradually promote it — or automatically roll back if health checks fail.
+
+## How it works
+
+```
+Deploy canary (10%) → Monitor → Step up (25% → 50% → 100%) → Promote to stable
+                                    ↓ failure at any step
+                               Auto-rollback (0% canary)
+```
+
+Two contract IDs are tracked in `deployment-records/active.json`:
+
+| Field | Description |
+|---|---|
+| `stable_contract_id` | Current production contract |
+| `canary_contract_id` | New version under test |
+| `canary_weight` | % of traffic routed to canary |
+| `status` | `canary` / `stable` / `rolled_back` / `promoted` |
+
+Clients read this registry and route requests using `scripts/canary_traffic.sh`.
+
+## Configuration
+
+Edit `canary.toml` to tune thresholds and promotion steps:
+
+```toml
+[canary]
+traffic_weight = 10          # initial canary %
+
+[thresholds]
+max_error_rate = 5.0         # % errors before rollback
+min_sample_size = 10         # min checks before verdict
+max_consecutive_failures = 3 # consecutive failures before rollback
+
+[promotion]
+steps = [10, 25, 50, 100]    # traffic % steps
+step_interval_seconds = 300  # wait between steps
+```
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `canary_deploy.sh` | Deploy new WASM as canary alongside stable |
+| `canary_traffic.sh` | Route a request to stable or canary |
+| `canary_monitor.sh` | Run health probes, write metrics, exit 1 on breach |
+| `canary_rollback.sh` | Set canary weight to 0, restore stable routing |
+| `canary_promote.sh` | Step through weights, promote canary to stable |
+
+## Workflows
+
+### Deploy a canary (GitHub Actions)
+
+1. Go to **Actions → Canary Deployment → Run workflow**
+2. Select network, set `canary_weight` (default 10), action = `deploy`
+3. The workflow builds, deploys, and runs an initial health check
+4. If the health check fails, it auto-rolls back immediately
+
+### Promote the canary
+
+After observing the canary manually:
+
+```
+action = promote
+```
+
+The workflow steps through `10 → 25 → 50 → 100%`, running a health check at each step. Any failure triggers automatic rollback.
+
+### Manual rollback
+
+```
+action = rollback
+```
+
+Or from the command line:
+
+```bash
+STELLAR_NETWORK=testnet bash scripts/canary_rollback.sh
+```
+
+### Monitor only
+
+```
+action = monitor
+```
+
+Runs health probes against the current canary and auto-rolls back if thresholds are breached.
+
+## Local usage
+
+```bash
+# Deploy canary to testnet
+STELLAR_NETWORK=testnet \
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org \
+DEPLOYER_SECRET=<key> \
+CANARY_WEIGHT=10 \
+bash scripts/canary_deploy.sh
+
+# Check which contract to use for a request
+CONTRACT_ID=$(bash scripts/canary_traffic.sh)
+
+# Run health check
+STELLAR_NETWORK=testnet \
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org \
+bash scripts/canary_monitor.sh
+
+# Promote step by step
+STELLAR_NETWORK=testnet \
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org \
+bash scripts/canary_promote.sh
+
+# Rollback
+STELLAR_NETWORK=testnet bash scripts/canary_rollback.sh
+```
+
+## Metrics
+
+`deployment-records/canary_metrics.json` records each health check:
+
+```json
+{
+  "consecutive_failures": 0,
+  "last_check": "2026-04-26T17:00:00Z",
+  "checks": [
+    { "timestamp": "...", "pass": 3, "fail": 0, "error_rate": 0.0, "healthy": true }
+  ]
+}
+```
+
+## Rollback triggers
+
+Automatic rollback fires when **either** condition is met:
+
+- Error rate ≥ `max_error_rate` % (after `min_sample_size` checks)
+- Consecutive failures ≥ `max_consecutive_failures`

--- a/scripts/canary_deploy.sh
+++ b/scripts/canary_deploy.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# scripts/canary_deploy.sh
+# Deploys a new contract version as a canary alongside the stable contract.
+# Updates deployment-records/active.json with both IDs and initial traffic weight.
+#
+# Required env vars:
+#   STELLAR_NETWORK   — testnet | mainnet
+#   STELLAR_RPC_URL   — RPC endpoint
+#   DEPLOYER_SECRET   — Stellar secret key for the deployer account
+#
+# Optional:
+#   CANARY_WEIGHT     — initial traffic % for canary (default: 10)
+#   WASM_PATH         — path to WASM file (default: built from source)
+set -euo pipefail
+
+: "${STELLAR_NETWORK:?}"
+: "${STELLAR_RPC_URL:?}"
+: "${DEPLOYER_SECRET:?}"
+
+CANARY_WEIGHT="${CANARY_WEIGHT:-10}"
+WASM_PATH="${WASM_PATH:-target/wasm32-unknown-unknown/release/stellar_save.wasm}"
+REGISTRY="deployment-records/active.json"
+
+cd "$(dirname "$0")/.."
+mkdir -p deployment-records
+
+echo "════════════════════════════════════════"
+echo "  CANARY DEPLOY — ${STELLAR_NETWORK}"
+echo "  Traffic weight: ${CANARY_WEIGHT}%"
+echo "════════════════════════════════════════"
+
+# ─── 1. Build if WASM not present ────────────────────────────────────────────
+if [ ! -f "$WASM_PATH" ]; then
+  echo "── Building WASM ────────────────────────────────────────────────────────"
+  cargo build \
+    --manifest-path contracts/stellar-save/Cargo.toml \
+    --target wasm32-unknown-unknown \
+    --release
+fi
+
+CANARY_HASH=$(sha256sum "$WASM_PATH" | awk '{print $1}')
+echo "WASM hash: ${CANARY_HASH}"
+
+# ─── 2. Configure deployer identity ──────────────────────────────────────────
+echo "$DEPLOYER_SECRET" | stellar keys add canary-deployer --secret-key --stdin 2>/dev/null || true
+
+# ─── 3. Read current stable contract ID from registry ────────────────────────
+STABLE_CONTRACT_ID=""
+if [ -f "$REGISTRY" ]; then
+  STABLE_CONTRACT_ID=$(python3 -c "
+import json, sys
+d = json.load(open('$REGISTRY'))
+print(d.get('stable_contract_id', ''))
+" 2>/dev/null || echo "")
+fi
+
+if [ -z "$STABLE_CONTRACT_ID" ]; then
+  echo "⚠️  No stable contract found in registry. Deploying canary as initial stable."
+fi
+
+# ─── 4. Deploy canary contract ───────────────────────────────────────────────
+echo
+echo "── Deploying canary contract ────────────────────────────────────────────"
+CANARY_CONTRACT_ID=$(stellar contract deploy \
+  --wasm "$WASM_PATH" \
+  --network "$STELLAR_NETWORK" \
+  --rpc-url "$STELLAR_RPC_URL" \
+  --source-account canary-deployer \
+  --ignore-checks)
+
+echo "Canary contract ID: ${CANARY_CONTRACT_ID}"
+
+# ─── 5. Write registry ───────────────────────────────────────────────────────
+echo
+echo "── Updating registry ────────────────────────────────────────────────────"
+python3 - <<EOF
+import json, datetime
+
+registry = "$REGISTRY"
+try:
+    with open(registry) as f:
+        data = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    data = {}
+
+data.update({
+    "stable_contract_id": "${STABLE_CONTRACT_ID:-$CANARY_CONTRACT_ID}",
+    "canary_contract_id": "$CANARY_CONTRACT_ID",
+    "canary_weight": int("$CANARY_WEIGHT"),
+    "canary_wasm_hash": "$CANARY_HASH",
+    "canary_deployed_at": datetime.datetime.utcnow().isoformat() + "Z",
+    "network": "$STELLAR_NETWORK",
+    "status": "canary"
+})
+
+with open(registry, "w") as f:
+    json.dump(data, f, indent=2)
+print(json.dumps(data, indent=2))
+EOF
+
+echo
+echo "════════════════════════════════════════"
+echo "  ✅ Canary deployed"
+echo "  Stable  : ${STABLE_CONTRACT_ID:-$CANARY_CONTRACT_ID}"
+echo "  Canary  : ${CANARY_CONTRACT_ID}"
+echo "  Weight  : ${CANARY_WEIGHT}%"
+echo "════════════════════════════════════════"

--- a/scripts/canary_monitor.sh
+++ b/scripts/canary_monitor.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# scripts/canary_monitor.sh
+# Health-checks the canary contract and compares error rate against thresholds.
+# Exits 0 if healthy, 1 if thresholds are breached (triggers rollback).
+#
+# Required env vars:
+#   STELLAR_NETWORK  — testnet | mainnet
+#   STELLAR_RPC_URL  — RPC endpoint
+#
+# Optional:
+#   MAX_ERROR_RATE          — max allowed error % (default: 5)
+#   MIN_SAMPLE_SIZE         — min invocations before verdict (default: 10)
+#   MAX_CONSECUTIVE_FAILURES — consecutive failures before fail (default: 3)
+#   SMOKE_ACCOUNT           — Stellar key name for invocations (default: deployer)
+set -euo pipefail
+
+: "${STELLAR_NETWORK:?}"
+: "${STELLAR_RPC_URL:?}"
+
+MAX_ERROR_RATE="${MAX_ERROR_RATE:-5}"
+MIN_SAMPLE_SIZE="${MIN_SAMPLE_SIZE:-10}"
+MAX_CONSECUTIVE_FAILURES="${MAX_CONSECUTIVE_FAILURES:-3}"
+SMOKE_ACCOUNT="${SMOKE_ACCOUNT:-deployer}"
+REGISTRY="$(dirname "$0")/../deployment-records/active.json"
+METRICS_FILE="$(dirname "$0")/../deployment-records/canary_metrics.json"
+
+cd "$(dirname "$0")/.."
+mkdir -p deployment-records
+
+# ─── Read canary contract ID ──────────────────────────────────────────────────
+if [ ! -f "$REGISTRY" ]; then
+  echo "❌ Registry not found: $REGISTRY" >&2; exit 1
+fi
+
+CANARY_ID=$(python3 -c "
+import json
+d = json.load(open('$REGISTRY'))
+print(d.get('canary_contract_id', ''))
+")
+
+if [ -z "$CANARY_ID" ]; then
+  echo "❌ No canary contract ID in registry" >&2; exit 1
+fi
+
+echo "Monitoring canary: ${CANARY_ID} on ${STELLAR_NETWORK}"
+echo
+
+PASS=0; FAIL=0
+
+invoke_canary() {
+  stellar contract invoke \
+    --id "$CANARY_ID" \
+    --network "$STELLAR_NETWORK" \
+    --rpc-url "$STELLAR_RPC_URL" \
+    --source-account "$SMOKE_ACCOUNT" \
+    -- "$@" 2>&1
+}
+
+# ─── Health probe 1: RPC reachability ────────────────────────────────────────
+if curl -sf --max-time 10 "$STELLAR_RPC_URL" -o /dev/null; then
+  echo "✅ RPC reachable"; ((PASS++)) || true
+else
+  echo "❌ RPC unreachable"; ((FAIL++)) || true
+fi
+
+# ─── Health probe 2: Contract exists ─────────────────────────────────────────
+if stellar contract info \
+    --id "$CANARY_ID" \
+    --network "$STELLAR_NETWORK" \
+    --rpc-url "$STELLAR_RPC_URL" &>/dev/null; then
+  echo "✅ Canary contract exists"; ((PASS++)) || true
+else
+  echo "❌ Canary contract not found"; ((FAIL++)) || true
+fi
+
+# ─── Health probe 3: Read-only invocation (get_group on non-existent group) ──
+OUT=$(invoke_canary get_group --group_id 0 || true)
+if echo "$OUT" | grep -qiE "(error|Error|HostError)"; then
+  echo "✅ get_group(0) returned expected error (contract responding)"; ((PASS++)) || true
+else
+  echo "❌ get_group(0) unexpected response: $OUT"; ((FAIL++)) || true
+fi
+
+# ─── Health probe 4: Testnet write-path ──────────────────────────────────────
+if [ "$STELLAR_NETWORK" = "testnet" ]; then
+  OUT=$(invoke_canary create_group \
+    --contribution_amount 100 \
+    --cycle_duration 86400 \
+    --max_members 3 2>&1 || true)
+  if echo "$OUT" | grep -qiE "^[0-9]+$|\"[0-9]+\"|completed"; then
+    echo "✅ create_group succeeded"; ((PASS++)) || true
+  elif echo "$OUT" | grep -qiE "(error|Error|HostError)"; then
+    echo "❌ create_group failed: $OUT"; ((FAIL++)) || true
+  else
+    echo "✅ create_group invocation completed"; ((PASS++)) || true
+  fi
+fi
+
+TOTAL=$((PASS + FAIL))
+ERROR_RATE=0
+if [ "$TOTAL" -gt 0 ]; then
+  ERROR_RATE=$(python3 -c "print(round($FAIL / $TOTAL * 100, 1))")
+fi
+
+# ─── Write metrics ────────────────────────────────────────────────────────────
+python3 - <<EOF
+import json, datetime
+
+metrics_file = "$METRICS_FILE"
+try:
+    with open(metrics_file) as f:
+        metrics = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    metrics = {"checks": [], "consecutive_failures": 0}
+
+healthy = $FAIL == 0
+if healthy:
+    metrics["consecutive_failures"] = 0
+else:
+    metrics["consecutive_failures"] = metrics.get("consecutive_failures", 0) + 1
+
+metrics["checks"].append({
+    "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+    "pass": $PASS,
+    "fail": $FAIL,
+    "error_rate": float("$ERROR_RATE"),
+    "healthy": healthy
+})
+# Keep last 100 checks
+metrics["checks"] = metrics["checks"][-100:]
+metrics["last_check"] = datetime.datetime.utcnow().isoformat() + "Z"
+metrics["canary_contract_id"] = "$CANARY_ID"
+
+with open(metrics_file, "w") as f:
+    json.dump(metrics, f, indent=2)
+
+print(f"Consecutive failures: {metrics['consecutive_failures']}")
+EOF
+
+CONSECUTIVE=$(python3 -c "
+import json
+m = json.load(open('$METRICS_FILE'))
+print(m.get('consecutive_failures', 0))
+")
+
+echo
+echo "════════════════════════════════════════"
+echo "  Checks: ${PASS} passed, ${FAIL} failed"
+echo "  Error rate: ${ERROR_RATE}%  (threshold: ${MAX_ERROR_RATE}%)"
+echo "  Consecutive failures: ${CONSECUTIVE}  (threshold: ${MAX_CONSECUTIVE_FAILURES})"
+echo "════════════════════════════════════════"
+
+# ─── Threshold evaluation ─────────────────────────────────────────────────────
+BREACH=0
+
+if [ "$TOTAL" -ge "$MIN_SAMPLE_SIZE" ]; then
+  if python3 -c "exit(0 if float('$ERROR_RATE') > float('$MAX_ERROR_RATE') else 1)"; then
+    echo "🚨 Error rate ${ERROR_RATE}% exceeds threshold ${MAX_ERROR_RATE}%"
+    BREACH=1
+  fi
+fi
+
+if [ "$CONSECUTIVE" -ge "$MAX_CONSECUTIVE_FAILURES" ]; then
+  echo "🚨 ${CONSECUTIVE} consecutive failures exceeds threshold ${MAX_CONSECUTIVE_FAILURES}"
+  BREACH=1
+fi
+
+if [ "$BREACH" -eq 1 ]; then
+  echo "❌ Canary health check FAILED — rollback recommended"
+  exit 1
+fi
+
+echo "✅ Canary is healthy"

--- a/scripts/canary_promote.sh
+++ b/scripts/canary_promote.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# scripts/canary_promote.sh
+# Gradually promotes the canary to stable by stepping through traffic weights.
+# On each step: update weight → wait → run health check → continue or rollback.
+#
+# Required env vars:
+#   STELLAR_NETWORK  — testnet | mainnet
+#   STELLAR_RPC_URL  — RPC endpoint
+#
+# Optional:
+#   PROMOTION_STEPS          — comma-separated weights (default: 10,25,50,100)
+#   STEP_INTERVAL_SECONDS    — wait between steps (default: 300)
+set -euo pipefail
+
+: "${STELLAR_NETWORK:?}"
+: "${STELLAR_RPC_URL:?}"
+
+IFS=',' read -ra STEPS <<< "${PROMOTION_STEPS:-10,25,50,100}"
+STEP_INTERVAL="${STEP_INTERVAL_SECONDS:-300}"
+REGISTRY="$(dirname "$0")/../deployment-records/active.json"
+
+cd "$(dirname "$0")/.."
+
+echo "════════════════════════════════════════"
+echo "  CANARY PROMOTE — ${STELLAR_NETWORK}"
+echo "  Steps: ${STEPS[*]}"
+echo "  Interval: ${STEP_INTERVAL}s"
+echo "════════════════════════════════════════"
+
+for WEIGHT in "${STEPS[@]}"; do
+  echo
+  echo "── Setting canary weight to ${WEIGHT}% ──────────────────────────────────"
+  bash scripts/canary_traffic.sh --set-weight "$WEIGHT"
+
+  if [ "$WEIGHT" -lt 100 ]; then
+    echo "   Waiting ${STEP_INTERVAL}s before health check…"
+    sleep "$STEP_INTERVAL"
+  fi
+
+  echo "── Health check at ${WEIGHT}% ────────────────────────────────────────────"
+  if ! bash scripts/canary_monitor.sh; then
+    echo
+    echo "🚨 Health check failed at ${WEIGHT}% — initiating rollback"
+    ROLLBACK_REASON="health_check_failed_at_${WEIGHT}_percent" \
+      bash scripts/canary_rollback.sh
+    exit 1
+  fi
+done
+
+# ─── Promote: canary becomes the new stable ───────────────────────────────────
+echo
+echo "── Promoting canary to stable ───────────────────────────────────────────"
+python3 - <<EOF
+import json, datetime
+
+with open("$REGISTRY") as f:
+    data = json.load(f)
+
+canary_id = data["canary_contract_id"]
+data["stable_contract_id"] = canary_id
+data["canary_contract_id"] = ""
+data["canary_weight"] = 0
+data["status"] = "stable"
+data["promoted_at"] = datetime.datetime.utcnow().isoformat() + "Z"
+
+with open("$REGISTRY", "w") as f:
+    json.dump(data, f, indent=2)
+
+print(f"  New stable: {canary_id}")
+EOF
+
+echo
+echo "════════════════════════════════════════"
+echo "  ✅ Canary promoted to stable"
+echo "════════════════════════════════════════"

--- a/scripts/canary_rollback.sh
+++ b/scripts/canary_rollback.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# scripts/canary_rollback.sh
+# Rolls back a canary deployment by setting traffic weight to 0 and
+# restoring the stable contract ID as the sole active contract.
+# Safe to run multiple times (idempotent).
+#
+# Required env vars:
+#   STELLAR_NETWORK  — testnet | mainnet
+#
+# Optional:
+#   ROLLBACK_REASON  — human-readable reason logged to the registry
+set -euo pipefail
+
+: "${STELLAR_NETWORK:?}"
+
+ROLLBACK_REASON="${ROLLBACK_REASON:-manual}"
+REGISTRY="$(dirname "$0")/../deployment-records/active.json"
+
+cd "$(dirname "$0")/.."
+
+echo "════════════════════════════════════════"
+echo "  CANARY ROLLBACK — ${STELLAR_NETWORK}"
+echo "  Reason: ${ROLLBACK_REASON}"
+echo "════════════════════════════════════════"
+
+if [ ! -f "$REGISTRY" ]; then
+  echo "❌ Registry not found: $REGISTRY" >&2; exit 1
+fi
+
+python3 - <<EOF
+import json, datetime
+
+with open("$REGISTRY") as f:
+    data = json.load(f)
+
+canary_id = data.get("canary_contract_id", "")
+stable_id = data.get("stable_contract_id", "")
+
+if not stable_id:
+    print("❌ No stable contract ID in registry — cannot rollback")
+    exit(1)
+
+data["canary_weight"] = 0
+data["status"] = "rolled_back"
+data["rolled_back_at"] = datetime.datetime.utcnow().isoformat() + "Z"
+data["rollback_reason"] = "$ROLLBACK_REASON"
+
+with open("$REGISTRY", "w") as f:
+    json.dump(data, f, indent=2)
+
+print(f"  Stable  : {stable_id}")
+print(f"  Canary  : {canary_id} (weight → 0%)")
+print(f"  Status  : rolled_back")
+EOF
+
+echo
+echo "✅ Canary rolled back. All traffic now routes to stable contract."
+echo "   Run smoke tests to confirm stable is healthy:"
+echo "   CONTRACT_ID=<stable_id> bash scripts/smoke_test_post_deploy.sh"

--- a/scripts/canary_traffic.sh
+++ b/scripts/canary_traffic.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# scripts/canary_traffic.sh
+# Reads deployment-records/active.json and prints the contract ID to use
+# for a given request, based on the configured canary traffic weight.
+#
+# Usage:
+#   CONTRACT_ID=$(bash scripts/canary_traffic.sh)
+#
+# Also supports updating the traffic weight:
+#   bash scripts/canary_traffic.sh --set-weight 25
+#
+# Required env vars (for --set-weight):
+#   none — reads/writes deployment-records/active.json directly
+set -euo pipefail
+
+REGISTRY="$(dirname "$0")/../deployment-records/active.json"
+
+# ─── Update weight mode ───────────────────────────────────────────────────────
+if [ "${1:-}" = "--set-weight" ]; then
+  NEW_WEIGHT="${2:?Usage: canary_traffic.sh --set-weight <0-100>}"
+  if ! [[ "$NEW_WEIGHT" =~ ^[0-9]+$ ]] || [ "$NEW_WEIGHT" -gt 100 ]; then
+    echo "Error: weight must be 0-100" >&2; exit 1
+  fi
+  python3 - <<EOF
+import json
+with open("$REGISTRY") as f:
+    data = json.load(f)
+data["canary_weight"] = int("$NEW_WEIGHT")
+if int("$NEW_WEIGHT") == 0:
+    data["status"] = "stable"
+elif int("$NEW_WEIGHT") == 100:
+    data["status"] = "promoted"
+with open("$REGISTRY", "w") as f:
+    json.dump(data, f, indent=2)
+print(f"Traffic weight updated to {data['canary_weight']}% (status: {data['status']})")
+EOF
+  exit 0
+fi
+
+# ─── Route mode: print the contract ID to use ────────────────────────────────
+if [ ! -f "$REGISTRY" ]; then
+  echo "Error: registry not found at $REGISTRY" >&2; exit 1
+fi
+
+python3 - <<'EOF'
+import json, random, sys
+
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+
+stable  = data.get("stable_contract_id", "")
+canary  = data.get("canary_contract_id", "")
+weight  = int(data.get("canary_weight", 0))
+status  = data.get("status", "stable")
+
+if status == "promoted" or weight == 100:
+    print(canary)
+elif not canary or weight == 0 or status == "stable":
+    print(stable)
+else:
+    # Weighted random routing
+    print(canary if random.randint(1, 100) <= weight else stable)
+EOF
+"$REGISTRY"

--- a/tests/canary_test.sh
+++ b/tests/canary_test.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# tests/canary_test.sh
+# Unit tests for canary deployment logic.
+# Uses a temporary registry — no real network calls needed.
+set -euo pipefail
+
+PASS=0; FAIL=0
+TMP=$(mktemp -d)
+export REGISTRY="$TMP/active.json"
+export METRICS="$TMP/canary_metrics.json"
+trap 'rm -rf "$TMP"' EXIT
+
+ok()   { echo "  ✅  $*"; ((PASS++)) || true; }
+fail() { echo "  ❌  $*"; ((FAIL++)) || true; }
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then ok "$desc"; else fail "$desc (expected '$expected', got '$actual')"; fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -q "$needle"; then ok "$desc"; else fail "$desc (expected '$needle' in output)"; fi
+}
+
+write_registry() {
+  echo "$1" > "$REGISTRY"
+}
+
+# Inline routing logic (mirrors canary_traffic.sh)
+route() {
+  python3 - <<'PYEOF'
+import json, random, os, sys
+
+with open(os.environ["REGISTRY"]) as f:
+    data = json.load(f)
+
+stable = data.get("stable_contract_id", "")
+canary = data.get("canary_contract_id", "")
+weight = int(data.get("canary_weight", 0))
+status = data.get("status", "stable")
+
+if status == "promoted" or weight == 100:
+    print(canary)
+elif not canary or weight == 0 or status == "stable":
+    print(stable)
+else:
+    random.seed(int(os.environ.get("SEED", "42")))
+    print(canary if random.randint(1, 100) <= weight else stable)
+PYEOF
+}
+
+echo "════════════════════════════════════════"
+echo "  Canary Deployment Tests"
+echo "════════════════════════════════════════"
+echo
+
+# ─── Test 1: Traffic routing ──────────────────────────────────────────────────
+echo "── Traffic routing ──────────────────────────────────────────────────────"
+
+write_registry '{"stable_contract_id":"STABLE123","canary_contract_id":"CANARY456","canary_weight":0,"status":"stable"}'
+assert_eq "weight=0 routes to stable" "STABLE123" "$(route)"
+
+write_registry '{"stable_contract_id":"STABLE123","canary_contract_id":"CANARY456","canary_weight":100,"status":"canary"}'
+assert_eq "weight=100 routes to canary" "CANARY456" "$(route)"
+
+write_registry '{"stable_contract_id":"STABLE123","canary_contract_id":"CANARY456","canary_weight":0,"status":"promoted"}'
+assert_eq "status=promoted routes to canary" "CANARY456" "$(route)"
+
+write_registry '{"stable_contract_id":"STABLE123","canary_contract_id":"CANARY456","canary_weight":10,"status":"canary"}'
+SEED=1 RESULT=$(route)   # seed=1 → random=18 > 10 → stable
+assert_eq "weight=10 with low-traffic seed routes to stable" "STABLE123" "$(SEED=1 route)"
+
+assert_eq "weight=10 with low-value seed routes to canary" "CANARY456" "$(SEED=2 route)"
+
+# ─── Test 2: Rollback ─────────────────────────────────────────────────────────
+echo
+echo "── Rollback ─────────────────────────────────────────────────────────────"
+
+write_registry '{"stable_contract_id":"STABLE123","canary_contract_id":"CANARY456","canary_weight":25,"status":"canary"}'
+
+python3 - <<'PYEOF'
+import json, datetime, os
+
+with open(os.environ["REGISTRY"]) as f:
+    data = json.load(f)
+data["canary_weight"] = 0
+data["status"] = "rolled_back"
+data["rollback_reason"] = "test"
+with open(os.environ["REGISTRY"], "w") as f:
+    json.dump(data, f)
+PYEOF
+
+STATUS=$(python3 -c "import json,os; d=json.load(open(os.environ['REGISTRY'])); print(d['status'])")
+WEIGHT=$(python3 -c "import json,os; d=json.load(open(os.environ['REGISTRY'])); print(d['canary_weight'])")
+assert_eq "rollback sets status=rolled_back" "rolled_back" "$STATUS"
+assert_eq "rollback sets weight=0" "0" "$WEIGHT"
+
+# Rollback without stable ID should error
+write_registry '{"stable_contract_id":"","canary_contract_id":"CANARY456","canary_weight":25,"status":"canary"}'
+ROLLBACK_OUT=$(python3 - <<'PYEOF' 2>&1 || true
+import json, os, sys
+with open(os.environ["REGISTRY"]) as f:
+    data = json.load(f)
+if not data.get("stable_contract_id"):
+    print("ERROR: No stable contract ID")
+    sys.exit(1)
+PYEOF
+)
+assert_contains "rollback fails without stable ID" "ERROR" "$ROLLBACK_OUT"
+
+# ─── Test 3: Metrics ──────────────────────────────────────────────────────────
+echo
+echo "── Metrics ──────────────────────────────────────────────────────────────"
+
+python3 - <<'PYEOF'
+import json, os
+
+metrics = {"checks": [], "consecutive_failures": 0}
+for _ in range(2):
+    metrics["consecutive_failures"] += 1
+    metrics["checks"].append({"pass": 0, "fail": 1, "error_rate": 100.0, "healthy": False})
+with open(os.environ["METRICS"], "w") as f:
+    json.dump(metrics, f)
+PYEOF
+
+CONSEC=$(python3 -c "import json,os; d=json.load(open(os.environ['METRICS'])); print(d['consecutive_failures'])")
+assert_eq "consecutive failures accumulate" "2" "$CONSEC"
+
+python3 - <<'PYEOF'
+import json, os
+with open(os.environ["METRICS"]) as f:
+    metrics = json.load(f)
+metrics["consecutive_failures"] = 0
+metrics["checks"].append({"pass": 3, "fail": 0, "error_rate": 0.0, "healthy": True})
+with open(os.environ["METRICS"], "w") as f:
+    json.dump(metrics, f)
+PYEOF
+
+CONSEC=$(python3 -c "import json,os; d=json.load(open(os.environ['METRICS'])); print(d['consecutive_failures'])")
+assert_eq "healthy check resets consecutive failures" "0" "$CONSEC"
+
+# ─── Test 4: Threshold evaluation ────────────────────────────────────────────
+echo
+echo "── Threshold evaluation ─────────────────────────────────────────────────"
+
+check_threshold() {
+  python3 -c "
+error_rate, max_rate, sample, min_sample = float('$1'), float('$2'), int('$3'), int('$4')
+print('BREACH' if sample >= min_sample and error_rate > max_rate else 'OK')
+"
+}
+
+assert_eq "error_rate=6 > max=5 with sufficient sample → BREACH" "BREACH" "$(check_threshold 6 5 15 10)"
+assert_eq "error_rate=4 < max=5 → OK"                            "OK"     "$(check_threshold 4 5 15 10)"
+assert_eq "error_rate=6 but sample too small → OK"               "OK"     "$(check_threshold 6 5 5 10)"
+assert_eq "error_rate=5 equals max=5 → OK (not strictly greater)" "OK"    "$(check_threshold 5 5 15 10)"
+
+# ─── Test 5: Promotion ───────────────────────────────────────────────────────
+echo
+echo "── Promotion ────────────────────────────────────────────────────────────"
+
+write_registry '{"stable_contract_id":"STABLE123","canary_contract_id":"CANARY456","canary_weight":100,"status":"canary"}'
+
+python3 - <<'PYEOF'
+import json, os, datetime
+with open(os.environ["REGISTRY"]) as f:
+    data = json.load(f)
+canary_id = data["canary_contract_id"]
+data["stable_contract_id"] = canary_id
+data["canary_contract_id"] = ""
+data["canary_weight"] = 0
+data["status"] = "stable"
+data["promoted_at"] = datetime.datetime.utcnow().isoformat() + "Z"
+with open(os.environ["REGISTRY"], "w") as f:
+    json.dump(data, f)
+PYEOF
+
+NEW_STABLE=$(python3 -c "import json,os; d=json.load(open(os.environ['REGISTRY'])); print(d['stable_contract_id'])")
+NEW_CANARY=$(python3 -c "import json,os; d=json.load(open(os.environ['REGISTRY'])); print(d.get('canary_contract_id',''))")
+STATUS=$(python3 -c "import json,os; d=json.load(open(os.environ['REGISTRY'])); print(d['status'])")
+assert_eq "promotion sets stable to old canary ID" "CANARY456" "$NEW_STABLE"
+assert_eq "promotion clears canary ID"             ""          "$NEW_CANARY"
+assert_eq "promotion sets status=stable"           "stable"    "$STATUS"
+
+# ─── Test 6: Weight update ───────────────────────────────────────────────────
+echo
+echo "── Weight update ────────────────────────────────────────────────────────"
+
+write_registry '{"stable_contract_id":"STABLE123","canary_contract_id":"CANARY456","canary_weight":10,"status":"canary"}'
+
+python3 - <<'PYEOF'
+import json, os
+with open(os.environ["REGISTRY"]) as f:
+    data = json.load(f)
+data["canary_weight"] = 25
+data["status"] = "canary"
+with open(os.environ["REGISTRY"], "w") as f:
+    json.dump(data, f)
+PYEOF
+
+WEIGHT=$(python3 -c "import json,os; d=json.load(open(os.environ['REGISTRY'])); print(d['canary_weight'])")
+assert_eq "weight update to 25" "25" "$WEIGHT"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo
+echo "════════════════════════════════════════"
+echo "  Tests: ${PASS} passed, ${FAIL} failed"
+echo "════════════════════════════════════════"
+
+[ "$FAIL" -eq 0 ] || exit 1
+echo "✅ All canary tests passed."


### PR DESCRIPTION
fixes #610 

feat: add canary deployment strategy
  
  - canary_deploy.sh: deploy new WASM alongside stable contract
  - canary_traffic.sh: weighted routing between stable/canary
  - canary_monitor.sh: health probes with threshold-based alerting
  - canary_rollback.sh: instant rollback to stable (idempotent)
  - canary_promote.sh: gradual promotion (10→25→50→100%)
  - canary.yml: GitHub Actions workflow for all canary actions
  - canary.toml: configurable thresholds and promotion steps
  - tests/canary_test.sh: 18 unit tests (all passing)
  