### PR TITLE
docs: add comprehensive contributor guide and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,62 @@
+## Summary
+
+<!-- What does this PR do? One or two sentences. -->
+
+## Motivation
+
+<!-- Why is this change needed? Link to the issue it resolves. -->
+
+Closes #
+
+## Type of change
+
+<!-- Check all that apply -->
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `docs` — documentation only
+- [ ] `refactor` — code restructuring, no behaviour change
+- [ ] `test` — tests only
+- [ ] `chore` — build, deps, tooling
+- [ ] `perf` — performance improvement
+- [ ] Breaking change (existing behaviour changes)
+
+## Changes
+
+<!-- List the key changes made. Be specific enough that a reviewer knows where to look. -->
+
+-
+-
+
+## Testing
+
+<!-- Describe how you tested this. Include commands a reviewer can run to verify. -->
+
+**Smart contract:**
+```bash
+cargo test -p stellar-save
+```
+
+**Frontend:**
+```bash
+cd frontend && npm test run
+```
+
+**Manual steps (if applicable):**
+
+1.
+2.
+
+## Checklist
+
+- [ ] `cargo fmt` run (Rust changes)
+- [ ] `cargo clippy -- -D warnings` passes (Rust changes)
+- [ ] `npm run lint` passes (frontend changes)
+- [ ] Tests added or updated for new/changed behaviour
+- [ ] CI is green
+- [ ] Documentation updated (if behaviour changed)
+- [ ] No secrets or `.env` files staged
+
+## Screenshots / recordings
+
+<!-- For UI changes, include before/after screenshots or a short screen recording. Delete this section if not applicable. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,85 +1,176 @@
 # Contributing to Stellar-Save
 
