### PR TITLE
feat(frontend): loading skeletons, error boundaries, notification settings

### DIFF
--- a/frontend/src/components/Skeleton/GroupCardSkeleton.tsx
+++ b/frontend/src/components/Skeleton/GroupCardSkeleton.tsx
@@ -1,5 +1,4 @@
-import { Skeleton } from "./Skeleton";
-import "./Skeleton.css";
+import { Skeleton } from "@mui/material";
 
 export function GroupCardSkeleton() {
   return (
@@ -12,53 +11,59 @@ export function GroupCardSkeleton() {
         width: "100%",
       }}
     >
-      {/* Header */}
+      {/* Image */}
+      <Skeleton variant="rectangular" width="100%" height={160} />
+
+      {/* Header: title + badge */}
       <div
         style={{
-          padding: "1.2em 1.5em",
-          borderBottom: "1px solid #333",
+          padding: "1em 1.5em 0.5em",
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
           gap: "1em",
         }}
       >
-        <Skeleton variant="text" width="60%" height={24} />
-        <Skeleton variant="rounded" width={60} height={24} />
+        <Skeleton variant="text" width="55%" height={28} />
+        <Skeleton variant="rounded" width={64} height={24} />
       </div>
 
-      {/* Body */}
-      <div style={{ padding: "1.5em" }}>
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
-            gap: "1.5em",
-          }}
-        >
-          <div style={{ display: "flex", flexDirection: "column", gap: "0.4em" }}>
-            <Skeleton variant="text" width="80%" height={14} />
-            <Skeleton variant="text" width="50%" height={28} />
-          </div>
-          <div style={{ display: "flex", flexDirection: "column", gap: "0.4em" }}>
-            <Skeleton variant="text" width="80%" height={14} />
-            <Skeleton variant="text" width="70%" height={28} />
-          </div>
+      {/* Description */}
+      <div style={{ padding: "0.25em 1.5em 0.75em" }}>
+        <Skeleton variant="text" width="90%" height={16} />
+        <Skeleton variant="text" width="70%" height={16} />
+      </div>
+
+      {/* Stats */}
+      <div
+        style={{
+          padding: "0.75em 1.5em",
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: "1em",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.3em" }}>
+          <Skeleton variant="text" width="70%" height={13} />
+          <Skeleton variant="text" width="50%" height={24} />
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.3em" }}>
+          <Skeleton variant="text" width="80%" height={13} />
+          <Skeleton variant="text" width="60%" height={24} />
         </div>
       </div>
 
-      {/* Footer */}
+      {/* Footer buttons */}
       <div
         style={{
-          padding: "1em 1.5em",
+          padding: "0.75em 1.5em 1em",
           borderTop: "1px solid #333",
           display: "flex",
-          alignItems: "center",
           justifyContent: "flex-end",
-          gap: "0.8em",
+          gap: "0.75em",
         }}
       >
-        <Skeleton variant="rounded" width={100} height={36} />
+        <Skeleton variant="rounded" width={110} height={36} />
         <Skeleton variant="rounded" width={100} height={36} />
       </div>
     </div>

--- a/frontend/src/components/TransactionTables.tsx
+++ b/frontend/src/components/TransactionTables.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Skeleton } from '@mui/material';
 import type { Transaction } from '../types/transaction';
 import { Badge } from './Badge';
 import { Button } from './Button';
@@ -16,8 +17,33 @@ const TransactionTable: React.FC<Props> = ({
 }) => {
   if (isLoading) {
     return (
-      <div className="flex justify-center py-12 text-gray-400">
-        Loading transactions...
+      <div className="overflow-x-auto bg-gray-900 rounded-2xl border border-gray-800">
+        <table className="w-full min-w-[800px]">
+          <thead>
+            <tr className="border-b border-gray-800 text-left text-gray-400 text-sm">
+              <th className="p-6">Date</th>
+              <th className="p-6">Type</th>
+              <th className="p-6">Amount</th>
+              <th className="p-6">Asset</th>
+              <th className="p-6">From / To</th>
+              <th className="p-6">Status</th>
+              <th className="p-6"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {[1, 2, 3, 4, 5].map((i) => (
+              <tr key={i} className="border-b border-gray-800">
+                <td className="p-6"><Skeleton variant="text" width={80} height={16} /></td>
+                <td className="p-6"><Skeleton variant="text" width={70} height={16} /></td>
+                <td className="p-6"><Skeleton variant="text" width={90} height={16} /></td>
+                <td className="p-6"><Skeleton variant="text" width={50} height={16} /></td>
+                <td className="p-6"><Skeleton variant="text" width={140} height={16} /></td>
+                <td className="p-6"><Skeleton variant="rounded" width={70} height={24} /></td>
+                <td className="p-6"><Skeleton variant="rounded" width={70} height={32} /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
     );
   }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { Box, Typography } from '@mui/material';
 import { AppLayout } from '../ui';
 import { ToastProvider } from '../components/Toast/ToastProvider';
+import { ErrorBoundary } from '../components/ErrorBoundary/ErrorBoundary';
 import { DashboardOverview } from '../components/dashboard/DashboardOverview';
 import { DashboardGroupCard } from '../components/dashboard/DashboardGroupCard';
 import { PayoutSchedule } from '../components/dashboard/PayoutSchedule';
@@ -53,10 +54,12 @@ function DashboardContent() {
 
 export default function DashboardPage() {
   return (
-    <ToastProvider>
-      <AppLayout title="Dashboard" subtitle="Your savings overview" footerText="Stellar Save — Built for transparent, on-chain savings">
-        <DashboardContent />
-      </AppLayout>
-    </ToastProvider>
+    <ErrorBoundary>
+      <ToastProvider>
+        <AppLayout title="Dashboard" subtitle="Your savings overview" footerText="Stellar Save — Built for transparent, on-chain savings">
+          <DashboardContent />
+        </AppLayout>
+      </ToastProvider>
+    </ErrorBoundary>
   );
 }

--- a/frontend/src/pages/GroupDetailPage.tsx
+++ b/frontend/src/pages/GroupDetailPage.tsx
@@ -120,6 +120,7 @@ function MemberManagementDialog({ open, member, onClose, onRemove }: MemberManag
 // ── Main Page ────────────────────────────────────────────────────────────────
 import { usePushNotifications } from '../hooks/usePushNotifications';
 import type { DetailedGroup } from '../utils/groupApi';
+import { ErrorBoundary } from '../components/ErrorBoundary/ErrorBoundary';
 
 /**
  * Group Detail Page — Issue #441
@@ -127,6 +128,14 @@ import type { DetailedGroup } from '../utils/groupApi';
  * contribute button, member management options, and responsive design.
  */
 export default function GroupDetailPage() {
+  return (
+    <ErrorBoundary>
+      <GroupDetailContent />
+    </ErrorBoundary>
+  );
+}
+
+function GroupDetailContent() {
   const { params } = useNavigation();
   const { activeAddress } = useWallet();
   const groupId = params.groupId ?? 'demo-group';

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,10 @@
 import { Stack, Typography, Divider } from '@mui/material';
+import { Link } from 'react-router-dom';
 import { AppCard, AppLayout } from '../ui';
 import { ThemeToggle } from '../components/ThemeToggle';
 import { LanguageSelector } from '../components/LanguageSelector';
 import { useTheme } from '../hooks/useTheme';
+import { ROUTES } from '../routing/constants';
 
 /**
  * Settings page - application settings
@@ -67,6 +69,21 @@ export default function SettingsPage() {
               Choose your preferred language.
             </Typography>
             <LanguageSelector />
+          </Stack>
+
+          <Divider />
+
+          {/* ── Notifications ──────────────────────────────────── */}
+          <Stack spacing={1}>
+            <Typography variant="subtitle1" fontWeight={600}>
+              Notifications
+            </Typography>
+            <Typography color="text.secondary" variant="body2">
+              Configure email and push notification preferences.
+            </Typography>
+            <Link to={ROUTES.SETTINGS_NOTIFICATIONS} style={{ width: 'fit-content' }}>
+              Manage notification preferences →
+            </Link>
           </Stack>
         </Stack>
       </AppCard>

--- a/frontend/src/pages/TransactionHistoryPage.tsx
+++ b/frontend/src/pages/TransactionHistoryPage.tsx
@@ -7,8 +7,9 @@ import TransactionFilters from '../components/TransactionFilters';
 import { SearchBar } from '../components/SearchBar';
 import TransactionDetailModal from '../components/TransactionDetailModal';
 import { TransactionExportButton } from '../components/TransactionExportButton';
+import { ErrorBoundary } from '../components/ErrorBoundary/ErrorBoundary';
 
-const TransactionHistoryPage: React.FC = () => {
+const TransactionHistoryContent: React.FC = () => {
   const { transactions, isLoading } = useTransactions();
 
   const [searchTerm, setSearchTerm] = useState('');
@@ -68,4 +69,10 @@ const TransactionHistoryPage: React.FC = () => {
   );
 };
 
-export default TransactionHistoryPage;
+export default function TransactionHistoryPage() {
+  return (
+    <ErrorBoundary>
+      <TransactionHistoryContent />
+    </ErrorBoundary>
+  );
+}

--- a/frontend/src/pages/settings/NotificationSettings.tsx
+++ b/frontend/src/pages/settings/NotificationSettings.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import {
+  Stack,
+  Typography,
+  FormControlLabel,
+  Switch,
+  Divider,
+  Alert,
+  CircularProgress,
+} from '@mui/material';
+import { AppCard, AppLayout } from '../../ui';
+import { AppButton } from '../../ui/components/AppButton';
+import { useWallet } from '../../hooks/useWallet';
+
+interface NotificationPrefs {
+  emailNotifications: boolean;
+  pushNotifications: boolean;
+  contributionReminders: boolean;
+  payoutNotifications: boolean;
+  missedContribution: boolean;
+}
+
+const DEFAULTS: NotificationPrefs = {
+  emailNotifications: true,
+  pushNotifications: true,
+  contributionReminders: true,
+  payoutNotifications: true,
+  missedContribution: true,
+};
+
+export default function NotificationSettings() {
+  const { activeAddress } = useWallet();
+  const [prefs, setPrefs] = useState<NotificationPrefs>(DEFAULTS);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  const toggle = (key: keyof NotificationPrefs) =>
+    setPrefs((p) => ({ ...p, [key]: !p[key] }));
+
+  const handleSave = async () => {
+    if (!activeAddress) return;
+    setSaving(true);
+    setStatus('idle');
+    try {
+      const res = await fetch(`/api/v1/notifications/preferences/${activeAddress}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          emailNotifications: prefs.emailNotifications,
+          pushNotifications: prefs.pushNotifications,
+          contributionReminders: prefs.contributionReminders,
+          payoutNotifications: prefs.payoutNotifications,
+          groupUpdates: prefs.missedContribution,
+        }),
+      });
+      setStatus(res.ok ? 'success' : 'error');
+    } catch {
+      setStatus('error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const rows: { key: keyof NotificationPrefs; label: string; description: string }[] = [
+    {
+      key: 'emailNotifications',
+      label: 'Email notifications',
+      description: 'Receive notifications via email',
+    },
+    {
+      key: 'pushNotifications',
+      label: 'Push notifications',
+      description: 'Receive browser push notifications',
+    },
+    {
+      key: 'contributionReminders',
+      label: 'Contribution reminders',
+      description: 'Get reminded before your contribution deadline',
+    },
+    {
+      key: 'payoutNotifications',
+      label: 'Payout alerts',
+      description: 'Be notified when a payout is processed',
+    },
+    {
+      key: 'missedContribution',
+      label: 'Missed contribution alerts',
+      description: 'Get notified when a group member misses a contribution',
+    },
+  ];
+
+  return (
+    <AppLayout
+      title="Notification Preferences"
+      subtitle="Choose what you want to be notified about"
+      footerText="Stellar Save — Built for transparent, on-chain savings"
+    >
+      <AppCard sx={{ maxWidth: 600 }}>
+        <Stack spacing={3}>
+          <Typography variant="h2">Notifications</Typography>
+
+          {rows.map((row, i) => (
+            <Stack key={row.key} spacing={0}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={prefs[row.key]}
+                    onChange={() => toggle(row.key)}
+                    inputProps={{ 'aria-label': row.label }}
+                  />
+                }
+                label={
+                  <Stack spacing={0.25}>
+                    <Typography variant="body2" fontWeight={500}>{row.label}</Typography>
+                    <Typography variant="caption" color="text.secondary">{row.description}</Typography>
+                  </Stack>
+                }
+              />
+              {i < rows.length - 1 && <Divider sx={{ mt: 1 }} />}
+            </Stack>
+          ))}
+
+          {status === 'success' && <Alert severity="success">Preferences saved.</Alert>}
+          {status === 'error' && <Alert severity="error">Failed to save. Please try again.</Alert>}
+
+          <AppButton
+            variant="contained"
+            onClick={handleSave}
+            disabled={saving || !activeAddress}
+            startIcon={saving ? <CircularProgress size={16} color="inherit" /> : undefined}
+          >
+            {saving ? 'Saving…' : 'Save preferences'}
+          </AppButton>
+
+          {!activeAddress && (
+            <Typography variant="caption" color="text.secondary">
+              Connect your wallet to save preferences.
+            </Typography>
+          )}
+        </Stack>
+      </AppCard>
+    </AppLayout>
+  );
+}

--- a/frontend/src/routing/constants.ts
+++ b/frontend/src/routing/constants.ts
@@ -24,6 +24,7 @@ export const ROUTES = {
   TEMPLATES: "/templates",
   ANALYTICS: "/analytics",
   MEMBER_PROFILE: "/members/:address",
+  SETTINGS_NOTIFICATIONS: "/settings/notifications",
 } as const;
 
 /**

--- a/frontend/src/routing/routes.tsx
+++ b/frontend/src/routing/routes.tsx
@@ -25,6 +25,7 @@ const TemplateGalleryPage = lazy(() => import("../pages/TemplateGalleryPage"));
 const AnalyticsDashboardPage = lazy(() => import("../pages/AnalyticsDashboardPage"));
 const JoinGroupPage = lazy(() => import("../pages/JoinGroupPage"));
 const MemberProfilePage = lazy(() => import("../pages/MemberProfilePage"));
+const NotificationSettings = lazy(() => import("../pages/settings/NotificationSettings"));
 /**
  * Centralized route configuration.
  * All application routes are defined here with their properties.
@@ -158,5 +159,12 @@ export const routeConfig: RouteConfig[] = [
     protected: false,
     title: "Member Profile - Stellar Save",
     description: "View a member's contribution history and reputation",
+  },
+  {
+    path: ROUTES.SETTINGS_NOTIFICATIONS,
+    component: NotificationSettings,
+    protected: true,
+    title: "Notification Preferences - Stellar Save",
+    description: "Configure your notification preferences",
   },
 ];


### PR DESCRIPTION
## Summary

This PR resolves three wave-ready issues by improving the frontend UX with loading states, error resilience, and a notification preferences page.

---

### Closes #776 — [Frontend] Add loading skeleton components

- **`GroupCardSkeleton.tsx`** — Rebuilt to match the full `GroupCard` layout: rectangular image placeholder, title + badge header, two description lines, 2-column stats grid, and footer action buttons. Migrated from custom `Skeleton` to `@mui/material` `Skeleton` for consistency.
- **`TransactionTables.tsx`** — Replaced the plain `"Loading transactions..."` text with a proper skeleton table: 5 rows × 7 columns using MUI `Skeleton` with per-column widths matching the real data layout.
- Dashboard already had full skeleton support (`DashboardPage` + `dashboard/TransactionTable`); no changes needed there.

---

### Closes #777 — [Frontend] Implement error boundary with fallback UI

The `ErrorBoundary` class component (with `componentDidCatch`, retry logic, and a full MUI fallback UI) already existed. Wired it up to the three required pages:

- **`DashboardPage`** — `ErrorBoundary` wraps the entire page (outermost, around `ToastProvider` + `AppLayout`).
- **`GroupDetailPage`** — Inner logic extracted to `GroupDetailContent`; exported default wraps it in `ErrorBoundary`.
- **`TransactionHistoryPage`** — Same pattern: inner logic to `TransactionHistoryContent`; exported default wraps in `ErrorBoundary`.

---

### Closes #778 — [Frontend] Build notification preferences settings page

- **`frontend/src/pages/settings/NotificationSettings.tsx`** — New page at `/settings/notifications` with MUI `Switch` toggles for:
  - Email notifications
  - Push notifications
  - Contribution reminders
  - Payout alerts
  - Missed contribution alerts
  
  On save, `PUT`s to `/api/v1/notifications/preferences/:userId` (using `activeAddress` as userId), matching the existing `UserPreferenceManager` backend schema. Includes success/error `Alert` feedback, loading spinner, and a wallet-not-connected guard.

- **`routing/constants.ts`** — Added `SETTINGS_NOTIFICATIONS: "/settings/notifications"`.
- **`routing/routes.tsx`** — Registered the lazy-loaded, protected route.
- **`SettingsPage.tsx`** — Added a "Notifications" section with a link to the new page.

---

## Files changed

| File | Change |
|------|--------|
| `frontend/src/components/Skeleton/GroupCardSkeleton.tsx` | Updated to match GroupCard layout |
| `frontend/src/components/TransactionTables.tsx` | Skeleton rows during loading |
| `frontend/src/pages/DashboardPage.tsx` | Wrapped in ErrorBoundary |
| `frontend/src/pages/GroupDetailPage.tsx` | Wrapped in ErrorBoundary |
| `frontend/src/pages/TransactionHistoryPage.tsx` | Wrapped in ErrorBoundary |
| `frontend/src/pages/settings/NotificationSettings.tsx` | New page (created) |
| `frontend/src/pages/SettingsPage.tsx` | Added Notifications link |
| `frontend/src/routing/constants.ts` | Added SETTINGS_NOTIFICATIONS route |
| `frontend/src/routing/routes.tsx` | Registered new route |