### PR TITLE
feat(testing): add visual regression testing with Percy + Playwright

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -39,6 +39,14 @@ jobs:
         run: npm run build
 
       - name: Run Percy visual snapshots
-        run: npm run test:visual
+        run: npm run test:visual:ci
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-test-results
+          path: frontend/test-results/
+          retention-days: 7

--- a/docs/visual-regression.md
+++ b/docs/visual-regression.md
@@ -1,0 +1,87 @@
+# Visual Regression Testing
+
+Stellar-Save uses [Percy](https://percy.io) + [Playwright](https://playwright.dev) to catch unintended UI changes before they reach production.
+
+## How it works
+
+1. Playwright navigates to key UI surfaces and calls `percySnapshot()`.
+2. Percy uploads the screenshots to its cloud service and diffs them against the approved baseline.
+3. If visual changes are detected, the Percy check on the PR is marked as **needs review**.
+4. A team member reviews the diff in the Percy dashboard and either **approves** (new baseline) or **rejects** (fix the regression).
+
+## Setup
+
+### Local development
+
+1. Get a Percy token from [percy.io](https://percy.io) (project → Settings → Token).
+2. Export it in your shell:
+   ```bash
+   export PERCY_TOKEN=<your-token>
+   ```
+3. Build the frontend and run the visual tests:
+   ```bash
+   cd frontend
+   npm run build
+   npm run test:visual
+   ```
+
+### CI (GitHub Actions)
+
+Add `PERCY_TOKEN` as a repository secret:  
+**Settings → Secrets and variables → Actions → New repository secret**
+
+The workflow (`.github/workflows/visual-regression.yml`) runs automatically on every PR targeting `main` or `develop`.
+
+## Running tests
+
+| Command | Description |
+|---|---|
+| `npm run test:visual` | Run visual snapshots locally (list reporter) |
+| `npm run test:visual:ci` | Run visual snapshots in CI (GitHub reporter) |
+
+## Adding new snapshots
+
+Edit `frontend/src/test/visual/visual.spec.ts`:
+
+```ts
+import { test } from '@playwright/test';
+import percySnapshot from '@percy/playwright';
+
+test('My new component', async ({ page }) => {
+  await page.goto('/my-route');
+  await page.waitForLoadState('networkidle');
+  await percySnapshot(page, 'My new component');
+});
+```
+
+## Approving baseline changes
+
+When intentional UI changes are made:
+
+1. Open the Percy build from the PR checks.
+2. Review each changed snapshot.
+3. Click **Approve** for expected changes.
+4. The PR check turns green and the new screenshots become the baseline.
+
+## Configuration
+
+| File | Purpose |
+|---|---|
+| `frontend/playwright.visual.config.ts` | Playwright config for visual tests (uses `vite preview` on port 4173) |
+| `frontend/src/test/visual/visual.spec.ts` | Percy snapshot test suite |
+| `.github/workflows/visual-regression.yml` | CI workflow |
+
+## Diff thresholds
+
+Percy's default diff threshold is **0%** (any pixel change triggers a review). To adjust sensitivity, configure it in the Percy dashboard under **Project → Settings → Diff sensitivity**.
+
+## Troubleshooting
+
+**Percy check is skipped in CI**  
+The workflow only runs when `PERCY_TOKEN` is set. Forks without the secret will skip the job gracefully.
+
+**Flaky snapshots due to animations**  
+The test helper `freezeAnimations()` in `visual.spec.ts` disables CSS transitions and animations. Apply it before taking snapshots on pages with motion.
+
+**`npm run test:visual` fails locally**  
+Make sure you ran `npm run build` first — the visual tests use `vite preview` (the production build), not the dev server.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,9 @@
     "test:mutation:ci": "stryker run stryker.config.mjs --reporters json,clear-text --concurrency 2",
     "test:a11y": "vitest run src/test/a11y.test.tsx",
     "test:a11y:pa11y": "pa11y-ci --config .pa11yrc.json",
-    "test:a11y:ci": "vitest run src/test/a11y.test.tsx --reporter=verbose"
+    "test:a11y:ci": "vitest run src/test/a11y.test.tsx --reporter=verbose",
+    "test:visual": "percy exec -- playwright test --config=playwright.visual.config.ts",
+    "test:visual:ci": "percy exec -- playwright test --config=playwright.visual.config.ts --reporter=github"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/frontend/playwright.visual.config.ts
+++ b/frontend/playwright.visual.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for Percy visual regression tests.
+ * Run via: npm run test:visual
+ * Requires PERCY_TOKEN env var (set in CI secrets or locally).
+ */
+export default defineConfig({
+  testDir: './src/test/visual',
+  timeout: 60_000,
+  retries: 0,
+  workers: 1, // Percy requires sequential snapshots
+  reporter: process.env['CI'] ? 'github' : 'list',
+  use: {
+    baseURL: 'http://localhost:4173', // Vite preview server
+    browserName: 'chromium',
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+    launchOptions: { args: ['--disable-web-security'] },
+    screenshot: 'only-on-failure',
+  },
+  webServer: {
+    command: 'npm run preview',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env['CI'],
+    timeout: 120_000,
+  },
+  projects: [
+    { name: 'chromium-desktop', use: { ...devices['Desktop Chrome'] } },
+    {
+      name: 'chromium-mobile',
+      use: { ...devices['Pixel 5'] },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Implements visual regression testing to catch unintended UI changes.

## Changes

- **`frontend/package.json`** — adds `test:visual` and `test:visual:ci` npm scripts
- **`frontend/playwright.visual.config.ts`** — dedicated Playwright config for visual tests (uses `vite preview` on port 4173, sequential workers for Percy)
- **`.github/workflows/visual-regression.yml`** — improved CI workflow: uses the new `test:visual:ci` script and uploads Playwright artifacts on failure
- **`docs/visual-regression.md`** — full documentation covering setup, running tests, adding snapshots, approving baselines, diff thresholds, and troubleshooting

## How it works

1. Percy + Playwright navigates to key UI surfaces (landing page, wallet button, browse groups, create group wizard, 404 page) and takes screenshots
2. Percy diffs them against the approved baseline and marks the PR check as **needs review** if changes are detected
3. A reviewer approves expected changes in the Percy dashboard, which updates the baseline

## Setup required

Add `PERCY_TOKEN` as a repository secret (Settings → Secrets → Actions) to enable the CI workflow.

## Testing

Locally:
```bash
cd frontend
npm run build
PERCY_TOKEN=<token> npm run test:visual
```

Closes #636