-Thank you for your interest in contributing to Stellar-Save. This document explains how to get involved, what standards to follow, and how to submit your work.
+Thank you for your interest in contributing to Stellar-Save — a decentralized ROSCA (Rotating Savings and Credit Association) built on Stellar Soroban smart contracts.
+
+This guide covers everything you need to get started: environment setup, coding standards, testing requirements, and the PR process.
+
+> New to the project? Start with [docs/first-time-contributor.md](docs/first-time-contributor.md) for a gentler walkthrough.
 
 ---
 
 ## Table of Contents
 
 - [Code of Conduct](#code-of-conduct)
-- [Getting Started](#getting-started)
-- [Code Style Guidelines](#code-style-guidelines)
+- [Architecture Overview](#architecture-overview)
+- [Development Setup](#development-setup)
+- [Project Structure](#project-structure)
+- [Coding Standards](#coding-standards)
 - [Commit Message Conventions](#commit-message-conventions)
-- [Pull Request Process](#pull-request-process)
 - [Testing Requirements](#testing-requirements)
+- [Pull Request Process](#pull-request-process)
+- [Drips Wave Contributions](#drips-wave-contributions)
+- [Getting Help](#getting-help)
 
 ---
 
 ## Code of Conduct
 
-By participating in this project, you agree to treat all contributors with respect. We do not tolerate harassment, discrimination, or hostile behaviour of any kind. If you experience or witness a violation, please open a private issue or contact a maintainer directly.
+By participating in this project you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md). We do not tolerate harassment, discrimination, or hostile behaviour. Report violations by opening a private issue or contacting a maintainer directly.
 
 ---
 
-## Getting Started
+## Architecture Overview
+
+Stellar-Save has four main layers:
+
+```
+User (Stellar wallet)
+       │
+       ▼
+Frontend (React + TypeScript + Vite)
+       │
+       ▼
+Soroban Smart Contracts (Rust)
+       │
+       ▼
+Stellar Network (on-chain storage + Horizon API)
+```
+
+**Smart contract modules** (`contracts/stellar-save/src/`):
+
+| Module | Responsibility |
+|---|---|
+| `lib.rs` | Contract entry points and public API |
+| `group.rs` | Group creation and configuration |
+| `contribution.rs` | Contribution logic and tracking |
+| `payout.rs` / `payout_executor.rs` | Payout rotation and distribution |
+| `storage.rs` | On-chain data layout |
+| `security.rs` | Authorization and access control |
+| `error.rs` | Typed error variants |
+| `events.rs` | Soroban event emission |
+
+**Frontend** (`frontend/src/`): React 19 + TypeScript SPA using MUI, React Router, and `@stellar/stellar-sdk`.
+
+For full architecture details see [docs/architecture.md](docs/architecture.md).
+
+---
+
+## Development Setup
 
 ### Prerequisites
 
-- [Rust](https://www.rust-lang.org/tools/install) (stable toolchain)
-- [Soroban CLI](https://soroban.stellar.org/docs/getting-started/setup)
-- [Node.js](https://nodejs.org/) v18+ and npm
-- [Freighter wallet](https://www.freighter.app/) (for manual testing)
+| Tool | Version | Install |
+|---|---|---|
+| Rust | 1.81.0 (pinned) | [rustup.rs](https://rustup.rs) |
+| Soroban / Stellar CLI | latest | [Stellar CLI docs](https://developers.stellar.org/docs/tools/stellar-cli) |
+| Node.js | 18+ | [nodejs.org](https://nodejs.org) |
+| npm | 9+ | bundled with Node.js |
 
-### Setup
+The Rust toolchain version is pinned in `rust-toolchain.toml`. Running any `cargo` command will install it automatically via rustup.
+
+### Clone and install
 
 ```bash
-# Clone the repository
 git clone https://github.com/Xoulomon/Stellar-Save.git
 cd Stellar-Save
 
-# Install frontend dependencies
-cd frontend
+# Install root-level tooling (commitlint, husky)
 npm install
 
-# Build the smart contract
-cd ../contracts/stellar-save
+# Install frontend dependencies
+cd frontend && npm install && cd ..
+```
+
+### Environment configuration
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` with your network settings. Available networks are defined in `environments.toml`:
+
+- `testnet` — Stellar testnet (recommended for development)
+- `futurenet` — Stellar futurenet
+- `standalone` — Local development node
+- `mainnet` — Production (do not use for development)
+
+### Build the smart contract
+
+```bash
+./scripts/build.sh
+# or directly:
 cargo build --target wasm32-unknown-unknown --release
 ```
 
-### Branching
-
-Always branch from `main`:
+### Run the frontend dev server
 
 ```bash
-git checkout main
-git pull origin main
-git checkout -b your-branch-name
+cd frontend
+npm run dev
 ```
 
-Use descriptive branch names:
-- `fix/contribution-overflow`
-- `docs/api-reference`
-- `feat/custom-tokens`
+### Deploy to testnet
 
-> **Note:** Avoid using `feature/` as a prefix — use `feat/` instead to prevent directory conflicts on some remotes.
+```bash
+# Generate a testnet identity (one-time)
+stellar keys generate deployer --network testnet
+
+# Deploy
+./scripts/deploy_testnet.sh
+```
 
 ---
 
-## Code Style Guidelines
+## Project Structure
 
-### Rust (Smart Contract)
+```
+Stellar-Save/
+├── contracts/
+│   └── stellar-save/        # Main ROSCA smart contract (Rust)
+│       └── src/             # Contract modules
+├── frontend/                # React + TypeScript SPA
+│   └── src/
+├── client/                  # Rust client library
+├── scripts/                 # Build, deploy, and test scripts
+├── docs/                    # Project documentation
+├── tests/                   # Integration and shell tests
+├── infra/                   # Terraform infrastructure
+├── monitoring/              # Prometheus / Grafana / ELK configs
+├── .github/workflows/       # CI/CD pipelines
+├── Cargo.toml               # Workspace manifest
+├── environments.toml        # Network configurations
+└── rust-toolchain.toml      # Pinned Rust version
+```
 
-- Follow standard Rust formatting — run `cargo fmt` before committing
-- Run `cargo clippy` and resolve all warnings before opening a PR
-- Keep functions small and focused — one responsibility per function
-- Use descriptive variable names; avoid single-letter names outside of iterators
-- Document public functions with `///` doc comments
+---
+
+## Coding Standards
+
+### Rust (smart contract)
+
+- Run `cargo fmt` before every commit — formatting is enforced in CI
+- Run `cargo clippy -- -D warnings` and fix all warnings before opening a PR
+- Keep functions small and single-purpose
+- Use descriptive names; avoid single-letter variables outside iterators
+- Document all public items with `///` doc comments
 - Prefer `Result<T, ContractError>` over panics for recoverable errors
-- Group related logic into modules (see existing `contribution.rs`, `payout.rs`, etc.)
+- Use the typed error variants in `error.rs` — do not add bare `panic!` calls
 
 ```rust
-/// Verifies that the caller is the group creator.
-/// Returns an error if the caller is not authorised.
+/// Verifies the caller is the group creator.
+///
+/// # Errors
+/// Returns [`ContractError::Unauthorized`] if the caller is not the creator.
 pub fn require_creator(env: &Env, group: &Group) -> Result<(), ContractError> {
     let caller = env.invoker();
     if caller != group.creator {
@@ -89,35 +180,43 @@ pub fn require_creator(env: &Env, group: &Group) -> Result<(), ContractError> {
 }
 ```
 
-### TypeScript / React (Frontend)
+### TypeScript / React (frontend)
 
 - Use functional components with hooks — no class components
-- Type all props and state with TypeScript interfaces or types
-- Use `const` by default; only use `let` when reassignment is needed
-- Keep components small — extract sub-components when a file exceeds ~150 lines
-- Co-locate component CSS files (e.g. `Button.tsx` + `Button.css`)
-- Use semantic HTML elements for accessibility (`<button>`, `<nav>`, `<main>`, etc.)
-- Run `npm run lint` before committing
+- Type all props and state with TypeScript interfaces or types; avoid `any`
+- Use `const` by default; `let` only when reassignment is necessary
+- Keep components under ~150 lines; extract sub-components when they grow larger
+- Use semantic HTML for accessibility (`<button>`, `<nav>`, `<main>`, etc.)
+- Run `npm run lint` before committing — ESLint is enforced in CI
+
+Prettier config (`.prettierrc`):
+- Single quotes, semicolons, trailing commas (ES5), 100-char print width, 2-space indent
 
 ```tsx
-interface ButtonProps {
-  label: string;
-  onClick: () => void;
-  disabled?: boolean;
+interface ContributionCardProps {
+  amount: bigint;
+  member: string;
+  isPaid: boolean;
 }
 
-const Button = ({ label, onClick, disabled = false }: ButtonProps) => (
-  <button onClick={onClick} disabled={disabled} className="btn">
-    {label}
-  </button>
+const ContributionCard = ({ amount, member, isPaid }: ContributionCardProps) => (
+  <article className="contribution-card">
+    <span>{member}</span>
+    <span>{isPaid ? '✓' : 'Pending'}</span>
+  </article>
 );
 ```
+
+### General
+
+- `.editorconfig` is present — use an editor that respects it (UTF-8, LF line endings, final newline)
+- Do not commit secrets, private keys, or `.env` files — `.gitignore` covers common cases but double-check before staging
 
 ---
 
 ## Commit Message Conventions
 
-We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+We use [Conventional Commits](https://www.conventionalcommits.org/). Commits are validated by commitlint via a Husky `commit-msg` hook.
 
 ### Format
 
@@ -126,94 +225,155 @@ We follow the [Conventional Commits](https://www.conventionalcommits.org/) speci
 
 [optional body]
 
-[optional footer]
+[optional footer(s)]
 ```
 
-### Types
+### Allowed types
 
-| Type | When to use |
-|------|-------------|
-| `feat` | A new feature |
-| `fix` | A bug fix |
-| `docs` | Documentation changes only |
+| Type | Use for |
+|---|---|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
 | `style` | Formatting, whitespace (no logic change) |
 | `refactor` | Code restructuring without behaviour change |
+| `perf` | Performance improvement |
 | `test` | Adding or updating tests |
 | `chore` | Build process, dependency updates, tooling |
+| `ci` | CI/CD configuration changes |
+| `revert` | Reverting a previous commit |
+
+### Rules
+
+- Use imperative mood: "add" not "added" or "adds"
+- Keep the subject line under 100 characters
+- Reference issues in the footer: `Closes #42`
+- Use `feat!` or add `BREAKING CHANGE:` in the footer for breaking changes
 
 ### Examples
 
 ```
-feat(contract): add custom token support for contributions
+feat(contract): add penalty mechanism for missed contributions
 
-fix(frontend): correct payout position display off-by-one error
+fix(frontend): correct off-by-one in payout position display
 
-docs: add contributing guidelines
+docs: expand contributing guide with architecture overview
 
-test(contract): add edge case tests for missed contribution handling
-```
+test(contract): add fuzz tests for contribution overflow edge cases
 
-### Rules
-
-- Use the imperative mood in the description: "add" not "added" or "adds"
-- Keep the first line under 72 characters
-- Reference issues in the footer: `Closes #42`
-
----
-
-## Pull Request Process
-
-1. **Open an issue first** for non-trivial changes so the approach can be discussed before you invest time coding
-2. **Branch from `main`** — never commit directly to `main`
-3. **Keep PRs focused** — one feature or fix per PR; avoid bundling unrelated changes
-4. **Fill in the PR template** — describe what changed, why, and how to test it
-5. **Ensure CI passes** — all tests must pass before a review is requested
-6. **Request a review** from at least one maintainer
-7. **Address review comments** — push follow-up commits to the same branch; do not force-push after review has started
-8. **Squash on merge** — maintainers will squash commits when merging to keep history clean
-
-### PR Title
-
-Follow the same Conventional Commits format as commit messages:
-
-```
-feat(contract): implement penalty for missed contributions
+chore: update soroban-sdk to 23.0.3
 ```
 
 ---
 
 ## Testing Requirements
 
-### Smart Contract (Rust)
+### Smart contract (Rust)
 
-- All new public functions must have at least one unit test
-- Cover both the happy path and expected error cases
-- Use `#[should_panic]` or `assert_eq!(result, Err(...))` for error cases
-- Run the full test suite before opening a PR:
+All new public functions must have tests covering:
+- The happy path
+- Expected error cases (use `assert_eq!(result, Err(ContractError::...))`)
 
-```bash
-cargo test
-```
-
-- Snapshot tests live in `test_snapshots/` — update them if your change affects output
-
-### Frontend (TypeScript / React)
-
-- Add tests for any new utility functions or hooks
-- Component tests are encouraged but not yet required for all components
-- Run the linter before committing:
+Run the full test suite before opening a PR:
 
 ```bash
-npm run lint
+# All contracts
+cargo test --workspace
+
+# Stellar-save contract only
+cargo test -p stellar-save
+
+# With stdout output
+cargo test -- --nocapture
+
+# With coverage (requires cargo-tarpaulin)
+cargo tarpaulin --config contracts/stellar-save/tarpaulin.toml
 ```
 
-### General
+Test snapshots live in `contracts/stellar-save/test_snapshots/`. Update them if your change intentionally affects output.
+
+### Frontend (TypeScript)
+
+Add tests for new utility functions and hooks. Component tests are encouraged.
+
+```bash
+cd frontend
+
+# Watch mode (development)
+npm test
+
+# Single run (CI)
+npm test run
+
+# With coverage
+npm run test:coverage
+
+# Accessibility checks are included via jest-axe / vitest-axe
+```
+
+Test files live alongside source files as `*.test.ts` / `*.test.tsx`. Setup is in `src/test/setup.ts`.
+
+### General rules
 
 - Do not reduce overall test coverage — PRs that delete tests without replacement will be rejected
 - If you find a bug, write a failing test that reproduces it before fixing it
+- CI must be green before requesting review
 
 ---
 
-## Questions?
+## Pull Request Process
 
-Open a [GitHub Discussion](https://github.com/Xoulomon/Stellar-Save/discussions) or comment on the relevant issue. We're happy to help you get your contribution across the line.
+1. **Open an issue first** for non-trivial changes — discuss the approach before investing time coding
+2. **Branch from `main`** — never commit directly to `main`
+
+   ```bash
+   git checkout main && git pull origin main
+   git checkout -b feat/your-feature-name
+   ```
+
+   Branch naming conventions:
+   - `feat/description` — new feature
+   - `fix/description` — bug fix
+   - `docs/description` — documentation
+   - `refactor/description` — refactoring
+   - `test/description` — tests only
+
+3. **Keep PRs focused** — one feature or fix per PR; avoid bundling unrelated changes
+4. **Fill in the PR template** completely — describe what changed, why, and how to test it
+5. **Ensure CI passes** — all checks must be green before requesting review
+6. **Request a review** from at least one maintainer
+7. **Address review comments** — push follow-up commits to the same branch; do not force-push after review has started
+8. **Squash on merge** — maintainers squash commits when merging to keep history clean
+
+### PR title format
+
+Follow the same Conventional Commits format as commit messages:
+
+```
+feat(contract): implement penalty for missed contributions
+fix(frontend): resolve wallet connection timeout on mobile
+```
+
+---
+
+## Drips Wave Contributions
+
+Stellar-Save participates in **Drips Wave** — a contributor funding program. Funded issues are labelled `wave-ready` on GitHub and categorised by effort:
+
+| Label | Points | Examples |
+|---|---|---|
+| `trivial` | 100 | Documentation fixes, simple tests, minor UI copy |
+| `medium` | 150 | Helper functions, validation logic, moderate features |
+| `high` | 200 | Core features, complex integrations, security enhancements |
+
+See [docs/wave-guide.md](docs/wave-guide.md) for how to claim and earn funding.
+
+---
+
+## Getting Help
+
+- **GitHub Issues** — bug reports and feature requests
+- **GitHub Discussions** — questions, ideas, and general conversation
+- **Telegram** — [@Xoulomon](https://t.me/Xoulomon) for quick questions
+
+If you are unsure whether your idea fits the project, open a Discussion before writing code. We are happy to help you get your contribution across the line.

--- a/docs/first-time-contributor.md
+++ b/docs/first-time-contributor.md
@@ -1,0 +1,279 @@
+# First-Time Contributor Guide
+
+Welcome to Stellar-Save! This guide walks you through making your first contribution from zero — no prior Stellar or Soroban experience required.
+
+---
+
+## What is Stellar-Save?
+
+Stellar-Save is a decentralized **ROSCA** (Rotating Savings and Credit Association) — a community savings system common in Nigeria and across Africa where members contribute a fixed amount each cycle and take turns receiving the full pool. We have built this on the Stellar blockchain using Soroban smart contracts, making it trustless, transparent, and accessible globally.
+
+---
+
+## Before you write any code
+
+### 1. Read the basics
+
+- [README.md](../README.md) — project overview and quick start
+- [docs/architecture.md](architecture.md) — how the system fits together
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — full contributor reference
+
+### 2. Find something to work on
+
+The easiest place to start is a `wave-ready` issue on GitHub. These are pre-scoped, funded tasks with clear acceptance criteria:
+
+- **`trivial` (100 points)** — documentation fixes, simple tests, minor UI copy changes
+- **`medium` (150 points)** — helper functions, validation logic, moderate features
+- **`high` (200 points)** — core features, complex integrations, security enhancements
+
+Filter issues by the `good first issue` label if you want something even smaller to start with.
+
+### 3. Comment on the issue
+
+Before starting, leave a comment on the issue saying you are working on it. This prevents duplicate effort and gives maintainers a chance to share context that is not in the issue description.
+
+---
+
+## Setting up your environment
+
+### Install Rust
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source ~/.cargo/env
+```
+
+The project pins Rust to **1.81.0** via `rust-toolchain.toml`. Rustup will install the correct version automatically when you run any `cargo` command inside the repo.
+
+### Install the Stellar CLI
+
+```bash
+cargo install --locked stellar-cli --features opt
+```
+
+Verify:
+
+```bash
+stellar --version
+```
+
+### Install Node.js
+
+Download from [nodejs.org](https://nodejs.org) or use a version manager like `nvm`:
+
+```bash
+nvm install 20
+nvm use 20
+```
+
+### Fork and clone the repository
+
+1. Click **Fork** on the GitHub repository page
+2. Clone your fork:
+
+```bash
+git clone https://github.com/<your-username>/Stellar-Save.git
+cd Stellar-Save
+```
+
+3. Add the upstream remote so you can pull future changes:
+
+```bash
+git remote add upstream https://github.com/Xoulomon/Stellar-Save.git
+```
+
+### Install dependencies
+
+```bash
+# Root-level tooling (commitlint, husky)
+npm install
+
+# Frontend
+cd frontend && npm install && cd ..
+```
+
+### Verify the setup
+
+```bash
+# Build the smart contract
+cargo build --target wasm32-unknown-unknown --release
+
+# Run contract tests
+cargo test -p stellar-save
+
+# Run frontend tests
+cd frontend && npm test run && cd ..
+```
+
+All tests should pass. If something fails, open an issue or ask in GitHub Discussions before proceeding.
+
+---
+
+## Making your first change
+
+### 1. Create a branch
+
+Always branch from an up-to-date `main`:
+
+```bash
+git checkout main
+git pull upstream main
+git checkout -b docs/improve-faq
+```
+
+Use a descriptive branch name that matches the type of change:
+- `feat/` — new feature
+- `fix/` — bug fix
+- `docs/` — documentation
+- `test/` — tests only
+- `refactor/` — restructuring
+
+### 2. Make your changes
+
+Keep changes focused. A PR that does one thing is much easier to review than one that does five.
+
+**For Rust changes**, run these before committing:
+
+```bash
+cargo fmt
+cargo clippy -- -D warnings
+cargo test -p stellar-save
+```
+
+**For frontend changes**, run:
+
+```bash
+cd frontend
+npm run lint
+npm test run
+```
+
+### 3. Commit your changes
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). The format is:
+
+```
+<type>(<scope>): <short description>
+```
+
+Examples:
+
+```bash
+git commit -m "docs: fix typo in architecture overview"
+git commit -m "fix(contract): handle zero-amount contribution correctly"
+git commit -m "feat(frontend): add group search filter"
+```
+
+A Husky hook will validate your commit message format automatically. If it rejects your message, check the [commit types table in CONTRIBUTING.md](../CONTRIBUTING.md#commit-message-conventions).
+
+### 4. Push and open a PR
+
+```bash
+git push -u origin docs/improve-faq
+```
+
+Then open a pull request on GitHub from your fork to `Xoulomon/Stellar-Save:main`. Fill in the PR template completely — the more context you provide, the faster the review.
+
+---
+
+## Understanding the codebase
+
+### Smart contract structure
+
+The main contract lives in `contracts/stellar-save/src/`. Key files to read first:
+
+| File | What it does |
+|---|---|
+| `lib.rs` | Public contract API — all callable functions |
+| `group.rs` | Group creation, configuration, membership |
+| `contribution.rs` | Contribution recording and validation |
+| `payout.rs` | Payout rotation logic |
+| `error.rs` | All error types — read this to understand failure modes |
+| `storage.rs` | How data is stored on-chain |
+
+### Frontend structure
+
+The frontend lives in `frontend/src/`. Key directories:
+
+| Directory | What it contains |
+|---|---|
+| `components/` | Reusable UI components |
+| `pages/` | Top-level route pages |
+| `hooks/` | Custom React hooks (wallet, groups, transactions) |
+| `test/` | Test setup and integration tests |
+
+### How a contribution flows
+
+1. User clicks "Contribute" in the frontend
+2. Frontend builds a Soroban transaction using `@stellar/stellar-sdk`
+3. User signs the transaction with their Freighter wallet
+4. Transaction is submitted to the Stellar network
+5. The `contribute()` function in `lib.rs` is invoked on-chain
+6. `contribution.rs` validates and records the contribution
+7. If all members have contributed, `payout_executor.rs` triggers the payout
+8. Events are emitted and the frontend updates via Soroban event subscriptions
+
+---
+
+## Common questions
+
+**Do I need XLM to contribute?**
+For development, use the testnet. You can get free testnet XLM from the [Stellar Friendbot](https://friendbot.stellar.org).
+
+**How do I run a local Stellar node?**
+The easiest option is to use the testnet (`STELLAR_NETWORK=testnet` in your `.env`). For a fully local setup, see [docs/deployment.md](deployment.md).
+
+**My commit was rejected by the hook — what do I do?**
+Check the error message from commitlint. The most common issues are: wrong type (use one from the allowed list), subject line too long (keep it under 100 characters), or wrong format (must be `type(scope): description`).
+
+**Can I contribute without knowing Rust?**
+Yes. Documentation, frontend, tests, and tooling contributions are all valuable and do not require Rust knowledge.
+
+**How long does review take?**
+We aim to review PRs within a few days. If you have not heard back after a week, leave a comment on the PR to ping maintainers.
+
+---
+
+## Useful commands reference
+
+```bash
+# Build contract
+cargo build --target wasm32-unknown-unknown --release
+
+# Run all contract tests
+cargo test --workspace
+
+# Run contract tests with output
+cargo test -p stellar-save -- --nocapture
+
+# Format Rust code
+cargo fmt
+
+# Lint Rust code
+cargo clippy -- -D warnings
+
+# Run frontend dev server
+cd frontend && npm run dev
+
+# Run frontend tests (watch)
+cd frontend && npm test
+
+# Run frontend tests (single run)
+cd frontend && npm test run
+
+# Run frontend linter
+cd frontend && npm run lint
+
+# Deploy to testnet
+./scripts/deploy_testnet.sh
+```
+
+---
+
+## Still stuck?
+
+- Open a [GitHub Discussion](https://github.com/Xoulomon/Stellar-Save/discussions) — no question is too small
+- Comment on the issue you are working on
+- Reach out on Telegram: [@Xoulomon](https://t.me/Xoulomon)
+
+We want your contribution to succeed. Do not hesitate to ask for help.


### PR DESCRIPTION
Closes #624

---

## Summary

Adds a complete contributor guide covering all six requested areas.

## Changes

- **CONTRIBUTING.md** — dev setup, architecture overview, coding standards (Rust + TypeScript), commit conventions, testing requirements, PR process
- **.github/PULL_REQUEST_TEMPLATE.md** — PR template with type-of-change checkboxes, testing commands, pre-merge checklist
- **docs/first-time-contributor.md** — onboarding guide: finding issues, env setup, fork/branch/commit/PR workflow, codebase orientation, FAQ, commands reference

## Type of change

- [x] `docs` — documentation only