### PR TITLE
docs: add community guidelines and update code of conduct (#632)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,33 +2,51 @@
 
 ## Our Pledge
 
-We are committed to providing a welcoming and inclusive environment for all contributors, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+We as contributors and maintainers of Stellar-Save pledge to make participation in our project and community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
 **Positive behavior includes:**
+
 - Using welcoming and inclusive language
 - Being respectful of differing viewpoints and experiences
 - Gracefully accepting constructive criticism
-- Focusing on what is best for the community
+- Focusing on what is best for the community and the mission of financial inclusion
 - Showing empathy towards other community members
+- Crediting others for their contributions and ideas
 
 **Unacceptable behavior includes:**
-- Harassment, trolling, or discriminatory comments
+
+- Harassment, trolling, or discriminatory comments in any form
 - Personal or political attacks
-- Publishing others' private information without permission
+- Publishing others' private information (doxxing) without explicit permission
+- Spam or repeated off-topic posts
 - Any conduct that could reasonably be considered inappropriate in a professional setting
+- Threats or intimidation of any kind
+
+## Reporting
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by:
+
+- **Telegram**: Contact [@Xoulomon](https://t.me/Xoulomon) privately
+- **GitHub**: Open a private security advisory on the repository
+
+All reports will be reviewed and investigated promptly and fairly. Reporters will not face retaliation.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainer at [@Xoulomon](https://t.me/Xoulomon). All complaints will be reviewed and investigated promptly and fairly.
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that do not align with this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
-Project maintainers have the right to remove, edit, or reject comments, commits, code, issues, and other contributions that do not align with this Code of Conduct.
+Enforcement actions scale with severity — from a warning for minor violations to a permanent ban for severe or repeated violations. See [COMMUNITY_GUIDELINES.md](COMMUNITY_GUIDELINES.md) for the full moderation policy.
 
 ## Scope
 
-This Code of Conduct applies within all project spaces, including GitHub repositories, discussions, and any public spaces where an individual is representing the project or community.
+This Code of Conduct applies within all project spaces — GitHub repository, discussions, pull requests, and any public space where an individual is representing the Stellar-Save project or community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+For full community guidelines including moderation procedures and community resources, see [COMMUNITY_GUIDELINES.md](COMMUNITY_GUIDELINES.md).

--- a/COMMUNITY_GUIDELINES.md
+++ b/COMMUNITY_GUIDELINES.md
@@ -1,0 +1,92 @@
+# Stellar-Save Community Guidelines
+
+Welcome to the Stellar-Save community — a decentralized rotational savings platform built on Stellar Soroban. These guidelines exist to keep our community welcoming, productive, and safe for everyone.
+
+---
+
+## Our Values
+
+- **Inclusion** — Everyone is welcome regardless of background, experience level, or location.
+- **Transparency** — We build in the open. Decisions, trade-offs, and failures are shared honestly.
+- **Financial empowerment** — We exist to serve unbanked and underbanked communities. Keep that mission central.
+- **Collaboration** — The best ideas come from working together. Credit others generously.
+- **Accountability** — Own your mistakes. Fix them. Move forward.
+
+---
+
+## Expected Behavior
+
+- Be respectful and constructive in all interactions — issues, PRs, discussions, Telegram, and social media.
+- Give helpful, specific feedback. "This is wrong" is not feedback; "this breaks when X because Y" is.
+- Assume good intent. Ask for clarification before assuming malice.
+- Keep discussions on-topic. Off-topic threads will be redirected or closed.
+- Respect maintainer decisions even when you disagree. Disagreement is fine; disrespect is not.
+- Credit contributors when building on their work.
+
+---
+
+## Unacceptable Behavior
+
+The following will not be tolerated in any community space:
+
+- Harassment, intimidation, or personal attacks of any kind
+- Discriminatory language or jokes related to race, ethnicity, gender, religion, disability, sexual orientation, or nationality
+- Sharing private information (doxxing) without explicit consent
+- Spam, self-promotion unrelated to the project, or repeated off-topic posts
+- Deliberate disruption of discussions or contribution workflows
+- Threats of any kind
+
+---
+
+## Reporting
+
+If you experience or witness unacceptable behavior:
+
+1. **Telegram**: Message [@Xoulomon](https://t.me/Xoulomon) directly and privately.
+2. **GitHub**: Open a private security advisory or email the maintainer via the GitHub profile.
+3. **What to include**: A description of the incident, links or screenshots if available, and the date/time.
+
+All reports are treated confidentially. Reporters will not face retaliation.
+
+---
+
+## Moderation
+
+Maintainers are responsible for enforcing these guidelines. Actions taken depend on severity:
+
+| Severity | Example | Action |
+|----------|---------|--------|
+| Minor | Off-topic post, mild rudeness | Warning + redirect |
+| Moderate | Repeated rudeness, spam | Temporary mute or removal from discussion |
+| Severe | Harassment, doxxing, threats | Permanent ban from all community spaces |
+
+Moderation decisions are final. If you believe a decision was made in error, you may appeal once by contacting a different maintainer.
+
+---
+
+## Contribution Spaces
+
+These guidelines apply in all Stellar-Save spaces:
+
+- GitHub repository (issues, PRs, discussions, code reviews)
+- Telegram group and direct messages with maintainers
+- Any public forum where you represent the Stellar-Save project
+
+---
+
+## Community Resources
+
+- **Contributing guide**: [CONTRIBUTING.md](CONTRIBUTING.md)
+- **Code of Conduct**: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- **Security policy**: [SECURITY.md](SECURITY.md)
+- **GitHub Discussions**: [github.com/Xoulomon/Stellar-Save/discussions](https://github.com/Xoulomon/Stellar-Save/discussions)
+- **Telegram**: [@Xoulomon](https://t.me/Xoulomon)
+- **Wave contributor guide**: [docs/wave-guide.md](docs/wave-guide.md)
+
+---
+
+## Updates
+
+These guidelines may be updated as the community grows. Significant changes will be announced in GitHub Discussions. Continued participation constitutes acceptance of the current version.
+
+_Last updated: April 2026_


### PR DESCRIPTION
Closes #632

## Changes

- **`COMMUNITY_GUIDELINES.md`** — new file covering:
  - Community values (inclusion, transparency, financial empowerment, collaboration, accountability)
  - Expected and unacceptable behavior
  - Reporting procedures (Telegram + GitHub)
  - Moderation policy with severity table
  - Community resources and links

- **`CODE_OF_CONDUCT.md`** — updated with:
  - Fuller standards section
  - Reporting channels
  - Enforcement description linking to full moderation policy
  - Attribution to Contributor Covenant v2.1