### PR TITLE
feat: Implement real-time event polling for group state

### DIFF
--- a/frontend/src/hooks/useGroupEvents.ts
+++ b/frontend/src/hooks/useGroupEvents.ts
@@ -1,0 +1,60 @@
+import { useEffect } from 'react';
+import { useEventService } from './useEventService';
+import { useEventTrigger } from './useEventTrigger';
+import { AppEvent, ContributionMadeEvent, PayoutExecutedEvent, GroupPausedEvent } from '../types/events';
+import { useToast } from '../components/Toast';
+
+/**
+ * Custom hook to subscribe to Soroban contract events and trigger
+ * cache invalidation for group-related data, and show toast notifications.
+ *
+ * It uses the global EventService for event subscription and the EventTriggerContext
+ * to notify other hooks to refresh their data.
+ */
+export function useGroupEvents() {
+  const { on } = useEventService();
+  const { triggerRefresh } = useEventTrigger();
+  const { showToast } = useToast(); // Assuming useToast hook from ToastProvider
+
+  useEffect(() => {
+    // Subscribe to ContributionMade events
+    const unsubscribeContribution = on('ContributionMade', (event: AppEvent) => {
+      const contributionEvent = event as ContributionMadeEvent;
+      const groupId = String(contributionEvent.groupId); // Convert bigint to string
+      triggerRefresh(groupId);
+      showToast({
+        message: `New contribution made in group ${groupId} by ${contributionEvent.contributor}!`,
+        type: 'success',
+      });
+    });
+
+    // Subscribe to PayoutExecuted events
+    const unsubscribePayout = on('PayoutExecuted', (event: AppEvent) => {
+      const payoutEvent = event as PayoutExecutedEvent;
+      const groupId = String(payoutEvent.groupId); // Convert bigint to string
+      triggerRefresh(groupId);
+      showToast({
+        message: `Payout executed for group ${groupId} to ${payoutEvent.recipient}!`,
+        type: 'info',
+      });
+    });
+
+    // Subscribe to GroupPaused events
+    const unsubscribeGroupPaused = on('GroupPaused', (event: AppEvent) => {
+      const groupPausedEvent = event as GroupPausedEvent;
+      const groupId = String(groupPausedEvent.groupId); // Convert bigint to string
+      triggerRefresh(groupId);
+      showToast({
+        message: `Group ${groupId} has been paused!`,
+        type: 'warning',
+      });
+    });
+
+    // Cleanup subscriptions on unmount
+    return () => {
+      unsubscribeContribution();
+      unsubscribePayout();
+      unsubscribeGroupPaused();
+    };
+  }, [on, triggerRefresh, showToast]);
+}

--- a/frontend/src/lib/EventService.ts
+++ b/frontend/src/lib/EventService.ts
@@ -19,6 +19,7 @@ import type {
   GroupCreatedEvent,
   ContributionMadeEvent,
   PayoutExecutedEvent,
+  GroupPausedEvent, // Import GroupPausedEvent
 } from '../types/events';
 
 export const PAGE_SIZE = 20;
@@ -89,6 +90,14 @@ function parseRawEvent(raw: SorobanRpc.Api.RawEventResponse): AppEvent | null {
           amount: BigInt(String(data['amount'] ?? 0)),
           cycle: Number(data['cycle'] ?? 0),
           executedAt: BigInt(String(data['executed_at'] ?? 0)),
+        };
+        return e;
+      }
+      case 'GroupPaused': {
+        const e: GroupPausedEvent = {
+          type: 'GroupPaused',
+          groupId: BigInt(String(data['group_id'] ?? 0)),
+          pausedAt: BigInt(String(data['paused_at'] ?? 0)),
         };
         return e;
       }

--- a/frontend/src/types/events.ts
+++ b/frontend/src/types/events.ts
@@ -38,11 +38,18 @@ export interface PayoutExecutedEvent {
   executedAt: bigint;
 }
 
+export interface GroupPausedEvent {
+  type: 'GroupPaused';
+  groupId: bigint;
+  pausedAt: bigint;
+}
+
 export type AppEvent =
   | GroupCreatedEvent
   | MemberJoinedEvent
   | ContributionMadeEvent
-  | PayoutExecutedEvent;
+  | PayoutExecutedEvent
+  | GroupPausedEvent;
 
 export type EventType = AppEvent['type'];
 


### PR DESCRIPTION
This commit introduces real-time event polling for Soroban contract events to update the group state without requiring manual page refreshes.

- Added GroupPausedEvent definition in frontend/src/types/events.ts.
- Updated frontend/src/lib/EventService.ts to parse GroupPaused events.
- Modified/Created frontend/src/hooks/useGroupEvents.ts to subscribe to GroupPaused events, invalidate the React Query cache, and display toast notifications for ContributionMade, PayoutExecuted, and GroupPaused events.

This implementation leverages the existing event polling mechanism within EventService to provide a more dynamic user experience.

closes #780 