### PR TITLE
#638 [Testing] Create accessibility testing suite

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,224 @@
+name: Accessibility Testing
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  # ─── Unit-level axe-core accessibility tests (Vitest + jest-axe) ────────────
+  axe-unit:
+    name: axe-core Component Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run accessibility unit tests
+        run: npm run test:a11y:ci
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: a11y-unit-results
+          path: frontend/test-results/
+          retention-days: 30
+
+  # ─── Pa11y full-page WCAG 2.1 AA scan ───────────────────────────────────────
+  pa11y:
+    name: Pa11y WCAG 2.1 AA Scan
+    runs-on: ubuntu-latest
+    needs: axe-unit
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Build frontend
+        run: npm run build
+        working-directory: frontend
+
+      - name: Install pa11y-ci
+        run: npm install -g pa11y-ci@3.1.0
+
+      - name: Start preview server
+        run: |
+          nohup npm run preview -- --host 127.0.0.1 --port 4173 > /tmp/pa11y-server.log 2>&1 &
+          echo $! > /tmp/pa11y-server.pid
+          # Wait for server to be ready
+          timeout 30 bash -c 'until curl -sf http://127.0.0.1:4173 > /dev/null; do sleep 1; done'
+        working-directory: frontend
+
+      - name: Create screenshots directory
+        run: mkdir -p frontend/pa11y-screenshots
+
+      - name: Run Pa11y CI scan
+        run: pa11y-ci --config frontend/.pa11yrc.json
+        continue-on-error: true
+        id: pa11y_scan
+
+      - name: Stop preview server
+        if: always()
+        run: |
+          PID=$(cat /tmp/pa11y-server.pid 2>/dev/null || echo "")
+          [ -n "$PID" ] && kill "$PID" || true
+
+      - name: Upload Pa11y screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pa11y-screenshots
+          path: frontend/pa11y-screenshots/
+          retention-days: 30
+
+      - name: Upload Pa11y server log
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pa11y-server-log
+          path: /tmp/pa11y-server.log
+          retention-days: 7
+
+      - name: Fail if Pa11y found errors
+        if: steps.pa11y_scan.outcome == 'failure'
+        run: |
+          echo "::error::Pa11y found WCAG 2.1 AA violations. Review the uploaded screenshots and logs."
+          exit 1
+
+  # ─── Lighthouse accessibility audit ─────────────────────────────────────────
+  lighthouse-a11y:
+    name: Lighthouse Accessibility Audit
+    runs-on: ubuntu-latest
+    needs: axe-unit
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Build frontend
+        run: npm run build
+        working-directory: frontend
+
+      - name: Start preview server
+        run: |
+          cd frontend
+          nohup npm run preview -- --host 127.0.0.1 --port 4173 > /tmp/lhci-a11y.log 2>&1 &
+          echo $! > /tmp/lhci-server.pid
+          timeout 30 bash -c 'until curl -sf http://127.0.0.1:4173 > /dev/null; do sleep 1; done'
+
+      - name: Run Lighthouse accessibility audit
+        run: |
+          npx lhci autorun \
+            --collect.url=http://127.0.0.1:4173 \
+            --collect.numberOfRuns=1 \
+            --assert.assertions.accessibility=["error",{"minScore":0.9}] \
+            --assert.assertions.best-practices=["warn",{"minScore":0.8}] \
+            --upload.target=filesystem \
+            --upload.outputDir=/tmp/lhci-results
+        continue-on-error: true
+        id: lhci_a11y
+
+      - name: Stop preview server
+        if: always()
+        run: |
+          PID=$(cat /tmp/lhci-server.pid 2>/dev/null || echo "")
+          [ -n "$PID" ] && kill "$PID" || true
+
+      - name: Upload Lighthouse results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: lighthouse-a11y-results
+          path: /tmp/lhci-results/
+          retention-days: 30
+
+      - name: Comment Lighthouse score on PR
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const resultsDir = '/tmp/lhci-results';
+            let comment = '## ♿ Lighthouse Accessibility Audit\n\n';
+
+            try {
+              const files = fs.readdirSync(resultsDir);
+              const manifestFile = files.find(f => f === 'manifest.json');
+              if (manifestFile) {
+                const manifest = JSON.parse(fs.readFileSync(`${resultsDir}/${manifestFile}`, 'utf8'));
+                const run = manifest[0];
+                if (run && run.summary) {
+                  const score = Math.round(run.summary.accessibility * 100);
+                  const emoji = score >= 90 ? '✅' : score >= 70 ? '⚠️' : '❌';
+                  comment += `${emoji} **Accessibility Score: ${score}/100**\n\n`;
+                  comment += `> Minimum required: 90/100\n\n`;
+                  comment += `[View full report](${run.url})\n`;
+                }
+              }
+            } catch (e) {
+              comment += `_Could not parse Lighthouse results: ${e.message}_\n`;
+            }
+
+            if (context.payload.pull_request) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: comment,
+              });
+            }
+
+  # ─── Summary gate ────────────────────────────────────────────────────────────
+  a11y-gate:
+    name: Accessibility Gate
+    runs-on: ubuntu-latest
+    needs: [axe-unit, pa11y, lighthouse-a11y]
+    if: always()
+
+    steps:
+      - name: Check all accessibility jobs passed
+        run: |
+          if [ "${{ needs.axe-unit.result }}" != "success" ]; then
+            echo "::error::axe-core unit tests failed"
+            exit 1
+          fi
+          if [ "${{ needs.pa11y.result }}" != "success" ]; then
+            echo "::error::Pa11y WCAG scan failed"
+            exit 1
+          fi
+          echo "✅ All accessibility checks passed"

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,358 @@
+name: Mutation Testing
+
+on:
+  # Run on PRs to main/develop so mutation scores are visible before merge
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'contracts/stellar-save/src/**'
+      - 'frontend/src/**'
+      - '.github/workflows/mutation-testing.yml'
+      - 'contracts/stellar-save/mutants.toml'
+      - 'frontend/stryker.config.mjs'
+
+  # Weekly scheduled run (Sunday 03:00 UTC) for a full baseline report
+  schedule:
+    - cron: '0 3 * * 0'
+
+  # Allow manual trigger with optional scope selection
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: 'Which mutation suite to run'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - contracts
+          - frontend
+
+# Cancel in-progress runs on the same branch to save CI minutes
+concurrency:
+  group: mutation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ─── Rust Contract Mutation Testing (cargo-mutants) ─────────────────────────
+  contract-mutation:
+    name: Contract Mutation Tests (cargo-mutants)
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.scope == 'all' ||
+      github.event.inputs.scope == 'contracts'
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+          # Include cargo-mutants binary in the cache key
+          key: mutants-${{ hashFiles('contracts/stellar-save/Cargo.lock') }}
+
+      - name: Install cargo-mutants
+        # Pin to a specific version for reproducibility
+        run: cargo install cargo-mutants --version 24.11.1 --locked
+
+      - name: Run mutation tests
+        working-directory: contracts/stellar-save
+        run: |
+          cargo mutants \
+            --manifest-path Cargo.toml \
+            --jobs 2 \
+            --timeout 120 \
+            --output mutants-out \
+            --json \
+            -- --test-threads=1
+        # Continue even if mutants survive so we can upload the report
+        continue-on-error: true
+
+      - name: Parse and display mutation score
+        working-directory: contracts/stellar-save
+        run: |
+          if [ -f mutants-out/mutants.json ]; then
+            python3 - <<'EOF'
+          import json, sys
+
+          with open("mutants-out/mutants.json") as f:
+              data = json.load(f)
+
+          total    = len(data)
+          caught   = sum(1 for m in data if m.get("status") == "caught")
+          missed   = sum(1 for m in data if m.get("status") == "missed")
+          timeout  = sum(1 for m in data if m.get("status") == "timeout")
+          unviable = sum(1 for m in data if m.get("status") == "unviable")
+
+          tested   = total - unviable
+          score    = (caught / tested * 100) if tested > 0 else 0.0
+
+          print(f"=== Contract Mutation Score ===")
+          print(f"  Total mutants : {total}")
+          print(f"  Caught        : {caught}")
+          print(f"  Missed        : {missed}")
+          print(f"  Timeout       : {timeout}")
+          print(f"  Unviable      : {unviable}")
+          print(f"  Score         : {score:.1f}%")
+
+          if missed > 0:
+              print("\n--- Surviving mutants (missed) ---")
+              for m in data:
+                  if m.get("status") == "missed":
+                      print(f"  [{m.get('file','?')}:{m.get('line','?')}] {m.get('mutation','?')}")
+
+          # Enforce minimum threshold
+          THRESHOLD = 60.0
+          if score < THRESHOLD:
+              print(f"\nFAIL: mutation score {score:.1f}% is below the {THRESHOLD}% threshold")
+              sys.exit(1)
+          else:
+              print(f"\nPASS: mutation score {score:.1f}% meets the {THRESHOLD}% threshold")
+          EOF
+          else
+            echo "mutants.json not found — cargo-mutants may have failed to produce output"
+            exit 1
+          fi
+
+      - name: Upload mutation report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: contract-mutation-report
+          path: contracts/stellar-save/mutants-out/
+          retention-days: 30
+
+      - name: Comment mutation score on PR
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'contracts/stellar-save/mutants-out/mutants.json';
+
+            if (!fs.existsSync(path)) {
+              console.log('No mutants.json found, skipping PR comment');
+              return;
+            }
+
+            const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+            const total    = data.length;
+            const caught   = data.filter(m => m.status === 'caught').length;
+            const missed   = data.filter(m => m.status === 'missed').length;
+            const unviable = data.filter(m => m.status === 'unviable').length;
+            const tested   = total - unviable;
+            const score    = tested > 0 ? (caught / tested * 100).toFixed(1) : '0.0';
+
+            const emoji = parseFloat(score) >= 80 ? '🟢' : parseFloat(score) >= 60 ? '🟡' : '🔴';
+
+            let body = `## ${emoji} Contract Mutation Score: ${score}%\n\n`;
+            body += `| Metric | Count |\n|--------|-------|\n`;
+            body += `| Total mutants | ${total} |\n`;
+            body += `| Caught (killed) | ${caught} |\n`;
+            body += `| Missed (survived) | ${missed} |\n`;
+            body += `| Unviable (skipped) | ${unviable} |\n`;
+            body += `| **Score** | **${score}%** |\n\n`;
+
+            if (missed > 0) {
+              body += `<details><summary>Surviving mutants (${missed})</summary>\n\n`;
+              data.filter(m => m.status === 'missed').forEach(m => {
+                body += `- \`${m.file}:${m.line}\` — ${m.mutation}\n`;
+              });
+              body += `\n</details>\n`;
+            }
+
+            body += `\n> Full report available in the [workflow artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).`;
+
+            // Find and update existing comment, or create a new one
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('Contract Mutation Score')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  # ─── Frontend Mutation Testing (Stryker) ────────────────────────────────────
+  frontend-mutation:
+    name: Frontend Mutation Tests (Stryker)
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.scope == 'all' ||
+      github.event.inputs.scope == 'frontend'
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Stryker mutation tests
+        run: npm run test:mutation:ci
+        # Continue so we can always upload the report
+        continue-on-error: true
+
+      - name: Parse and enforce mutation score threshold
+        run: |
+          REPORT="reports/mutation/mutation.json"
+          if [ ! -f "$REPORT" ]; then
+            echo "mutation.json not found — Stryker may have failed"
+            exit 1
+          fi
+
+          python3 - <<'EOF'
+          import json, sys
+
+          with open("reports/mutation/mutation.json") as f:
+              data = json.load(f)
+
+          metrics = data.get("metrics", {})
+          score   = metrics.get("mutationScore", 0.0)
+          total   = metrics.get("totalMutants", 0)
+          killed  = metrics.get("killed", 0)
+          survived = metrics.get("survived", 0)
+          timeout = metrics.get("timedOut", 0)
+          no_cov  = metrics.get("noCoverage", 0)
+
+          print(f"=== Frontend Mutation Score ===")
+          print(f"  Total mutants : {total}")
+          print(f"  Killed        : {killed}")
+          print(f"  Survived      : {survived}")
+          print(f"  Timeout       : {timeout}")
+          print(f"  No coverage   : {no_cov}")
+          print(f"  Score         : {score:.1f}%")
+
+          THRESHOLD = 50.0
+          if score < THRESHOLD:
+              print(f"\nFAIL: mutation score {score:.1f}% is below the {THRESHOLD}% threshold")
+              sys.exit(1)
+          else:
+              print(f"\nPASS: mutation score {score:.1f}% meets the {THRESHOLD}% threshold")
+          EOF
+
+      - name: Upload Stryker mutation report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: frontend-mutation-report
+          path: frontend/reports/mutation/
+          retention-days: 30
+
+      - name: Comment Stryker score on PR
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'frontend/reports/mutation/mutation.json';
+
+            if (!fs.existsSync(path)) {
+              console.log('No mutation.json found, skipping PR comment');
+              return;
+            }
+
+            const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+            const m = data.metrics || {};
+            const score    = (m.mutationScore || 0).toFixed(1);
+            const total    = m.totalMutants || 0;
+            const killed   = m.killed || 0;
+            const survived = m.survived || 0;
+            const noCov    = m.noCoverage || 0;
+
+            const emoji = parseFloat(score) >= 80 ? '🟢' : parseFloat(score) >= 60 ? '🟡' : '🔴';
+
+            let body = `## ${emoji} Frontend Mutation Score: ${score}%\n\n`;
+            body += `| Metric | Count |\n|--------|-------|\n`;
+            body += `| Total mutants | ${total} |\n`;
+            body += `| Killed | ${killed} |\n`;
+            body += `| Survived | ${survived} |\n`;
+            body += `| No coverage | ${noCov} |\n`;
+            body += `| **Score** | **${score}%** |\n\n`;
+            body += `> Full HTML report available in the [workflow artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('Frontend Mutation Score')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  # ─── Summary gate ────────────────────────────────────────────────────────────
+  mutation-summary:
+    name: Mutation Testing Summary
+    runs-on: ubuntu-latest
+    needs: [contract-mutation, frontend-mutation]
+    if: always()
+
+    steps:
+      - name: Check job results
+        run: |
+          CONTRACT="${{ needs.contract-mutation.result }}"
+          FRONTEND="${{ needs.frontend-mutation.result }}"
+
+          echo "Contract mutation result : $CONTRACT"
+          echo "Frontend mutation result : $FRONTEND"
+
+          # Treat 'skipped' (workflow_dispatch scope filter) as success
+          if [[ "$CONTRACT" == "failure" || "$FRONTEND" == "failure" ]]; then
+            echo "One or more mutation suites failed the score threshold."
+            exit 1
+          fi
+
+          echo "All mutation suites passed."

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -1,0 +1,202 @@
+# Accessibility Testing — Stellar Save
+
+This document describes the automated accessibility testing suite for Stellar Save, how to run it, and known issues.
+
+> **Note:** Automated tools catch roughly 30–40% of WCAG issues. Full compliance requires manual testing with assistive technologies (screen readers, keyboard-only navigation, high-contrast mode). See [Manual Testing](#manual-testing) below.
+
+---
+
+## Tools
+
+| Tool | Purpose | Standard |
+|------|---------|----------|
+| [jest-axe](https://github.com/nickcolley/jest-axe) | axe-core violations in Vitest component tests | WCAG 2.1 AA |
+| [Pa11y CI](https://github.com/pa11y/pa11y-ci) | Full-page scans against the built app | WCAG 2.1 AA |
+| [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci) | Accessibility score audit per build | Lighthouse accessibility rules |
+| [@axe-core/react](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/react) | Runtime dev-mode warnings in the browser | WCAG 2.1 AA |
+
+---
+
+## Running Tests Locally
+
+### 1. axe-core component tests (fast, no server needed)
+
+```bash
+cd frontend
+npm run test:a11y          # run once
+npm run test:a11y:ci       # verbose output for CI
+```
+
+These tests live in `frontend/src/test/a11y.test.tsx` and cover:
+
+- **UI primitives:** `Input`, `Button`, `Tabs`, `Pagination`, `SearchBar`, `Spinner`
+- **Feature components:** `WalletButton`, `CreateGroupForm`, `JoinGroupButton`, `ContributeButton`
+- **Pages:** `LandingPage`, `NotFoundPage`, `ErrorPage`, `SettingsPage`
+- **Keyboard navigation:** Tab order, arrow-key navigation in Tabs, Enter/Space on buttons, Escape to close modals
+- **Screen reader attributes:** `role`, `aria-label`, `aria-labelledby`, `aria-describedby`, `aria-live`, `aria-invalid`, `aria-selected`, `aria-current`
+
+### 2. Pa11y full-page scan (requires built app)
+
+```bash
+cd frontend
+npm run build
+npm run preview &          # starts on http://localhost:4173
+npm run test:a11y:pa11y    # scans all pages defined in .pa11yrc.json
+```
+
+Screenshots are saved to `frontend/pa11y-screenshots/`.
+
+### 3. Lighthouse accessibility audit
+
+```bash
+cd frontend
+npm run build
+npm run lhci               # runs Lighthouse CI including accessibility audit
+```
+
+---
+
+## CI Pipeline
+
+The `accessibility.yml` workflow runs on every push and pull request to `main` and `develop`:
+
+```
+axe-unit  ──┐
+             ├──► a11y-gate (blocks merge on failure)
+pa11y     ──┤
+             │
+lighthouse ──┘
+```
+
+- **axe-unit** — Vitest + jest-axe component tests. Blocks the gate on failure.
+- **pa11y** — Full-page WCAG 2.1 AA scan. Blocks the gate on failure.
+- **lighthouse-a11y** — Lighthouse accessibility score ≥ 90. Posts a comment on PRs. Does not block the gate (score is a warning signal).
+
+---
+
+## What Is Tested
+
+### WCAG 2.1 AA Criteria Covered (Automated)
+
+| Criterion | Description | How Tested |
+|-----------|-------------|------------|
+| 1.1.1 Non-text Content | Images have alt text | axe, Pa11y |
+| 1.3.1 Info and Relationships | Semantic HTML, labels, roles | axe, Pa11y |
+| 1.3.3 Sensory Characteristics | Instructions don't rely on shape/color alone | axe |
+| 1.4.3 Contrast (Minimum) | Text contrast ≥ 4.5:1 | axe, Pa11y, Lighthouse |
+| 2.1.1 Keyboard | All functionality via keyboard | Vitest keyboard tests |
+| 2.1.2 No Keyboard Trap | Focus can always move away | Vitest keyboard tests |
+| 2.4.3 Focus Order | Logical tab order | Vitest tab tests |
+| 2.4.6 Headings and Labels | Descriptive headings and labels | axe, Pa11y |
+| 2.4.7 Focus Visible | Keyboard focus is visible | axe |
+| 3.3.1 Error Identification | Errors identified in text | axe (aria-invalid, role=alert) |
+| 3.3.2 Labels or Instructions | Form inputs have labels | axe, Pa11y |
+| 4.1.2 Name, Role, Value | ARIA attributes correct | axe, Pa11y |
+| 4.1.3 Status Messages | Live regions for dynamic content | axe (aria-live) |
+
+### Components with Dedicated Tests
+
+- `Input` — label association, `aria-invalid`, `aria-describedby`, `role="alert"` on errors
+- `Button` — keyboard focus, disabled state, loading spinner `aria-hidden`
+- `Tabs` — `role="tablist"`, `role="tab"`, `role="tabpanel"`, arrow-key navigation, `aria-selected`
+- `Pagination` — `aria-label` on prev/next, `aria-current="page"`, labelled page-size select
+- `SearchBar` — `role="searchbox"`, `aria-label`, `role="listbox"` for suggestions, `aria-hidden` on decorative icon
+- `Spinner` — `role="status"`, `aria-label`, `FullPageLoader` `role="alert"`
+- `WalletButton` — keyboard open/close, accessible text when connected
+- `CreateGroupForm` — multi-step form, `role="progressbar"` with `aria-valuenow/min/max`, validation `role="alert"`, Tab order
+- `JoinGroupButton` — all states (eligible, confirmation, disabled)
+- `ContributeButton` — modal heading, keyboard dismiss with Escape
+- `LandingPage` — skip link, `role="banner"`, `role="contentinfo"`, `role="navigation"` with labels, section headings
+- `NotFoundPage` — `h1` heading, image alt text, keyboard-focusable buttons
+- `ErrorPage` — heading, image alt text, keyboard-focusable buttons
+- `SettingsPage` — radio group, shared `name` attribute, keyboard navigation
+
+---
+
+## Manual Testing
+
+Automated tools cannot catch everything. The following should be tested manually before each release:
+
+### Screen Reader Testing
+
+| Screen Reader | Browser | Platform |
+|---------------|---------|----------|
+| NVDA | Firefox, Chrome | Windows |
+| JAWS | Chrome, Edge | Windows |
+| VoiceOver | Safari | macOS / iOS |
+| TalkBack | Chrome | Android |
+
+**Key flows to test:**
+1. Landing page — read all sections in order, navigate by headings
+2. Connect wallet — announce connection state changes
+3. Browse groups — filter and search results announced
+4. Create group — multi-step form, step progress announced, validation errors announced
+5. Join group — confirmation dialog announced, focus managed
+6. Contribute — modal focus trap, success/error announced
+7. Settings — theme and language changes announced
+8. Dashboard — loading states announced, data updates announced
+
+### Keyboard-Only Navigation
+
+1. Tab through every interactive element on each page
+2. Verify focus indicator is always visible
+3. Verify no keyboard traps (can always Tab away)
+4. Verify modals trap focus correctly and restore focus on close
+5. Verify dropdowns open/close with Enter/Space/Escape
+6. Verify data tables are navigable with arrow keys
+
+### High Contrast Mode
+
+Test all pages in Windows High Contrast Mode and macOS Increase Contrast mode:
+- All text remains readable
+- Focus indicators remain visible
+- Icons are not the sole means of conveying information
+
+### Zoom / Text Resize
+
+- Test at 200% browser zoom — no content clipped or overlapping
+- Test with browser font size set to 200% — layout remains usable
+
+---
+
+## Known Issues
+
+| Issue | Component | WCAG Criterion | Status |
+|-------|-----------|----------------|--------|
+| Profile page tab list missing `role="tablist"` wrapper | `ProfilePage` | 4.1.2 | Open — tabs use `role="tab"` but no `tablist` container |
+| Transaction table missing column headers | `TransactionTables` | 1.3.1 | Open — `<th>` elements needed |
+| Color-only status indicators in GroupCard | `GroupCard` | 1.4.1 | Open — status badges rely on color alone |
+| Missing `lang` attribute on `<html>` | `index.html` | 3.1.1 | Open — add `lang="en"` |
+
+---
+
+## Adding New Tests
+
+When adding a new component or page:
+
+1. Add an axe scan to `frontend/src/test/a11y.test.tsx`:
+
+```tsx
+describe('MyComponent – accessibility', () => {
+  it('has no axe violations', async () => {
+    const { container } = render(<MyComponent />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+```
+
+2. Add keyboard navigation tests for any interactive elements.
+
+3. Add the page URL to `frontend/.pa11yrc.json` if it's a new route.
+
+4. Run `npm run test:a11y` locally before opening a PR.
+
+---
+
+## Resources
+
+- [WCAG 2.1 Quick Reference](https://www.w3.org/WAI/WCAG21/quickref/)
+- [axe-core Rules](https://dequeuniversity.com/rules/axe/)
+- [Pa11y Documentation](https://pa11y.org/)
+- [Inclusive Components](https://inclusive-components.design/)
+- [A11y Project Checklist](https://www.a11yproject.com/checklist/)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +179,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -194,6 +209,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -223,6 +244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "bytes-lit"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +259,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -278,6 +337,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -501,6 +580,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +680,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,7 +701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -656,6 +755,79 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fungible-allowlist-example"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+ "stellar-access",
+ "stellar-macros",
+ "stellar-tokens",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -715,6 +887,34 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "guess-the-number"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+ "stellar-registry",
+ "stellar-xdr",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -797,6 +997,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,6 +1092,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +1184,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -860,6 +1234,12 @@ name = "indexmap-nostd"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itertools"
@@ -932,6 +1312,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +1348,49 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "nft-enumerable-example"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+ "stellar-macros",
+ "stellar-tokens",
+]
 
 [[package]]
 name = "num-bigint"
@@ -1006,6 +1444,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,10 +1500,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -1031,6 +1548,21 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1084,7 +1616,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -1191,6 +1723,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,10 +1752,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
 
 [[package]]
 name = "rfc6979"
@@ -1241,11 +1845,20 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -1264,6 +1877,21 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1302,6 +1930,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,10 +1949,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -1364,12 +2025,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -1423,6 +2096,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,10 +2116,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
@@ -1541,7 +2250,7 @@ dependencies = [
  "serde_with",
  "soroban-env-common",
  "soroban-env-host",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1594,9 +2303,9 @@ version = "23.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc4fef2cad410563bbd56f9fa68731268f89e90a4d7e6c4d62adb45c0b4c571"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "stellar-xdr",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmparser 0.116.1",
 ]
 
@@ -1613,7 +2322,7 @@ dependencies = [
  "soroban-spec",
  "stellar-xdr",
  "syn 2.0.117",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1658,12 +2367,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stellar-access"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "974e461afe1538ee54dc9314ed46144f393265c7625606c240760cd6a2baaadf"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "stellar-build"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fd5e3be902a9658fb9f642d4eef7837ab1d51e52dde9be1d9b218326499d97"
+dependencies = [
+ "cargo_metadata",
+ "sha2",
+ "thiserror 2.0.18",
+ "topological-sort",
+]
+
+[[package]]
+name = "stellar-contract-utils"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a918daa29a4cfc0fe97118a2425893a0336a33b436e8f70ca4b4f5c739f23e4"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "stellar-core"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612c5341e1f73a9e8153da5cdcf80c0789532ba36537c7bba35b650fd63a7d7d"
+
+[[package]]
+name = "stellar-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb4b3dd8f599646dab3e949ba2febc3a060a194bc1a3711ddd5e7c275acfe5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "stellar-registry"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcacbce7779ca20863e3f980bc7d3b09865c8ece4bcb7b1b75ed22ca357c4b0"
+dependencies = [
+ "stellar-scaffold-macro",
+]
+
+[[package]]
 name = "stellar-save"
 version = "0.1.0"
 dependencies = [
  "ed25519-dalek",
  "proptest",
  "soroban-sdk",
+]
+
+[[package]]
+name = "stellar-save-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "stellar-core",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "stellar-scaffold-macro"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10db244165d775a521e6e73ee793cc7daafe5ad605b6550d8909b85b8b1745d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "sha2",
+ "stellar-build",
+ "stellar-strkey 0.0.13",
+ "stellar-xdr",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1688,13 +2484,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellar-tokens"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc8be39a374a3520726017623d7c79d7d0530e626778619ba8f9462037e37aa"
+dependencies = [
+ "soroban-sdk",
+ "stellar-contract-utils",
+]
+
+[[package]]
 name = "stellar-xdr"
 version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d2848e1694b0c8db81fd812bfab5ea71ee28073e09ccc45620ef3cf7a75a9b"
 dependencies = [
  "arbitrary",
- "base64",
+ "base64 0.22.1",
  "cfg_eval",
  "crate-git-revision",
  "escape-bytes",
@@ -1741,6 +2547,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,7 +2594,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1759,7 +2603,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1767,6 +2620,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1805,6 +2669,116 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2 0.6.3",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "topological-sort"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,6 +2801,30 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1852,6 +2850,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1889,6 +2896,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a42e96ea38f49b191e08a1bab66c7ffdba24b06f9995b39a9dd60222e5b6f1da"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1979,7 +3000,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
@@ -1992,6 +3013,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
  "indexmap-nostd",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c7c5718134e770ee62af3b6b4a84518ec10101aad610c024b64d6ff29bb1ff"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2055,11 +3086,160 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2120,7 +3300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap 2.13.0",
  "log",
  "serde",
@@ -2151,6 +3331,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2171,6 +3380,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,6 +3414,39 @@ name = "zeroize_derive"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,5 +1,13 @@
 # Testing Guide
 
+## Overview
+
+This project uses a comprehensive testing strategy including:
+- **Unit tests** for smart contracts (Rust) and frontend (TypeScript)
+- **Property-based testing** (fuzzing) for contracts
+- **Code coverage** tracking with 95% threshold for contracts
+- **Mutation testing** to verify test suite quality
+
 ## Smart Contract Tests (Rust)
 
 ### Running Tests
@@ -79,3 +87,192 @@ Add to your CI pipeline:
 # Frontend
 - run: cd frontend && npm install && npm test run
 ```
+
+## Mutation Testing
+
+Mutation testing verifies the quality of your test suite by introducing small changes (mutations) to the code and checking if tests catch them. A high mutation score indicates that tests effectively detect bugs.
+
+### What is Mutation Testing?
+
+Mutation testing works by:
+1. Creating "mutants" — small modifications to your code (e.g., changing `>` to `>=`, `+` to `-`)
+2. Running your test suite against each mutant
+3. Checking if tests fail (mutant "killed") or pass (mutant "survived")
+4. Calculating a mutation score: `killed / (killed + survived) × 100%`
+
+A surviving mutant indicates either:
+- Missing test coverage for that code path
+- Tests that don't assert the specific behavior being mutated
+
+### Rust Contracts (cargo-mutants)
+
+**Installation:**
+```bash
+cargo install cargo-mutants --locked
+```
+
+**Running locally:**
+```bash
+cd contracts/stellar-save
+
+# Run all mutations (can take 30-60 minutes)
+cargo mutants
+
+# Run with parallelism
+cargo mutants --jobs 4
+
+# Test specific files only
+cargo mutants --file src/penalty.rs --file src/pool.rs
+
+# Show caught mutants (for debugging)
+cargo mutants --caught
+```
+
+**Configuration:**
+- Config file: `contracts/stellar-save/mutants.toml`
+- Excludes: test files, benchmarks, migrations, generated code
+- Timeout: 120s per mutant (3x multiplier)
+- Target threshold: 60% mutation score
+
+**Interpreting results:**
+```
+Mutation score: 75.0% (45/60 mutants killed)
+  caught: 45    ← tests detected these mutations ✓
+  missed: 15    ← tests didn't catch these (need more tests)
+  timeout: 0    ← mutants that caused infinite loops
+  unviable: 5   ← mutants that don't compile (skipped)
+```
+
+**Adding tests for surviving mutants:**
+
+When a mutant survives, examine the mutation and add a test:
+
+```rust
+// Example: mutant changed `amount > 0` to `amount >= 0`
+// Surviving mutant in penalty.rs:
+//   - if amount <= 0 { return 0; }
+//   + if amount < 0 { return 0; }
+
+// Add test to catch this:
+#[test]
+fn test_calculate_penalty_zero_amount() {
+    let cfg = PenaltyConfig::default();
+    // This test now catches the >= vs > mutation
+    assert_eq!(calculate_penalty(0, 3, &cfg), 0);
+}
+```
+
+### Frontend (Stryker)
+
+**Installation:**
+```bash
+cd frontend
+npm install --save-dev @stryker-mutator/core @stryker-mutator/vitest-runner
+```
+
+**Running locally:**
+```bash
+cd frontend
+
+# Run all mutations (can take 20-40 minutes)
+npm run test:mutation
+
+# View HTML report
+open reports/mutation/mutation.html
+```
+
+**Configuration:**
+- Config file: `frontend/stryker.config.mjs`
+- Excludes: test files, assets, i18n, type definitions
+- Thresholds: 80% (high), 60% (low), 50% (break/fail)
+- Concurrency: 4 workers
+
+**Interpreting results:**
+```
+Mutation score: 68.5% (137/200 mutants killed)
+  Killed: 137       ← tests caught these ✓
+  Survived: 63      ← tests missed these (need assertions)
+  No coverage: 12   ← code not executed by tests
+  Timeout: 3        ← mutants caused infinite loops
+```
+
+**Adding tests for surviving mutants:**
+
+```typescript
+// Example: mutant changed `amount > 0` to `amount >= 0`
+// Surviving mutant in utils/validation.ts
+
+// Add test to catch this:
+it('rejects zero amount', () => {
+  expect(validateAmount(0)).toBe(false);
+  // This assertion now catches the > vs >= mutation
+});
+```
+
+### CI Integration
+
+Mutation testing runs automatically:
+- **On PRs** to main/develop (for changed files only)
+- **Weekly** (Sunday 03:00 UTC) for full baseline
+- **Manual trigger** via GitHub Actions (can select scope: all/contracts/frontend)
+
+**Workflow:** `.github/workflows/mutation-testing.yml`
+
+**Thresholds enforced in CI:**
+- Contracts: 60% minimum mutation score
+- Frontend: 50% minimum mutation score
+
+**PR comments:**
+The workflow automatically posts mutation scores as PR comments with:
+- Overall score and emoji indicator (🟢 ≥80%, 🟡 ≥60%, 🔴 <60%)
+- Breakdown of killed/survived/timeout mutants
+- List of surviving mutants (expandable)
+- Link to full HTML report in artifacts
+
+### Best Practices
+
+1. **Start with high-value modules**: Focus mutation testing on critical business logic (penalty calculations, pool math, contribution validation)
+
+2. **Don't chase 100%**: Some mutants are equivalent (produce identical behavior) or test implementation details. Aim for 70-85% on critical modules.
+
+3. **Use mutation testing to find gaps**: Surviving mutants reveal:
+   - Missing edge case tests
+   - Assertions that are too weak
+   - Dead code that can be removed
+
+4. **Combine with coverage**: High line coverage + high mutation score = robust test suite
+
+5. **Run incrementally**: Use `--file` (cargo-mutants) or `mutate` patterns (Stryker) to test specific modules during development
+
+6. **Review timeouts**: Mutants that timeout often indicate:
+   - Missing loop termination checks
+   - Unbounded recursion guards
+   - Performance-critical code paths
+
+### Troubleshooting
+
+**cargo-mutants is slow:**
+- Use `--jobs N` to parallelize
+- Use `--file` to test specific modules
+- Increase `--timeout` if legitimate tests are timing out
+
+**Stryker uses too much memory:**
+- Reduce `concurrency` in `stryker.config.mjs`
+- Use `--mutate` CLI flag to test specific files
+- Exclude large generated files
+
+**False positives (equivalent mutants):**
+- Some mutants produce identical behavior (e.g., `i++` vs `++i` in some contexts)
+- Document these in code comments or ignore patterns
+- Focus on the overall trend, not individual mutants
+
+**CI timeout:**
+- Mutation testing is CPU-intensive; adjust `timeout-minutes` in workflow
+- Consider running full suite only on schedule, not every PR
+
+### Resources
+
+- [cargo-mutants documentation](https://mutants.rs/)
+- [Stryker documentation](https://stryker-mutator.io/)
+- [Mutation testing explained](https://en.wikipedia.org/wiki/Mutation_testing)
+

--- a/contracts/stellar-save/mutants.toml
+++ b/contracts/stellar-save/mutants.toml
@@ -1,0 +1,38 @@
+# cargo-mutants configuration for the stellar-save contract
+# https://mutants.rs/configuration.html
+
+# ─── Timeout ──────────────────────────────────────────────────────────────────
+# Each mutant test run is capped at 120 s (Soroban tests are CPU-heavy).
+timeout_multiplier = 3.0
+minimum_test_timeout = 120
+
+# ─── Parallelism ──────────────────────────────────────────────────────────────
+# Use all available cores in CI; locally this can be overridden with -j.
+# jobs = 4   # uncomment to pin locally
+
+# ─── Scope ────────────────────────────────────────────────────────────────────
+# Only mutate production logic — exclude test helpers, benchmarks, and
+# generated/boilerplate files that are not meaningful mutation targets.
+exclude_globs = [
+    # Test-only modules
+    "src/*_tests.rs",
+    "src/fuzz_tests.rs",
+    # Benchmarks and storage-size helpers
+    "src/gas_benchmark*.rs",
+    "src/storage_benchmark.rs",
+    "src/storage_optimization.rs",
+    # Migration scaffolding (mostly data-shape, not logic)
+    "src/migration*.rs",
+    "src/migrations/**",
+    # Backup of old lib
+    "src/lib.rs.bak",
+]
+
+# ─── Mutation operators ───────────────────────────────────────────────────────
+# All operators are enabled by default; list here for documentation.
+# Operators: arithmetic, bitwise, comparison, literal, return, unary
+# (cargo-mutants enables all by default — no explicit list needed)
+
+# ─── Output ───────────────────────────────────────────────────────────────────
+# Write results to a JSON file so CI can parse the mutation score.
+# (passed via --json-output flag in the workflow)

--- a/contracts/stellar-save/src/lib.rs
+++ b/contracts/stellar-save/src/lib.rs
@@ -49,6 +49,7 @@ mod migration_tests;
 mod milestone_tests;
 pub mod milestones;
 mod multi_token_tests;
+mod mutation_tests;
 pub mod search;
 mod upgrade_tests;
 mod fuzz_tests;

--- a/contracts/stellar-save/src/mutation_tests.rs
+++ b/contracts/stellar-save/src/mutation_tests.rs
@@ -1,0 +1,554 @@
+//! Mutation testing supplement — tests targeting likely surviving mutants.
+//!
+//! These tests were written after analysing the mutation score from `cargo-mutants`
+//! and are specifically designed to kill mutants that the existing test suite misses.
+//!
+//! Each test is annotated with the mutation it is designed to catch.
+//!
+//! ## Modules covered
+//! - `penalty`  — `calculate_penalty` boundary conditions and BPS arithmetic
+//! - `pool`     — `PoolCalculator` and `PoolInfo` method mutations
+//! - `helpers`  — `round_contribution_amount`, `is_cycle_deadline_passed`
+//! - `rating`   — `RatingAggregate::average_scaled` calculation
+//! - `refund`   — `RefundRecord` field integrity
+
+#[cfg(test)]
+mod penalty_mutation_tests {
+    use crate::penalty::{
+        calculate_penalty, PenaltyConfig, BASE_PENALTY_BPS, MAX_PENALTY_BPS,
+        PENALTY_INCREMENT_BPS, RECOVERY_FEE_BPS,
+    };
+
+    // ── calculate_penalty boundary mutations ──────────────────────────────────
+
+    /// Catches: `missed_cycles == 0` → `missed_cycles != 0`
+    /// (negation of the early-return guard)
+    #[test]
+    fn test_penalty_exactly_zero_missed_returns_zero() {
+        let cfg = PenaltyConfig::default();
+        assert_eq!(calculate_penalty(1_000_000, 0, &cfg), 0);
+    }
+
+    /// Catches: `contribution_amount <= 0` → `contribution_amount < 0`
+    /// (off-by-one on the zero guard — zero must also return 0)
+    #[test]
+    fn test_penalty_zero_contribution_returns_zero() {
+        let cfg = PenaltyConfig::default();
+        assert_eq!(calculate_penalty(0, 5, &cfg), 0);
+    }
+
+    /// Catches: `contribution_amount <= 0` → `contribution_amount == 0`
+    /// (negative amounts must also return 0)
+    #[test]
+    fn test_penalty_negative_contribution_returns_zero() {
+        let cfg = PenaltyConfig::default();
+        assert_eq!(calculate_penalty(-1, 1, &cfg), 0);
+    }
+
+    /// Catches: `missed_cycles.saturating_sub(1)` → `missed_cycles`
+    /// (off-by-one in the increment calculation — 1 miss must use base only)
+    #[test]
+    fn test_penalty_one_miss_uses_base_only_no_increment() {
+        let cfg = PenaltyConfig::default();
+        // 1 miss → base_bps only (500 bps = 5%)
+        // Mutant using missed_cycles instead of missed_cycles-1:
+        //   raw_bps = 500 + 500*1 = 1000 → 10% (wrong)
+        let result = calculate_penalty(100_000_000, 1, &cfg);
+        assert_eq!(result, 5_000_000, "1 miss should be exactly 5%");
+    }
+
+    /// Catches: `raw_bps.min(config.max_penalty_bps)` → `raw_bps.max(config.max_penalty_bps)`
+    /// (min/max swap on the cap — penalty must never exceed MAX_PENALTY_BPS)
+    #[test]
+    fn test_penalty_cap_does_not_exceed_max() {
+        let cfg = PenaltyConfig::default();
+        // 5 misses → 500 + 500*4 = 2500 bps (exactly at cap)
+        let at_cap = calculate_penalty(100_000_000, 5, &cfg);
+        // 6 misses → would be 3000 bps without cap, but must be capped at 2500
+        let over_cap = calculate_penalty(100_000_000, 6, &cfg);
+        assert_eq!(at_cap, over_cap, "penalty must be capped at MAX_PENALTY_BPS");
+        assert_eq!(at_cap, 25_000_000);
+    }
+
+    /// Catches: `/ 10_000` → `* 10_000` or `/ 1_000`
+    /// (wrong divisor in basis-point calculation)
+    #[test]
+    fn test_penalty_bps_divisor_is_ten_thousand() {
+        let cfg = PenaltyConfig::default();
+        // 1 miss = 500 bps = 5% of 10_000_000 = 500_000
+        let result = calculate_penalty(10_000_000, 1, &cfg);
+        assert_eq!(result, 500_000);
+    }
+
+    /// Catches: `saturating_add` replaced with plain `+` (overflow panic)
+    #[test]
+    fn test_penalty_saturating_add_does_not_panic_on_large_bps() {
+        let cfg = PenaltyConfig {
+            base_penalty_bps: u32::MAX,
+            penalty_increment_bps: u32::MAX,
+            max_penalty_bps: u32::MAX,
+            recovery_fee_bps: RECOVERY_FEE_BPS,
+        };
+        // Should not panic — saturating_add prevents overflow
+        let _ = calculate_penalty(100_000_000, 2, &cfg);
+    }
+
+    /// Catches: constant value mutations on penalty BPS constants
+    #[test]
+    fn test_penalty_constants_have_correct_values() {
+        assert_eq!(BASE_PENALTY_BPS, 500, "base penalty must be 5%");
+        assert_eq!(PENALTY_INCREMENT_BPS, 500, "increment must be 5%");
+        assert_eq!(MAX_PENALTY_BPS, 2500, "max penalty must be 25%");
+        assert_eq!(RECOVERY_FEE_BPS, 1000, "recovery fee must be 10%");
+    }
+
+    /// Catches: capped_bps cast mutation and arithmetic mutations across all miss counts
+    #[test]
+    fn test_penalty_exact_values_for_each_miss_count() {
+        let cfg = PenaltyConfig::default();
+        let contribution = 200_000_000i128; // 20 XLM
+
+        // miss 1 → 5%  = 10_000_000
+        assert_eq!(calculate_penalty(contribution, 1, &cfg), 10_000_000);
+        // miss 2 → 10% = 20_000_000
+        assert_eq!(calculate_penalty(contribution, 2, &cfg), 20_000_000);
+        // miss 3 → 15% = 30_000_000
+        assert_eq!(calculate_penalty(contribution, 3, &cfg), 30_000_000);
+        // miss 4 → 20% = 40_000_000
+        assert_eq!(calculate_penalty(contribution, 4, &cfg), 40_000_000);
+        // miss 5 → 25% = 50_000_000 (at cap)
+        assert_eq!(calculate_penalty(contribution, 5, &cfg), 50_000_000);
+        // miss 6 → still 25% (capped)
+        assert_eq!(calculate_penalty(contribution, 6, &cfg), 50_000_000);
+    }
+
+    /// Catches: config fields being ignored (e.g., always using defaults)
+    #[test]
+    fn test_penalty_respects_custom_config() {
+        let cfg = PenaltyConfig {
+            base_penalty_bps: 200,       // 2%
+            penalty_increment_bps: 100,  // 1% per additional miss
+            max_penalty_bps: 500,        // 5% cap
+            recovery_fee_bps: 500,       // 5% recovery fee
+        };
+        let contribution = 100_000_000i128;
+
+        // 1 miss → 2%
+        assert_eq!(calculate_penalty(contribution, 1, &cfg), 2_000_000);
+        // 2 misses → 3%
+        assert_eq!(calculate_penalty(contribution, 2, &cfg), 3_000_000);
+        // 4 misses → 5% (capped)
+        assert_eq!(calculate_penalty(contribution, 4, &cfg), 5_000_000);
+        // 10 misses → still 5% (capped)
+        assert_eq!(calculate_penalty(contribution, 10, &cfg), 5_000_000);
+    }
+}
+
+#[cfg(test)]
+mod pool_mutation_tests {
+    use crate::error::StellarSaveError;
+    use crate::pool::{PoolCalculator, PoolInfo};
+
+    fn make_pool(member_count: u32, contributors_count: u32, total: i128, current: i128) -> PoolInfo {
+        PoolInfo {
+            group_id: 1,
+            cycle: 0,
+            member_count,
+            contribution_amount: if member_count > 0 { total / member_count as i128 } else { 0 },
+            total_pool_amount: total,
+            current_contributions: current,
+            contributors_count,
+            is_cycle_complete: contributors_count >= member_count,
+        }
+    }
+
+    // ── calculate_total_pool mutations ────────────────────────────────────────
+
+    /// Catches: `contribution_amount <= 0` → `contribution_amount < 0`
+    #[test]
+    fn test_pool_rejects_zero_contribution() {
+        let result = PoolCalculator::calculate_total_pool(0, 5);
+        assert_eq!(result, Err(StellarSaveError::InvalidAmount));
+    }
+
+    /// Catches: `member_count == 0` → `member_count != 0`
+    #[test]
+    fn test_pool_rejects_zero_members() {
+        let result = PoolCalculator::calculate_total_pool(1_000_000, 0);
+        assert_eq!(result, Err(StellarSaveError::InvalidState));
+    }
+
+    /// Catches: `checked_mul` replaced with `*` (overflow not caught)
+    #[test]
+    fn test_pool_overflow_returns_internal_error() {
+        let result = PoolCalculator::calculate_total_pool(i128::MAX, 2);
+        assert_eq!(result, Err(StellarSaveError::InternalError));
+    }
+
+    /// Catches: multiplication replaced with addition
+    #[test]
+    fn test_pool_total_is_product_not_sum() {
+        let contribution = 1_000_000i128;
+        let members = 5u32;
+        let result = PoolCalculator::calculate_total_pool(contribution, members).unwrap();
+        // Mutant using + instead of *: 1_000_000 + 5 = 1_000_005 (wrong)
+        assert_eq!(result, 5_000_000);
+        assert_ne!(result, contribution + members as i128);
+    }
+
+    // ── PoolInfo method mutations ─────────────────────────────────────────────
+
+    /// Catches: `contributors_count >= member_count` → `contributors_count > member_count`
+    #[test]
+    fn test_pool_is_complete_when_exactly_equal() {
+        let pool = make_pool(5, 5, 5_000_000, 5_000_000);
+        assert!(pool.is_complete(), "pool must be complete when contributors == members");
+    }
+
+    /// Catches: `contributors_count >= member_count` → `contributors_count <= member_count`
+    #[test]
+    fn test_pool_is_not_complete_when_one_short() {
+        let pool = make_pool(5, 4, 5_000_000, 4_000_000);
+        assert!(!pool.is_complete(), "pool must not be complete when one contributor is missing");
+    }
+
+    /// Catches: `member_count.saturating_sub(contributors_count)` → operands swapped
+    #[test]
+    fn test_remaining_contributions_is_members_minus_contributors() {
+        let pool = make_pool(10, 3, 10_000_000, 3_000_000);
+        assert_eq!(pool.remaining_contributions_needed(), 7);
+    }
+
+    /// Catches: saturating_sub replaced with plain subtraction (underflow panic)
+    #[test]
+    fn test_remaining_contributions_saturates_at_zero() {
+        // contributors_count > member_count (edge case — must not panic)
+        let pool = PoolInfo {
+            group_id: 1,
+            cycle: 0,
+            member_count: 3,
+            contribution_amount: 1_000_000,
+            total_pool_amount: 3_000_000,
+            current_contributions: 4_000_000,
+            contributors_count: 4,
+            is_cycle_complete: true,
+        };
+        assert_eq!(pool.remaining_contributions_needed(), 0);
+    }
+
+    /// Catches: `* 100` → `* 10` or `* 1000` in completion_percentage
+    #[test]
+    fn test_completion_percentage_scale_is_100() {
+        let pool = make_pool(4, 1, 4_000_000, 1_000_000);
+        assert_eq!(pool.completion_percentage(), 25);
+    }
+
+    /// Catches: `member_count == 0` guard removed in completion_percentage
+    #[test]
+    fn test_completion_percentage_zero_members_returns_zero() {
+        let pool = PoolInfo {
+            group_id: 1,
+            cycle: 0,
+            member_count: 0,
+            contribution_amount: 0,
+            total_pool_amount: 0,
+            current_contributions: 0,
+            contributors_count: 0,
+            is_cycle_complete: false,
+        };
+        assert_eq!(pool.completion_percentage(), 0);
+    }
+
+    // ── validate_pool_ready_for_payout mutations ──────────────────────────────
+
+    /// Catches: `!pool_info.is_cycle_complete` → `pool_info.is_cycle_complete`
+    #[test]
+    fn test_validate_payout_fails_when_incomplete() {
+        let pool = make_pool(5, 4, 5_000_000, 4_000_000);
+        let result = PoolCalculator::validate_pool_ready_for_payout(&pool);
+        assert_eq!(result, Err(StellarSaveError::CycleNotComplete));
+    }
+
+    /// Catches: `!=` → `==` in contribution mismatch check
+    #[test]
+    fn test_validate_payout_fails_when_contributions_mismatch() {
+        let mut pool = make_pool(5, 5, 5_000_000, 5_000_000);
+        pool.current_contributions = 4_999_999; // one stroop short
+        let result = PoolCalculator::validate_pool_ready_for_payout(&pool);
+        assert_eq!(result, Err(StellarSaveError::InvalidAmount));
+    }
+
+    /// Catches: either check being removed — success requires both conditions
+    #[test]
+    fn test_validate_payout_succeeds_only_when_both_conditions_met() {
+        let pool = make_pool(5, 5, 5_000_000, 5_000_000);
+        assert!(PoolCalculator::validate_pool_ready_for_payout(&pool).is_ok());
+    }
+
+    // ── calculate_payout_amount mutations ─────────────────────────────────────
+
+    /// Catches: `total_pool < 0` → `total_pool <= 0` (zero must be valid)
+    #[test]
+    fn test_payout_amount_zero_is_valid() {
+        let result = PoolCalculator::calculate_payout_amount(0);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    /// Catches: `fees = 0` → `fees = 1` (v1 must have zero fees)
+    #[test]
+    fn test_payout_amount_v1_has_zero_fees() {
+        let pool = 10_000_000i128;
+        let result = PoolCalculator::calculate_payout_amount(pool).unwrap();
+        assert_eq!(result, pool, "v1 must have zero fees — net payout equals total pool");
+    }
+
+    /// Catches: negative input guard removed
+    #[test]
+    fn test_payout_amount_negative_input_returns_error() {
+        let result = PoolCalculator::calculate_payout_amount(-1);
+        assert_eq!(result, Err(StellarSaveError::InvalidAmount));
+    }
+}
+
+#[cfg(test)]
+mod helpers_mutation_tests {
+    use crate::helpers::{
+        is_cycle_deadline_passed, round_contribution_amount, ROUNDING_PRECISION,
+    };
+    use crate::group::Group;
+    use soroban_sdk::{Address, Env};
+
+    // ── round_contribution_amount mutations ───────────────────────────────────
+
+    /// Catches: `amount <= 0` → `amount < 0` (zero must also pass through unchanged)
+    #[test]
+    fn test_round_zero_returns_zero() {
+        assert_eq!(round_contribution_amount(0), 0);
+    }
+
+    /// Catches: `ROUNDING_PRECISION / 2` → `ROUNDING_PRECISION` (wrong half-point)
+    #[test]
+    fn test_round_exactly_at_half_rounds_up() {
+        // 50_000 is exactly half of ROUNDING_PRECISION (100_000)
+        assert_eq!(round_contribution_amount(50_000), 100_000);
+    }
+
+    /// Catches: `/ ROUNDING_PRECISION * ROUNDING_PRECISION` → just `/ ROUNDING_PRECISION`
+    /// (missing the re-multiplication step — result must be a multiple of precision)
+    #[test]
+    fn test_round_result_is_multiple_of_precision() {
+        let result = round_contribution_amount(1_234_567);
+        assert_eq!(result % ROUNDING_PRECISION, 0, "result must be a multiple of ROUNDING_PRECISION");
+    }
+
+    /// Catches: `+` replaced with `-` in `amount + half_precision` (rounds wrong direction)
+    #[test]
+    fn test_round_one_below_half_rounds_down() {
+        // 49_999 < 50_000 (half precision) → rounds down to 0
+        assert_eq!(round_contribution_amount(49_999), 0);
+    }
+
+    /// Catches: `+` replaced with `-` in `amount + half_precision` (upper range)
+    #[test]
+    fn test_round_one_above_half_rounds_up() {
+        // 50_001 > 50_000 → rounds up to 100_000
+        assert_eq!(round_contribution_amount(50_001), 100_000);
+    }
+
+    /// Catches: ROUNDING_PRECISION constant mutation (e.g., 10_000 instead of 100_000)
+    #[test]
+    fn test_rounding_precision_constant_value() {
+        assert_eq!(ROUNDING_PRECISION, 100_000, "precision must be 0.01 XLM = 100_000 stroops");
+    }
+
+    // ── is_cycle_deadline_passed mutations ────────────────────────────────────
+
+    /// Catches: `!group.started` → `group.started` (inverted started guard)
+    #[test]
+    fn test_deadline_not_started_always_false() {
+        let env = Env::default();
+        let creator = Address::generate(&env);
+        let group = Group::new(1, creator, 1_000_000, 604_800, 5, 2, 1000, 0);
+        // group.started == false
+        assert!(
+            !is_cycle_deadline_passed(&group, u64::MAX),
+            "unstarted group must never report deadline passed"
+        );
+    }
+
+    /// Catches: `current_time > deadline` → `current_time >= deadline` (strict inequality)
+    #[test]
+    fn test_deadline_exactly_at_grace_end_is_not_passed() {
+        let env = Env::default();
+        let creator = Address::generate(&env);
+        let grace = 3_600u64;
+        let mut group = Group::new(1, creator, 1_000_000, 604_800, 5, 2, 1000, grace);
+        group.activate(1000);
+
+        // deadline = started_at + cycle_duration * (current_cycle + 1) = 1000 + 604_800
+        let deadline = 1000 + 604_800;
+        // Exactly at deadline + grace — must NOT be passed (strict >)
+        assert!(!is_cycle_deadline_passed(&group, deadline + grace));
+    }
+
+    /// Catches: `current_time > deadline` → `current_time >= deadline`
+    #[test]
+    fn test_deadline_one_second_past_grace_is_passed() {
+        let env = Env::default();
+        let creator = Address::generate(&env);
+        let grace = 3_600u64;
+        let mut group = Group::new(1, creator, 1_000_000, 604_800, 5, 2, 1000, grace);
+        group.activate(1000);
+
+        let deadline = 1000 + 604_800;
+        assert!(is_cycle_deadline_passed(&group, deadline + grace + 1));
+    }
+
+    /// Catches: `+` → `-` in `cycle_deadline + group.grace_period_seconds`
+    #[test]
+    fn test_deadline_grace_period_extends_deadline() {
+        let env = Env::default();
+        let creator = Address::generate(&env);
+        let grace = 86_400u64; // 1 day
+        let mut group = Group::new(1, creator, 1_000_000, 604_800, 5, 2, 1000, grace);
+        group.activate(1000);
+
+        let cycle_deadline = 1000 + 604_800;
+        // One second past cycle deadline but still within grace — must NOT be passed
+        assert!(
+            !is_cycle_deadline_passed(&group, cycle_deadline + 1),
+            "grace period must extend the deadline"
+        );
+    }
+
+    /// Catches: `current_cycle as u64 + 1` → `current_cycle as u64`
+    /// (off-by-one — deadline must be at end of cycle, not start)
+    #[test]
+    fn test_deadline_uses_next_cycle_boundary_not_current() {
+        let env = Env::default();
+        let creator = Address::generate(&env);
+        let mut group = Group::new(1, creator, 1_000_000, 604_800, 5, 2, 1000, 0);
+        group.activate(1000);
+
+        // Cycle 0 deadline = started_at + cycle_duration * 1 = 1000 + 604_800
+        // Mutant using current_cycle (0): deadline = started_at + 0 = 1000
+        // → any time > 1000 would be "passed" (wrong)
+        assert!(
+            !is_cycle_deadline_passed(&group, 1001),
+            "deadline must be at end of cycle, not at start"
+        );
+    }
+}
+
+#[cfg(test)]
+mod rating_mutation_tests {
+    use crate::rating::RatingAggregate;
+
+    fn make_agg(total_stars: u64, rating_count: u32) -> RatingAggregate {
+        RatingAggregate { total_stars, rating_count }
+    }
+
+    /// Catches: `rating_count == 0` guard removed (division by zero)
+    #[test]
+    fn test_rating_average_zero_count_returns_zero() {
+        let agg = make_agg(0, 0);
+        assert_eq!(agg.average_scaled(), 0);
+    }
+
+    /// Catches: `total_stars * 100` → `total_stars / 100` or `total_stars + 100`
+    #[test]
+    fn test_rating_average_scale_factor_is_100() {
+        // 5 stars, 1 rating → average_scaled = 500 (5.00 stars)
+        let agg = make_agg(5, 1);
+        assert_eq!(agg.average_scaled(), 500);
+    }
+
+    /// Catches: `/ rating_count` → `* rating_count` (division vs multiplication)
+    #[test]
+    fn test_rating_average_is_division_not_multiplication() {
+        let agg = make_agg(30, 3);
+        assert_eq!(agg.average_scaled(), 1000); // 10.00 stars × 100 = 1000
+        assert_ne!(agg.average_scaled() as u64, 30 * 3 * 100); // would be 9000 if * used
+    }
+
+    /// Catches: off-by-one mutations across a range of values
+    #[test]
+    fn test_rating_average_exact_values() {
+        // (4+5) / 2 = 4.50 → 450
+        assert_eq!(make_agg(9, 2).average_scaled(), 450);
+        // (1+2+3+4+5) / 5 = 3.00 → 300
+        assert_eq!(make_agg(15, 5).average_scaled(), 300);
+        // single 1-star → 100
+        assert_eq!(make_agg(1, 1).average_scaled(), 100);
+        // single 5-star → 500
+        assert_eq!(make_agg(5, 1).average_scaled(), 500);
+        // all zeros → 0
+        assert_eq!(make_agg(0, 5).average_scaled(), 0);
+    }
+
+    /// Catches: `rating_count as u64` cast mutation (truncation)
+    #[test]
+    fn test_rating_average_large_count() {
+        // 1000 ratings of 3 stars each → average_scaled = 300
+        let agg = make_agg(3000, 1000);
+        assert_eq!(agg.average_scaled(), 300);
+    }
+}
+
+#[cfg(test)]
+mod refund_mutation_tests {
+    use crate::refund::RefundRecord;
+    use soroban_sdk::{Address, Env};
+
+    /// Catches: field assignment mutations in RefundRecord construction
+    #[test]
+    fn test_refund_record_fields_are_stored_correctly() {
+        let env = Env::default();
+        let member = Address::generate(&env);
+        let record = RefundRecord {
+            group_id: 42,
+            member: member.clone(),
+            cycle: 3,
+            amount: 1_000_000,
+            refunded_at: 99999,
+        };
+
+        assert_eq!(record.group_id, 42);
+        assert_eq!(record.member, member);
+        assert_eq!(record.cycle, 3);
+        assert_eq!(record.amount, 1_000_000);
+        assert_eq!(record.refunded_at, 99999);
+    }
+
+    /// Catches: `amount > 0` → `amount >= 0` (zero amount must not be treated as positive)
+    #[test]
+    fn test_refund_record_amount_is_positive() {
+        let env = Env::default();
+        let member = Address::generate(&env);
+        let record = RefundRecord {
+            group_id: 1,
+            member,
+            cycle: 0,
+            amount: 1_000_000,
+            refunded_at: 12345,
+        };
+        assert!(record.amount > 0, "refund amount must be positive");
+    }
+
+    /// Catches: group_id/cycle field swap mutations
+    #[test]
+    fn test_refund_record_group_id_and_cycle_are_distinct() {
+        let env = Env::default();
+        let member = Address::generate(&env);
+        let record = RefundRecord {
+            group_id: 10,
+            member,
+            cycle: 2,
+            amount: 500_000,
+            refunded_at: 0,
+        };
+        assert_ne!(record.group_id as u32, record.cycle,
+            "group_id and cycle must be stored in separate fields");
+    }
+}

--- a/frontend/.pa11yrc.json
+++ b/frontend/.pa11yrc.json
@@ -1,0 +1,58 @@
+{
+  "standard": "WCAG2AA",
+  "level": "error",
+  "timeout": 30000,
+  "wait": 1000,
+  "chromeLaunchConfig": {
+    "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+  },
+  "ignore": [],
+  "hideElements": "",
+  "rootElement": null,
+  "runners": ["axe", "htmlcs"],
+  "includeNotices": false,
+  "includeWarnings": true,
+  "screenCapture": "pa11y-screenshots",
+  "urls": [
+    {
+      "url": "http://localhost:4173/",
+      "screenCapture": "pa11y-screenshots/landing.png"
+    },
+    {
+      "url": "http://localhost:4173/dashboard",
+      "screenCapture": "pa11y-screenshots/dashboard.png"
+    },
+    {
+      "url": "http://localhost:4173/groups",
+      "screenCapture": "pa11y-screenshots/browse-groups.png"
+    },
+    {
+      "url": "http://localhost:4173/groups/create",
+      "screenCapture": "pa11y-screenshots/create-group.png"
+    },
+    {
+      "url": "http://localhost:4173/leaderboard",
+      "screenCapture": "pa11y-screenshots/leaderboard.png"
+    },
+    {
+      "url": "http://localhost:4173/settings",
+      "screenCapture": "pa11y-screenshots/settings.png"
+    },
+    {
+      "url": "http://localhost:4173/profile",
+      "screenCapture": "pa11y-screenshots/profile.png"
+    },
+    {
+      "url": "http://localhost:4173/transactions",
+      "screenCapture": "pa11y-screenshots/transactions.png"
+    },
+    {
+      "url": "http://localhost:4173/about",
+      "screenCapture": "pa11y-screenshots/about.png"
+    },
+    {
+      "url": "http://localhost:4173/404-test-route",
+      "screenCapture": "pa11y-screenshots/not-found.png"
+    }
+  ]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,10 @@
     "test:e2e": "vitest run src/test/integration",
     "test:e2e:testnet": "tsx src/test/e2e-testnet/testnet.e2e.ts",
     "test:mutation": "stryker run stryker.config.mjs",
-    "test:mutation:ci": "stryker run stryker.config.mjs --reporters json,clear-text --concurrency 2"
+    "test:mutation:ci": "stryker run stryker.config.mjs --reporters json,clear-text --concurrency 2",
+    "test:a11y": "vitest run src/test/a11y.test.tsx",
+    "test:a11y:pa11y": "pa11y-ci --config .pa11yrc.json",
+    "test:a11y:ci": "vitest run src/test/a11y.test.tsx --reporter=verbose"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -67,6 +70,7 @@
     "vitest": "^2.1.8",
     "vitest-axe": "^0.1.0",
     "@stryker-mutator/core": "^8.7.1",
-    "@stryker-mutator/vitest-runner": "^8.7.1"
+    "@stryker-mutator/vitest-runner": "^8.7.1",
+    "pa11y-ci": "^3.1.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,9 @@
     "test:coverage:watch": "vitest --coverage",
     "lhci": "lhci autorun --config .lighthouserc.json --upload.target temporary-public-storage",
     "test:e2e": "vitest run src/test/integration",
-    "test:e2e:testnet": "tsx src/test/e2e-testnet/testnet.e2e.ts"
+    "test:e2e:testnet": "tsx src/test/e2e-testnet/testnet.e2e.ts",
+    "test:mutation": "stryker run stryker.config.mjs",
+    "test:mutation:ci": "stryker run stryker.config.mjs --reporters json,clear-text --concurrency 2"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -63,6 +65,8 @@
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1",
     "vitest": "^2.1.8",
-    "vitest-axe": "^0.1.0"
+    "vitest-axe": "^0.1.0",
+    "@stryker-mutator/core": "^8.7.1",
+    "@stryker-mutator/vitest-runner": "^8.7.1"
   }
 }

--- a/frontend/src/test/a11y.test.tsx
+++ b/frontend/src/test/a11y.test.tsx
@@ -1,12 +1,23 @@
 /**
- * Accessibility tests for key UI components.
+ * Accessibility tests for key UI components and pages.
  *
- * Uses vitest-axe (axe-core) to assert zero WCAG violations.
+ * Uses jest-axe (axe-core) to assert zero WCAG 2.1 AA violations.
  * Also covers keyboard navigation and screen reader support.
+ *
+ * Note: Full WCAG compliance requires manual testing with assistive
+ * technologies in addition to these automated checks.
+ *
+ * Coverage:
+ *   - Input, Button, Tabs, Pagination, SearchBar, Spinner (UI primitives)
+ *   - WalletButton, CreateGroupForm, JoinGroupButton, ContributeButton (feature components)
+ *   - LandingPage, NotFoundPage, ErrorPage, SettingsPage (pages)
+ *   - Keyboard navigation across interactive components
+ *   - Screen reader attributes (roles, labels, live regions)
  */
-import { render, screen, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { MemoryRouter } from 'react-router-dom';
 import { WalletContext } from '../wallet/WalletProvider';
@@ -16,6 +27,15 @@ import { CreateGroupForm } from '../components/CreateGroupForm';
 import { JoinGroupButton } from '../components/JoinGroupButton';
 import { ContributeButton } from '../components/ContributeButton';
 import { Input } from '../components/Input';
+import { Button } from '../components/Button';
+import { Tabs } from '../components/Tabs';
+import { Pagination } from '../components/Pagination';
+import { SearchBar } from '../components/SearchBar';
+import { Spinner, FullPageLoader } from '../components/Spinner';
+import LandingPage from '../pages/LandingPage';
+import NotFoundPage from '../pages/NotFoundPage';
+import ErrorPage from '../pages/ErrorPage';
+import SettingsPage from '../pages/SettingsPage';
 
 expect.extend(toHaveNoViolations);
 
@@ -40,6 +60,10 @@ function withWallet(wallet: WalletContextValue, ui: React.ReactElement) {
       <MemoryRouter>{ui}</MemoryRouter>
     </WalletContext.Provider>
   );
+}
+
+function withRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
 }
 
 // ── 1. Input component ────────────────────────────────────────────────────────
@@ -81,6 +105,20 @@ describe('Input – accessibility', () => {
     expect(input).toHaveAttribute('aria-describedby', 'amt-error');
     expect(document.getElementById('amt-error')).toHaveTextContent('Required');
   });
+
+  it('has no axe violations when disabled', async () => {
+    const { container } = render(
+      <Input label="Amount" value="100" onChange={vi.fn()} disabled />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no axe violations with placeholder', async () => {
+    const { container } = render(
+      <Input label="Search" value="" onChange={vi.fn()} placeholder="Enter search term" />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
 });
 
 // ── 2. WalletButton ───────────────────────────────────────────────────────────
@@ -105,7 +143,6 @@ describe('WalletButton – accessibility', () => {
 
   it('connected state button has accessible text (not just visual truncation)', () => {
     withWallet(connectedWallet, <WalletButton />);
-    // The button must have some accessible text — address prefix is visible text
     const btn = screen.getByRole('button');
     expect(btn.textContent?.trim().length).toBeGreaterThan(0);
   });
@@ -202,7 +239,6 @@ describe('CreateGroupForm – accessibility', () => {
     await user.type(screen.getByLabelText(/group name/i), 'My Group');
     await user.type(screen.getByLabelText(/description/i), 'A description');
     await user.click(screen.getByRole('button', { name: /next/i }));
-    // The select must be labelled
     expect(screen.getByLabelText(/cycle duration/i)).toBeInTheDocument();
   });
 });
@@ -297,5 +333,504 @@ describe('ContributeButton – accessibility', () => {
     const cancelBtn = screen.getByRole('button', { name: /cancel/i });
     cancelBtn.focus();
     expect(document.activeElement).toBe(cancelBtn);
+  });
+
+  it('modal can be dismissed with Escape key', async () => {
+    const user = userEvent.setup();
+    render(<ContributeButton amount={10} cycleId={1} walletAddress="GABC" />);
+    await user.click(screen.getByRole('button', { name: /contribute/i }));
+    expect(screen.getByRole('heading', { name: /confirm contribution/i })).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('heading', { name: /confirm contribution/i })).not.toBeInTheDocument();
+  });
+});
+
+// ── 6. Button component ───────────────────────────────────────────────────────
+
+describe('Button – accessibility', () => {
+  it('has no axe violations (primary)', async () => {
+    const { container } = render(<Button>Save Group</Button>);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no axe violations (disabled)', async () => {
+    const { container } = render(<Button disabled>Save Group</Button>);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no axe violations (loading state)', async () => {
+    const { container } = render(<Button loading>Save Group</Button>);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('is keyboard focusable', () => {
+    render(<Button>Click me</Button>);
+    const btn = screen.getByRole('button', { name: /click me/i });
+    btn.focus();
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it('disabled button is not activatable via keyboard', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(<Button disabled onClick={onClick}>Disabled</Button>);
+    const btn = screen.getByRole('button', { name: /disabled/i });
+    btn.focus();
+    await user.keyboard('{Enter}');
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('loading spinner is aria-hidden', () => {
+    render(<Button loading>Saving</Button>);
+    const spinner = document.querySelector('.btn-spinner');
+    expect(spinner).toHaveAttribute('aria-hidden', 'true');
+  });
+});
+
+// ── 7. Tabs component ─────────────────────────────────────────────────────────
+
+describe('Tabs – accessibility', () => {
+  const sampleTabs = [
+    { id: 'overview', label: 'Overview', content: <p>Overview content</p> },
+    { id: 'history', label: 'History', content: <p>History content</p> },
+    { id: 'settings', label: 'Settings', content: <p>Settings content</p> },
+  ];
+
+  it('has no axe violations', async () => {
+    const { container } = render(<Tabs tabs={sampleTabs} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('tablist has correct role', () => {
+    render(<Tabs tabs={sampleTabs} />);
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+  });
+
+  it('each tab has role="tab" and aria-selected', () => {
+    render(<Tabs tabs={sampleTabs} />);
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs).toHaveLength(3);
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('tabpanel has role="tabpanel" and is labelled by active tab', () => {
+    render(<Tabs tabs={sampleTabs} />);
+    const panel = screen.getByRole('tabpanel');
+    expect(panel).toHaveAttribute('aria-labelledby', 'tab-overview');
+  });
+
+  it('ArrowRight moves focus to next tab', async () => {
+    const user = userEvent.setup();
+    render(<Tabs tabs={sampleTabs} />);
+    const firstTab = screen.getByRole('tab', { name: /overview/i });
+    firstTab.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(screen.getByRole('tab', { name: /history/i }));
+  });
+
+  it('ArrowLeft moves focus to previous tab', async () => {
+    const user = userEvent.setup();
+    render(<Tabs tabs={sampleTabs} defaultTab="history" />);
+    const historyTab = screen.getByRole('tab', { name: /history/i });
+    historyTab.focus();
+    await user.keyboard('{ArrowLeft}');
+    expect(document.activeElement).toBe(screen.getByRole('tab', { name: /overview/i }));
+  });
+
+  it('Home key moves focus to first tab', async () => {
+    const user = userEvent.setup();
+    render(<Tabs tabs={sampleTabs} defaultTab="settings" />);
+    const settingsTab = screen.getByRole('tab', { name: /settings/i });
+    settingsTab.focus();
+    await user.keyboard('{Home}');
+    expect(document.activeElement).toBe(screen.getByRole('tab', { name: /overview/i }));
+  });
+
+  it('End key moves focus to last tab', async () => {
+    const user = userEvent.setup();
+    render(<Tabs tabs={sampleTabs} />);
+    const firstTab = screen.getByRole('tab', { name: /overview/i });
+    firstTab.focus();
+    await user.keyboard('{End}');
+    expect(document.activeElement).toBe(screen.getByRole('tab', { name: /settings/i }));
+  });
+
+  it('disabled tab has aria-disabled', () => {
+    const tabsWithDisabled = [
+      ...sampleTabs,
+      { id: 'locked', label: 'Locked', content: <p>Locked</p>, disabled: true },
+    ];
+    render(<Tabs tabs={tabsWithDisabled} />);
+    expect(screen.getByRole('tab', { name: /locked/i })).toHaveAttribute('aria-disabled', 'true');
+  });
+});
+
+// ── 8. Pagination component ───────────────────────────────────────────────────
+
+describe('Pagination – accessibility', () => {
+  const defaultProps = {
+    currentPage: 3,
+    totalPages: 10,
+    pageSize: 10,
+    totalItems: 100,
+    onPageChange: vi.fn(),
+  };
+
+  it('has no axe violations', async () => {
+    const { container } = render(<Pagination {...defaultProps} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('previous button has aria-label', () => {
+    render(<Pagination {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /previous page/i })).toBeInTheDocument();
+  });
+
+  it('next button has aria-label', () => {
+    render(<Pagination {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /next page/i })).toBeInTheDocument();
+  });
+
+  it('current page button has aria-current="page"', () => {
+    render(<Pagination {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /page 3/i })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('page size select has an associated label', () => {
+    render(<Pagination {...defaultProps} onPageSizeChange={vi.fn()} />);
+    expect(screen.getByLabelText(/per page/i)).toBeInTheDocument();
+  });
+
+  it('previous button is disabled on first page', () => {
+    render(<Pagination {...defaultProps} currentPage={1} />);
+    expect(screen.getByRole('button', { name: /previous page/i })).toBeDisabled();
+  });
+
+  it('next button is disabled on last page', () => {
+    render(<Pagination {...defaultProps} currentPage={10} />);
+    expect(screen.getByRole('button', { name: /next page/i })).toBeDisabled();
+  });
+});
+
+// ── 9. SearchBar component ────────────────────────────────────────────────────
+
+describe('SearchBar – accessibility', () => {
+  it('has no axe violations (empty)', async () => {
+    const { container } = render(<SearchBar onSearch={vi.fn()} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no axe violations (with suggestions)', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <SearchBar onSearch={vi.fn()} suggestions={['Alpha Group', 'Beta Circle']} />
+    );
+    await user.type(screen.getByRole('searchbox'), 'al');
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('input has role="searchbox" or type="search"', () => {
+    render(<SearchBar onSearch={vi.fn()} />);
+    // type="search" gives implicit role "searchbox"
+    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+  });
+
+  it('input has aria-label', () => {
+    render(<SearchBar onSearch={vi.fn()} />);
+    expect(screen.getByLabelText(/search/i)).toBeInTheDocument();
+  });
+
+  it('clear button has aria-label', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar onSearch={vi.fn()} />);
+    await user.type(screen.getByRole('searchbox'), 'test');
+    expect(screen.getByRole('button', { name: /clear search/i })).toBeInTheDocument();
+  });
+
+  it('suggestions list has role="listbox"', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar onSearch={vi.fn()} suggestions={['Alpha Group', 'Beta Circle']} />);
+    await user.type(screen.getByRole('searchbox'), 'al');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('search icon is aria-hidden', () => {
+    render(<SearchBar onSearch={vi.fn()} />);
+    const icon = document.querySelector('.search-bar-icon');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+});
+
+// ── 10. Spinner component ─────────────────────────────────────────────────────
+
+describe('Spinner – accessibility', () => {
+  it('has no axe violations', async () => {
+    const { container } = render(<Spinner />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no axe violations with label', async () => {
+    const { container } = render(<Spinner label="Loading groups..." />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('spinner element has role="status"', () => {
+    render(<Spinner ariaLabel="Loading data" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('spinner has aria-label', () => {
+    render(<Spinner ariaLabel="Loading groups" />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Loading groups');
+  });
+
+  it('FullPageLoader has role="alert" when visible', () => {
+    render(<FullPageLoader loading={true} message="Please wait..." />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('FullPageLoader renders nothing when loading=false', () => {
+    const { container } = render(<FullPageLoader loading={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+// ── 11. LandingPage ───────────────────────────────────────────────────────────
+
+describe('LandingPage – accessibility', () => {
+  it('has no axe violations', async () => {
+    const { container } = withRouter(<LandingPage />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has a skip-to-main-content link', () => {
+    withRouter(<LandingPage />);
+    const skip = screen.getByText(/skip to main content/i);
+    expect(skip).toBeInTheDocument();
+    expect(skip.closest('a')).toHaveAttribute('href', '#main-content');
+  });
+
+  it('main content area has id="main-content"', () => {
+    withRouter(<LandingPage />);
+    expect(document.getElementById('main-content')).toBeInTheDocument();
+  });
+
+  it('header has role="banner"', () => {
+    withRouter(<LandingPage />);
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+  });
+
+  it('footer has role="contentinfo"', () => {
+    withRouter(<LandingPage />);
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+  });
+
+  it('main navigation has aria-label', () => {
+    withRouter(<LandingPage />);
+    expect(screen.getByRole('navigation', { name: /main navigation/i })).toBeInTheDocument();
+  });
+
+  it('footer navigation has aria-label', () => {
+    withRouter(<LandingPage />);
+    expect(screen.getByRole('navigation', { name: /footer navigation/i })).toBeInTheDocument();
+  });
+
+  it('hero section is labelled by heading', () => {
+    withRouter(<LandingPage />);
+    expect(screen.getByRole('heading', { name: /save together/i })).toBeInTheDocument();
+  });
+
+  it('all sections have aria-labelledby', () => {
+    withRouter(<LandingPage />);
+    // Features section
+    expect(screen.getByRole('heading', { name: /built for trust/i })).toBeInTheDocument();
+    // How it works section
+    expect(screen.getByRole('heading', { name: /simple steps/i })).toBeInTheDocument();
+  });
+
+  it('statistics list has aria-label', () => {
+    withRouter(<LandingPage />);
+    expect(screen.getByRole('list', { name: /platform statistics/i })).toBeInTheDocument();
+  });
+});
+
+// ── 12. NotFoundPage ──────────────────────────────────────────────────────────
+
+describe('NotFoundPage – accessibility', () => {
+  it('has no axe violations', async () => {
+    const { container } = withRouter(<NotFoundPage />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has a visible h1 heading', () => {
+    withRouter(<NotFoundPage />);
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
+  it('"Go Back Home" button is keyboard focusable', () => {
+    withRouter(<NotFoundPage />);
+    const btn = screen.getByRole('button', { name: /go back home/i });
+    btn.focus();
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it('"Learn About Us" button is keyboard focusable', () => {
+    withRouter(<NotFoundPage />);
+    const btn = screen.getByRole('button', { name: /learn about us/i });
+    btn.focus();
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it('illustration image has alt text', () => {
+    withRouter(<NotFoundPage />);
+    expect(screen.getByRole('img', { name: /404 illustration/i })).toBeInTheDocument();
+  });
+});
+
+// ── 13. ErrorPage ─────────────────────────────────────────────────────────────
+
+describe('ErrorPage – accessibility', () => {
+  it('has no axe violations', async () => {
+    const { container } = withRouter(<ErrorPage />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has a visible heading', () => {
+    withRouter(<ErrorPage />);
+    expect(screen.getByRole('heading')).toBeInTheDocument();
+  });
+
+  it('"Go to Home" button is keyboard focusable', () => {
+    withRouter(<ErrorPage />);
+    const btn = screen.getByRole('button', { name: /go to home/i });
+    btn.focus();
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it('"Retry" button is keyboard focusable', () => {
+    withRouter(<ErrorPage />);
+    const btn = screen.getByRole('button', { name: /retry/i });
+    btn.focus();
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it('error illustration image has alt text', () => {
+    withRouter(<ErrorPage />);
+    expect(screen.getByRole('img', { name: /error illustration/i })).toBeInTheDocument();
+  });
+});
+
+// ── 14. SettingsPage ──────────────────────────────────────────────────────────
+
+describe('SettingsPage – accessibility', () => {
+  it('has no axe violations', async () => {
+    const { container } = withRouter(<SettingsPage />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('theme radio buttons are labelled', () => {
+    withRouter(<SettingsPage />);
+    expect(screen.getByRole('radio', { name: /light/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /dark/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /system/i })).toBeInTheDocument();
+  });
+
+  it('theme radio buttons share a name attribute (radio group)', () => {
+    withRouter(<SettingsPage />);
+    const radios = screen.getAllByRole('radio');
+    const names = radios.map((r) => r.getAttribute('name'));
+    expect(new Set(names).size).toBe(1); // all same name = one group
+  });
+
+  it('radio buttons are keyboard navigable', async () => {
+    const user = userEvent.setup();
+    withRouter(<SettingsPage />);
+    const lightRadio = screen.getByRole('radio', { name: /light/i });
+    lightRadio.focus();
+    expect(document.activeElement).toBe(lightRadio);
+    await user.keyboard('{ArrowDown}');
+    // Focus should move within the radio group
+    expect(['dark', 'system', 'light']).toContain(
+      (document.activeElement as HTMLInputElement)?.value
+    );
+  });
+});
+
+// ── 15. Input – additional keyboard tests ────────────────────────────────────
+
+describe('Input – keyboard navigation', () => {
+  it('Tab moves focus into the input', async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <button>Before</button>
+        <Input label="Group Name" value="" onChange={vi.fn()} />
+        <button>After</button>
+      </div>
+    );
+    screen.getByRole('button', { name: /before/i }).focus();
+    await user.tab();
+    expect(document.activeElement).toBe(screen.getByLabelText(/group name/i));
+  });
+
+  it('Shift+Tab moves focus back out of the input', async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <button>Before</button>
+        <Input label="Group Name" value="" onChange={vi.fn()} />
+      </div>
+    );
+    screen.getByLabelText(/group name/i).focus();
+    await user.tab({ shift: true });
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: /before/i }));
+  });
+});
+
+// ── 16. WalletButton – additional keyboard tests ──────────────────────────────
+
+describe('WalletButton – keyboard navigation', () => {
+  it('Enter key opens the wallet menu when connected', async () => {
+    const user = userEvent.setup();
+    withWallet(connectedWallet, <WalletButton />);
+    const btn = screen.getByRole('button');
+    btn.focus();
+    await user.keyboard('{Enter}');
+    expect(screen.getByRole('button', { name: /disconnect/i })).toBeInTheDocument();
+  });
+
+  it('Space key opens the wallet menu when connected', async () => {
+    const user = userEvent.setup();
+    withWallet(connectedWallet, <WalletButton />);
+    const btn = screen.getByRole('button');
+    btn.focus();
+    await user.keyboard(' ');
+    expect(screen.getByRole('button', { name: /disconnect/i })).toBeInTheDocument();
+  });
+});
+
+// ── 17. CreateGroupForm – additional keyboard tests ───────────────────────────
+
+describe('CreateGroupForm – keyboard navigation', () => {
+  it('Tab order follows visual order on step 1', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await user.tab();
+    const first = document.activeElement;
+    await user.tab();
+    const second = document.activeElement;
+    // Both should be form fields, not the same element
+    expect(first).not.toBe(second);
+    expect(first?.tagName).toMatch(/INPUT|TEXTAREA/i);
+  });
+
+  it('Escape does not break form state', async () => {
+    const user = userEvent.setup();
+    render(<CreateGroupForm onSubmit={vi.fn()} />);
+    await user.type(screen.getByLabelText(/group name/i), 'Test');
+    await user.keyboard('{Escape}');
+    // Form should still be present
+    expect(screen.getByLabelText(/group name/i)).toBeInTheDocument();
   });
 });

--- a/frontend/stryker.config.mjs
+++ b/frontend/stryker.config.mjs
@@ -1,0 +1,74 @@
+// Stryker mutation testing configuration for the Stellar-Save frontend.
+// https://stryker-mutator.io/docs/stryker-js/configuration/
+
+/** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
+const config = {
+  // ─── Test runner ──────────────────────────────────────────────────────────
+  testRunner: 'vitest',
+  vitest: {
+    // Reuse the project's vitest config so globals, jsdom, and setup files
+    // are all picked up automatically.
+    configFile: 'vitest.config.ts',
+  },
+
+  // ─── Mutation scope ───────────────────────────────────────────────────────
+  // Only mutate production source files — exclude tests, generated code,
+  // assets, i18n strings, and pure type definitions.
+  mutate: [
+    'src/**/*.{ts,tsx}',
+    // Exclusions
+    '!src/**/*.test.{ts,tsx}',
+    '!src/**/*.spec.{ts,tsx}',
+    '!src/test/**',
+    '!src/main.tsx',          // entry point — no logic
+    '!src/**/*.d.ts',
+    '!src/i18n/**',           // translation strings — not logic
+    '!src/assets/**',
+    '!src/img/**',
+    '!src/svg/**',
+    '!src/types/**',          // pure type definitions
+  ],
+
+  // ─── Reporters ────────────────────────────────────────────────────────────
+  reporters: ['html', 'json', 'progress', 'clear-text'],
+  htmlReporter: {
+    fileName: 'reports/mutation/mutation.html',
+  },
+  jsonReporter: {
+    fileName: 'reports/mutation/mutation.json',
+  },
+
+  // ─── Thresholds ───────────────────────────────────────────────────────────
+  // Fail the run if the mutation score drops below these levels.
+  thresholds: {
+    high: 80,    // green  — good coverage
+    low: 60,     // yellow — acceptable but needs improvement
+    break: 50,   // red    — CI fails below this
+  },
+
+  // ─── Performance ──────────────────────────────────────────────────────────
+  // Run mutants in parallel using all available CPU cores.
+  concurrency: 4,
+
+  // Incremental mode: only re-test mutants that changed since last run.
+  // Useful for local development; disabled in CI (clean slate each run).
+  incremental: false,
+
+  // ─── Misc ─────────────────────────────────────────────────────────────────
+  // Ignore mutants that are covered by a test but still survive (i.e. the
+  // test doesn't assert the mutated behaviour).  Set to 'all' to also ignore
+  // uncovered mutants (not recommended — they indicate missing tests).
+  ignoreStatic: false,
+
+  // Timeout factor applied on top of the baseline test run time.
+  timeoutFactor: 2,
+  timeoutMS: 60000,
+
+  // Log level: 'off' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'
+  logLevel: 'info',
+
+  // Temp directory for mutant builds.
+  tempDirName: '.stryker-tmp',
+};
+
+export default config;


### PR DESCRIPTION
Closes #638

---

<html><head></head><body>

<h2>What was delivered for issue #638</h2>
<h3>1. <code>frontend/src/test/a11y.test.tsx</code> — expanded test suite</h3>
<p>The existing file (5 component suites) was upgraded to <strong>17 test suites, ~120 individual tests</strong> covering:</p>

Suite | What's tested
-- | --
Input | axe violations, label association, aria-invalid, aria-describedby, role="alert", disabled/placeholder states
Button | axe violations, keyboard focus, disabled not activatable, loading spinner aria-hidden
Tabs | axe violations, role="tablist/tab/tabpanel", aria-selected, aria-labelledby, full arrow-key/Home/End navigation, aria-disabled
Pagination | axe violations, aria-label on prev/next, aria-current="page", labelled page-size select, disabled states
SearchBar | axe violations, role="searchbox", aria-label, role="listbox" for suggestions, aria-hidden on decorative icon
Spinner | axe violations, role="status", aria-label, FullPageLoader role="alert"
WalletButton | axe violations, keyboard focus, Enter/Space to open menu
CreateGroupForm | axe violations on all 4 steps, role="progressbar" ARIA attrs, Tab order, keyboard form advance, validation role="alert"
JoinGroupButton | axe violations in all states, keyboard focus
ContributeButton | axe violations, modal heading, keyboard dismiss with Escape
LandingPage | axe violations, skip link, role="banner/contentinfo/navigation", section headings, stats list
NotFoundPage | axe violations, h1, image alt text, keyboard-focusable buttons
ErrorPage | axe violations, heading, image alt text, keyboard-focusable buttons
SettingsPage | axe violations, radio group labels, shared name attribute, keyboard navigation
Input keyboard | Tab in/out
WalletButton keyboard | Enter and Space to open
CreateGroupForm keyboard | Tab order, Escape safety


<h3>2. <code>frontend/.pa11yrc.json</code> — Pa11y CI config</h3>
<p>Scans all 10 app routes against WCAG 2.1 AA using both axe and htmlcs runners, with screenshots saved per page.</p>
<h3>3. <code>frontend/package.json</code> — new scripts + <code>pa11y-ci</code> dependency</h3>
<ul>
<li><code>test:a11y</code> — run the axe unit tests once</li>
<li><code>test:a11y:ci</code> — verbose output for CI</li>
<li><code>test:a11y:pa11y</code> — full-page Pa11y scan (requires built app running)</li>
</ul>
<h3>4. <code>.github/workflows/accessibility.yml</code> — dedicated CI workflow</h3>
<p>Three jobs on every push/PR to <code>main</code>/<code>develop</code>:</p>
<ul>
<li><strong>axe-unit</strong> — Vitest component tests</li>
<li><strong>pa11y</strong> — full-page WCAG scan with screenshots as artifacts</li>
<li><strong>lighthouse-a11y</strong> — accessibility score ≥ 90, posts score comment on PRs</li>
<li><strong>a11y-gate</strong> — blocks merge if axe-unit or pa11y fail</li>
</ul>
<h3>5. <code>ACCESSIBILITY.md</code> — documentation</h3> 
</body></html>