### PR TITLE
feat: add PayoutOrder enum (Sequential, Random, Bid) to payout rotation

### DIFF
--- a/contracts/stellar-save/src/group.rs
+++ b/contracts/stellar-save/src/group.rs
@@ -253,6 +253,10 @@ pub struct Group {
     /// `list_groups()` results and are only visible via `list_archived_groups()`.
     /// This reduces active storage scan costs and improves query performance.
     pub archived: bool,
+
+    /// How the payout recipient is selected each cycle.
+    /// Defaults to Sequential (join-order rotation).
+    pub payout_order: crate::payout::PayoutOrder,
 }
 impl Group {
     /// Creates a new Group with validation.
@@ -366,6 +370,7 @@ impl Group {
             description: None,
             image_url: None,
             archived: false,
+            payout_order: crate::payout::PayoutOrder::Sequential,
         }
     }
     /// Checks if the group has completed all cycles.

--- a/contracts/stellar-save/src/lib.rs
+++ b/contracts/stellar-save/src/lib.rs
@@ -437,6 +437,7 @@ impl StellarSaveContract {
         max_members: u32,
         token_address: Address,
         grace_period_seconds: u64,
+        payout_order: crate::payout::PayoutOrder,
     ) -> Result<u64, StellarSaveError> {
         // 1. Authorization: Only the creator can initiate this transaction
         creator.require_auth();
@@ -493,7 +494,7 @@ impl StellarSaveContract {
         // 7. Initialize Group Struct (using rounded amount)
         let current_time = env.ledger().timestamp();
         let min_members = 2; // Default minimum members
-        let new_group = Group::new(
+        let mut new_group = Group::new(
             group_id,
             creator.clone(),
             rounded_amount,
@@ -503,6 +504,7 @@ impl StellarSaveContract {
             current_time,
             0, // grace_period_seconds - using default of 0
         );
+        new_group.payout_order = payout_order;
 
         // 8. Store Group Data
         let group_key = StorageKeyBuilder::group_data(group_id);
@@ -1730,9 +1732,60 @@ impl StellarSaveContract {
         payout_executor::execute_payout(env, group_id)
     }
 
-    // ============================================================================
-    // ISSUE #425: Group Status Management
-    // ============================================================================
+    /// Submits a bid for the current payout cycle in a `Bid`-order group.
+    ///
+    /// The member with the highest bid at payout time wins the cycle payout.
+    /// The bid amount is stored on-chain and replaces any previous bid by the
+    /// same member for the same cycle.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `group_id` - ID of the group
+    /// * `bidder` - Address of the bidding member
+    /// * `bid_amount` - Bid in stroops (must be ≥ 0)
+    ///
+    /// # Returns
+    /// * `Ok(())` - Bid recorded successfully
+    /// * `Err(StellarSaveError::InvalidState)` - Group is not using Bid payout order
+    /// * `Err(StellarSaveError::NotMember)` - Bidder is not a member
+    /// * `Err(StellarSaveError::InvalidAmount)` - Bid amount is negative
+    pub fn bid_for_payout(
+        env: Env,
+        group_id: u64,
+        bidder: Address,
+        bid_amount: i128,
+    ) -> Result<(), StellarSaveError> {
+        bidder.require_auth();
+
+        if bid_amount < 0 {
+            return Err(StellarSaveError::InvalidAmount);
+        }
+
+        let group_key = StorageKeyBuilder::group_data(group_id);
+        let group: Group = env
+            .storage()
+            .persistent()
+            .get(&group_key)
+            .ok_or(StellarSaveError::GroupNotFound)?;
+
+        if group.payout_order != crate::payout::PayoutOrder::Bid {
+            return Err(StellarSaveError::InvalidState);
+        }
+
+        if group.status != GroupStatus::Active {
+            return Err(StellarSaveError::InvalidState);
+        }
+
+        let member_key = StorageKeyBuilder::member_profile(group_id, bidder.clone());
+        if !env.storage().persistent().has(&member_key) {
+            return Err(StellarSaveError::NotMember);
+        }
+
+        let bid_key = StorageKeyBuilder::group_bid_amount(group_id, group.current_cycle, bidder);
+        env.storage().persistent().set(&bid_key, &bid_amount);
+
+        Ok(())
+    }
 
     /// Pauses a group, preventing contributions and payouts.
     ///

--- a/contracts/stellar-save/src/payout.rs
+++ b/contracts/stellar-save/src/payout.rs
@@ -1,5 +1,18 @@
 use soroban_sdk::{contracttype, Address};
 
+/// Determines how the payout recipient is selected each cycle.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PayoutOrder {
+    /// Members receive payouts in the fixed order assigned at group start (default).
+    Sequential,
+    /// Recipient is chosen randomly each cycle using ledger entropy.
+    Random,
+    /// Each cycle, the member who submits the highest bid wins the payout.
+    /// Bids are denominated in stroops and must be ≥ 0.
+    Bid,
+}
+
 /// Payout Record structure for tracking payout events in rotational savings groups.
 ///
 /// Each payout represents a distribution of pooled funds to a member during their

--- a/contracts/stellar-save/src/payout_executor.rs
+++ b/contracts/stellar-save/src/payout_executor.rs
@@ -20,7 +20,7 @@
 use crate::error::StellarSaveError;
 use crate::events::EventEmitter;
 use crate::group::{Group, GroupStatus};
-use crate::payout::PayoutRecord;
+use crate::payout::{PayoutOrder, PayoutRecord};
 use crate::pool::PoolCalculator;
 use crate::storage::StorageKeyBuilder;
 use crate::MemberProfile;
@@ -86,6 +86,24 @@ fn identify_recipient(
     group_id: u64,
     current_cycle: u32,
     member_count: u32,
+    payout_order: &PayoutOrder,
+) -> Result<Address, StellarSaveError> {
+    match payout_order {
+        PayoutOrder::Random => identify_recipient_random(env, group_id, current_cycle),
+        PayoutOrder::Bid => identify_recipient_bid(env, group_id, current_cycle),
+        PayoutOrder::Sequential => {
+            identify_recipient_sequential(env, group_id, current_cycle, member_count)
+        }
+    }
+}
+
+/// Selects the recipient for `Sequential` order: the member whose payout_position
+/// equals `current_cycle` (O(1) via reverse index, O(n) fallback for legacy groups).
+fn identify_recipient_sequential(
+    env: &Env,
+    group_id: u64,
+    current_cycle: u32,
+    member_count: u32,
 ) -> Result<Address, StellarSaveError> {
     // Gas opt: O(1) reverse-index lookup instead of O(n) member-list scan.
     // The index is written at join_group / assign_payout_positions time.
@@ -130,6 +148,87 @@ fn identify_recipient(
         1 => Ok(recipient.unwrap()),
         _ => Err(StellarSaveError::InvalidState),
     }
+}
+
+/// Selects the recipient for `Random` order: picks a random member who has not
+/// yet received a payout, using ledger sequence as entropy.
+fn identify_recipient_random(
+    env: &Env,
+    group_id: u64,
+    current_cycle: u32,
+) -> Result<Address, StellarSaveError> {
+    let members_key = StorageKeyBuilder::group_members(group_id);
+    let members: soroban_sdk::Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&members_key)
+        .ok_or(StellarSaveError::GroupNotFound)?;
+
+    // Collect members who have not yet received a payout.
+    let mut eligible: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(env);
+    for member in members.iter() {
+        // A member is eligible if they have no payout record for any prior cycle.
+        // We check the member_payout_eligibility flag: if it equals current_cycle
+        // the member has already been paid this cycle; otherwise they are eligible.
+        let paid_key = StorageKeyBuilder::member_payout_eligibility(group_id, member.clone());
+        let paid_cycle: Option<u32> = env.storage().persistent().get(&paid_key);
+        // paid_cycle stores the cycle at which the member received their payout.
+        // If it is None or points to a future cycle, the member hasn't been paid yet.
+        let already_paid = paid_cycle.map(|c| c < current_cycle).unwrap_or(false);
+        if !already_paid {
+            eligible.push_back(member);
+        }
+    }
+
+    if eligible.is_empty() {
+        return Err(StellarSaveError::InvalidState);
+    }
+
+    // Use Soroban PRNG + ledger timestamp as entropy source.
+    let prng_val = env.prng().u64_in_range(0..u64::MAX);
+    let ledger_salt = env.ledger().timestamp();
+    let idx = ((prng_val.wrapping_add(ledger_salt).wrapping_add(group_id as u64))
+        % eligible.len() as u64) as u32;
+
+    Ok(eligible.get(idx).unwrap())
+}
+
+/// Selects the recipient for `Bid` order: the member with the highest bid for
+/// `current_cycle`. Ties are broken by member list order (first highest bidder wins).
+fn identify_recipient_bid(
+    env: &Env,
+    group_id: u64,
+    current_cycle: u32,
+) -> Result<Address, StellarSaveError> {
+    let members_key = StorageKeyBuilder::group_members(group_id);
+    let members: soroban_sdk::Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&members_key)
+        .ok_or(StellarSaveError::GroupNotFound)?;
+
+    let mut best_bidder: Option<Address> = None;
+    let mut best_bid: i128 = -1;
+
+    for member in members.iter() {
+        // Skip members who have already received a payout in a prior cycle.
+        let paid_key = StorageKeyBuilder::member_payout_eligibility(group_id, member.clone());
+        let paid_cycle: Option<u32> = env.storage().persistent().get(&paid_key);
+        let already_paid = paid_cycle.map(|c| c < current_cycle).unwrap_or(false);
+        if already_paid {
+            continue;
+        }
+
+        let bid_key =
+            StorageKeyBuilder::group_bid_amount(group_id, current_cycle, member.clone());
+        let bid: i128 = env.storage().persistent().get(&bid_key).unwrap_or(0);
+        if bid > best_bid {
+            best_bid = bid;
+            best_bidder = Some(member);
+        }
+    }
+
+    best_bidder.ok_or(StellarSaveError::InvalidState)
 }
 
 /// Verifies that the identified recipient is eligible to receive the payout.
@@ -698,7 +797,7 @@ pub fn execute_payout(env: Env, group_id: u64) -> Result<(), StellarSaveError> {
     }
 
     // Step 5: Identify the recipient for this cycle based on payout position
-    let recipient = identify_recipient(&env, group_id, current_cycle, group.member_count)?;
+    let recipient = identify_recipient(&env, group_id, current_cycle, group.member_count, &group.payout_order)?;
 
     // Step 6: Verify the recipient is eligible to receive the payout
     verify_recipient_eligibility(&env, group_id, &recipient, current_cycle)?;

--- a/contracts/stellar-save/src/storage.rs
+++ b/contracts/stellar-save/src/storage.rs
@@ -107,6 +107,10 @@ pub enum GroupKey {
     /// Rating aggregate: GROUP_RATING_AGG_{id}
     /// Stores the running RatingAggregate (total_stars + rating_count) for a group.
     RatingAggregate(u64),
+
+    /// Bid amount for a member in a cycle: GROUP_BID_{id}_{cycle}_{member}
+    /// Stores the i128 bid submitted by a member for a specific payout cycle.
+    BidAmount(u64, u32, Address),
 }
 
 /// Storage keys for member-related data.
@@ -324,6 +328,14 @@ impl StorageKeyBuilder {
     /// Archived groups are hidden from `list_groups()` by default.
     pub fn group_archived(group_id: u64) -> StorageKey {
         StorageKey::Group(GroupKey::Archived(group_id))
+    }
+
+    /// Creates a key for a member's bid amount in a specific cycle.
+    ///
+    /// Used by the `Bid` payout order: stores the i128 bid submitted by
+    /// `member` for `cycle` in `group_id`.
+    pub fn group_bid_amount(group_id: u64, cycle: u32, member: Address) -> StorageKey {
+        StorageKey::Group(GroupKey::BidAmount(group_id, cycle, member))
     }
 
     /// Creates a key for a member's individual rating of a group.


### PR DESCRIPTION
- Add PayoutOrder enum to payout.rs with Sequential, Random, and Bid variants
- Add payout_order field to Group struct, defaulting to Sequential
- Update create_group to accept payout_order parameter
- Add bid_for_payout contract function for Bid-order groups
- Add BidAmount storage key to GroupKey and StorageKeyBuilder helper
- Refactor identify_recipient in payout_executor to dispatch on payout_order:
  - Sequential: existing O(1) reverse-index / O(n) fallback logic
  - Random: picks unpaid member using env.prng() + ledger timestamp entropy
  - Bid: selects highest bidder among unpaid members for the current cycle

## Summary

<!-- What does this PR do? One or two sentences. -->

## Motivation

<!-- Why is this change needed? Link to the issue it resolves. -->

Closes #

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — code restructuring, no behaviour change
- [ ] `test` — tests only
- [ ] `chore` — build, deps, tooling
- [ ] `perf` — performance improvement
- [ ] Breaking change (existing behaviour changes)

## Changes

<!-- List the key changes made. Be specific enough that a reviewer knows where to look. -->

-
-

## Testing

<!-- Describe how you tested this. Include commands a reviewer can run to verify. -->

**Smart contract:**
```bash
cargo test -p stellar-save
```

**Frontend:**
```bash
cd frontend && npm test run
```

**Manual steps (if applicable):**

1.
2.

## Checklist

- [ ] `cargo fmt` run (Rust changes)
- [ ] `cargo clippy -- -D warnings` passes (Rust changes)
- [ ] `npm run lint` passes (frontend changes)
- [ ] Tests added or updated for new/changed behaviour
- [ ] CI is green
- [ ] Documentation updated (if behaviour changed)
- [ ] No secrets or `.env` files staged

## Screenshots / recordings

<!-- For UI changes, include before/after screenshots or a short screen recording. Delete this section if not applicable. -->
closes #748 