### PR TITLE
docs: resolve issues #864, #865, #866 — OpenAPI spec, runbook, contra…

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1,0 +1,2443 @@
+openapi: 3.0.3
+info:
+  title: Stellar-Save Backend API
+  description: |
+    REST API for the Stellar-Save decentralised rotational savings platform.
+
+    ## Authentication
+    Most endpoints are public. Endpoints under `/api/user/*` require a Bearer JWT
+    obtained from `POST /api/auth/verify`. Pass it as:
+    ```
+    Authorization: Bearer <token>
+    ```
+
+    ## Versioning
+    The API is versioned via URL path prefix:
+    - `/api/v1/` — stable, production-ready
+    - `/api/v2/` — current development version (some routes return 501)
+
+    Unversioned legacy paths (`/health`, `/recommendations`, etc.) are deprecated
+    and will be removed on 2027-01-01.
+
+    ## Rate Limiting
+    - General endpoints: 100 req / 15 min per IP
+    - Auth & admin endpoints: 10 req / 15 min per IP
+    - Analytics write endpoints: stricter limits apply (see individual routes)
+  version: 1.0.0
+  contact:
+    name: Stellar-Save
+    url: https://github.com/Xoulomon/Stellar-Save
+
+servers:
+  - url: http://localhost:3001
+    description: Local development
+  - url: https://api.stellar-save.app
+    description: Production
+
+tags:
+  - name: Auth
+    description: Stellar wallet-based authentication
+  - name: User
+    description: Authenticated user profile and preferences
+  - name: Health
+    description: Liveness and readiness probes
+  - name: Recommendations
+    description: Group recommendation engine
+  - name: Search
+    description: Full-text and autocomplete search
+  - name: Analytics
+    description: Platform, user, and group analytics
+  - name: Events
+    description: Contract event index queries
+  - name: Export
+    description: Data export jobs (CSV / JSON)
+  - name: Backup
+    description: Database backup management
+  - name: Notifications
+    description: Email, push, and web-push notification management
+  - name: Webhooks
+    description: Outbound webhook registration and management
+  - name: Cache
+    description: Cache statistics and management
+  - name: Stats
+    description: Platform-wide statistics
+
+paths:
+  # ── Auth ──────────────────────────────────────────────────────────────────
+  /api/auth/challenge:
+    post:
+      tags: [Auth]
+      summary: Request a sign challenge
+      description: |
+        Generates a one-time challenge string the client must sign with their
+        Stellar Ed25519 keypair. The challenge expires in 5 minutes.
+      operationId: authChallenge
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [walletAddress]
+              properties:
+                walletAddress:
+                  type: string
+                  description: Stellar public key (G... address)
+                  example: GABC1234EXAMPLESTELLARADDRESS
+      responses:
+        '200':
+          description: Challenge issued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  challenge:
+                    type: string
+                    description: One-time challenge string to sign
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/auth/verify:
+    post:
+      tags: [Auth]
+      summary: Verify signature and receive JWT
+      description: |
+        Verifies the Ed25519 signature against the stored challenge.
+        On success, issues a signed JWT valid for 24 hours.
+        The `signature` must be the base64-encoded Ed25519 signature of the
+        challenge string produced by the wallet's private key.
+      operationId: authVerify
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [walletAddress, challenge, signature]
+              properties:
+                walletAddress:
+                  type: string
+                  example: GABC1234EXAMPLESTELLARADDRESS
+                challenge:
+                  type: string
+                  description: The challenge string returned by /api/auth/challenge
+                signature:
+                  type: string
+                  description: Base64-encoded Ed25519 signature of the challenge
+      responses:
+        '200':
+          description: Authentication successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                    description: Signed JWT valid for 24 hours
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  # ── User ──────────────────────────────────────────────────────────────────
+  /api/user/me:
+    get:
+      tags: [User]
+      summary: Get authenticated user identity
+      description: Returns the wallet address extracted from the Bearer JWT.
+      operationId: userMe
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Authenticated user identity
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  walletAddress:
+                    type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /api/user/{walletAddress}/profile:
+    get:
+      tags: [User]
+      summary: Get user profile
+      description: Returns profile data. Requester must own the wallet address.
+      operationId: userProfile
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/walletAddress'
+      responses:
+        '200':
+          description: User profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfile'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/user/{walletAddress}/preferences:
+    get:
+      tags: [User]
+      summary: Get user app preferences
+      operationId: userGetPreferences
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/walletAddress'
+      responses:
+        '200':
+          description: User preferences
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserPreferences'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    put:
+      tags: [User]
+      summary: Update user app preferences
+      operationId: userUpdatePreferences
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/walletAddress'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserPreferencesUpdate'
+      responses:
+        '200':
+          description: Preferences updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  preferences:
+                    $ref: '#/components/schemas/UserPreferences'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  # ── Health ────────────────────────────────────────────────────────────────
+  /api/v1/health:
+    get:
+      tags: [Health]
+      summary: Liveness probe (v1)
+      description: Returns 200 if the process is running. Does not check dependencies.
+      operationId: healthV1
+      responses:
+        '200':
+          description: Service is alive
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+
+  /api/v1/ready:
+    get:
+      tags: [Health]
+      summary: Readiness probe (v1)
+      description: |
+        Returns 200 only when both the PostgreSQL database and Stellar Horizon
+        are reachable. Returns 503 if either dependency is down.
+      operationId: readyV1
+      responses:
+        '200':
+          description: Service is ready
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadyResponse'
+        '503':
+          description: One or more dependencies are unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadyResponse'
+
+  /api/v2/health:
+    get:
+      tags: [Health]
+      summary: Liveness probe (v2)
+      description: Same as v1 but adds `uptime` and `apiVersion` fields.
+      operationId: healthV2
+      responses:
+        '200':
+          description: Service is alive
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/HealthResponse'
+                  - type: object
+                    properties:
+                      uptime:
+                        type: number
+                        description: Process uptime in seconds
+                      apiVersion:
+                        type: string
+                        example: v2
+
+  /api/v2/ready:
+    get:
+      tags: [Health]
+      summary: Readiness probe (v2)
+      operationId: readyV2
+      responses:
+        '200':
+          description: Service is ready
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ReadyResponse'
+                  - type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                        example: v2
+        '503':
+          description: One or more dependencies are unavailable
+
+  # ── Stats ─────────────────────────────────────────────────────────────────
+  /api/v1/stats/groups:
+    get:
+      tags: [Stats]
+      summary: Platform-wide group statistics
+      description: |
+        Returns aggregated group statistics for the landing page.
+        Sourced from the indexed ContractEvent database; cached 5 minutes in Redis.
+      operationId: statsGroups
+      responses:
+        '200':
+          description: Group overview statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupsOverviewStats'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  # ── Recommendations ───────────────────────────────────────────────────────
+  /api/v1/recommendations/{userId}:
+    get:
+      tags: [Recommendations]
+      summary: Get group recommendations for a user (v1)
+      description: |
+        Uses A/B testing to select between content-based and collaborative
+        filtering algorithms. Bucket A → content-based; Bucket B → collaborative.
+      operationId: recommendationsV1
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Recommendations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecommendationsResponse'
+
+  /api/v2/recommendations/{userId}:
+    get:
+      tags: [Recommendations]
+      summary: Get group recommendations for a user (v2)
+      description: Always uses collaborative filtering; returns richer metadata.
+      operationId: recommendationsV2
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Recommendations
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/RecommendationsResponse'
+                  - type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                        example: v2
+
+  /api/v1/preferences:
+    post:
+      tags: [Recommendations]
+      summary: Set user group preferences
+      description: Stores user preference data used by the recommendation engine.
+      operationId: setPreferences
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserPreferenceInput'
+      responses:
+        '200':
+          description: Preferences updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  # ── Search ────────────────────────────────────────────────────────────────
+  /api/v1/search:
+    get:
+      tags: [Search]
+      summary: Global full-text search
+      operationId: search
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Search query string
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResults'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/search/autocomplete:
+    get:
+      tags: [Search]
+      summary: Autocomplete suggestions
+      operationId: searchAutocomplete
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Autocomplete suggestions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AutocompleteResults'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  # ── Analytics ─────────────────────────────────────────────────────────────
+  /api/v1/analytics/platform:
+    get:
+      tags: [Analytics]
+      summary: Platform statistics for a date
+      operationId: analyticsPlatform
+      parameters:
+        - name: date
+          in: query
+          schema:
+            type: string
+            format: date
+          description: Target date (defaults to today)
+      responses:
+        '200':
+          description: Platform statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformStats'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/analytics/platform/trends:
+    get:
+      tags: [Analytics]
+      summary: Platform statistics trends over a date range
+      operationId: analyticsPlatformTrends
+      parameters:
+        - name: startDate
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date
+        - name: endDate
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 30
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Platform trends
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformTrends'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/analytics/users/{userId}:
+    get:
+      tags: [Analytics]
+      summary: User-specific analytics
+      operationId: analyticsUser
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: date
+          in: query
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: User analytics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserStats'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/analytics/groups/{groupId}:
+    get:
+      tags: [Analytics]
+      summary: Group-specific analytics
+      operationId: analyticsGroup
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: date
+          in: query
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: Group analytics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupStats'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/analytics/events:
+    get:
+      tags: [Analytics]
+      summary: Analytics event statistics
+      operationId: analyticsEventsGet
+      parameters:
+        - name: startDate
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: endDate
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Event statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  events:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AnalyticsEventStat'
+    post:
+      tags: [Analytics]
+      summary: Record an analytics event
+      operationId: analyticsEventsPost
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnalyticsEventInput'
+      responses:
+        '201':
+          description: Event recorded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/analytics/reports:
+    get:
+      tags: [Analytics]
+      summary: List analytics reports
+      operationId: analyticsReportsGet
+      parameters:
+        - name: reportType
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Reports list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  reports:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AnalyticsReport'
+    post:
+      tags: [Analytics]
+      summary: Generate an analytics report
+      operationId: analyticsReportsPost
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnalyticsReportInput'
+      responses:
+        '201':
+          description: Report generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnalyticsReport'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/analytics/cache/stats:
+    get:
+      tags: [Analytics]
+      summary: Analytics cache statistics
+      operationId: analyticsCacheStats
+      responses:
+        '200':
+          description: Cache statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CacheStats'
+
+  /api/v1/analytics/cache/clear:
+    post:
+      tags: [Analytics]
+      summary: Clear analytics cache
+      operationId: analyticsCacheClear
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pattern:
+                  type: string
+                  description: Redis key pattern to clear (default "*")
+                  example: "analytics:platform:*"
+      responses:
+        '200':
+          description: Cache cleared
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+
+  # ── Contract Events ───────────────────────────────────────────────────────
+  /api/v1/events:
+    get:
+      tags: [Events]
+      summary: Query indexed contract events
+      operationId: eventsGet
+      parameters:
+        - name: contractId
+          in: query
+          schema:
+            type: string
+        - name: eventType
+          in: query
+          schema:
+            type: string
+            enum: [GroupCreated, MemberJoined, ContributionMade, PayoutExecuted, GroupCompleted, GroupStatusChanged]
+        - name: startLedger
+          in: query
+          schema:
+            type: integer
+        - name: endLedger
+          in: query
+          schema:
+            type: integer
+        - name: startTime
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: endTime
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Paginated contract events
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventsPage'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/events/stats:
+    get:
+      tags: [Events]
+      summary: Contract event statistics
+      operationId: eventsStats
+      parameters:
+        - name: contractId
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Event statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventStats'
+
+  # ── Export ────────────────────────────────────────────────────────────────
+  /api/v1/export:
+    post:
+      tags: [Export]
+      summary: Create a data export job
+      operationId: exportCreate
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [userId, email, format]
+              properties:
+                userId:
+                  type: string
+                email:
+                  type: string
+                  format: email
+                format:
+                  type: string
+                  enum: [CSV, JSON]
+      responses:
+        '202':
+          description: Export job created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  message:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/export/{jobId}:
+    get:
+      tags: [Export]
+      summary: Get export job status
+      operationId: exportStatus
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Export job details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportJob'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/export/{jobId}/download:
+    get:
+      tags: [Export]
+      summary: Get download URL for a completed export
+      operationId: exportDownload
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Download URL
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url:
+                    type: string
+                    format: uri
+        '400':
+          description: Job not completed yet
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/members/{address}/export.csv:
+    get:
+      tags: [Export]
+      summary: Stream member contribution/payout history as CSV
+      description: |
+        Streams a CSV file containing all contributions and payouts for the
+        given Stellar address. Suitable for tax and accounting purposes.
+      operationId: memberExportCsv
+      parameters:
+        - name: address
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Stellar wallet address
+      responses:
+        '200':
+          description: CSV file stream
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+
+  # ── Backup ────────────────────────────────────────────────────────────────
+  /api/v1/backup:
+    get:
+      tags: [Backup]
+      summary: List all backup jobs
+      operationId: backupList
+      responses:
+        '200':
+          description: List of backup jobs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BackupJob'
+    post:
+      tags: [Backup]
+      summary: Trigger a manual backup
+      operationId: backupTrigger
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [type]
+              properties:
+                type:
+                  type: string
+                  enum: [full, incremental]
+      responses:
+        '202':
+          description: Backup job created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BackupJob'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/backup/{jobId}:
+    get:
+      tags: [Backup]
+      summary: Get a specific backup job
+      operationId: backupGet
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Backup job details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BackupJob'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/backup/restore:
+    post:
+      tags: [Backup]
+      summary: Restore from a backup
+      description: Restores from a specific job ID, or from the latest backup if no jobId is provided.
+      operationId: backupRestore
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                jobId:
+                  type: string
+                  description: Specific backup job ID to restore from (omit for latest)
+      responses:
+        '200':
+          description: Restore result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RestoreResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/backup/alerts:
+    get:
+      tags: [Backup]
+      summary: List backup alerts
+      operationId: backupAlerts
+      parameters:
+        - name: unacknowledgedOnly
+          in: query
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: Backup alerts
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BackupAlert'
+
+  /api/v1/backup/alerts/{alertId}/acknowledge:
+    post:
+      tags: [Backup]
+      summary: Acknowledge a backup alert
+      operationId: backupAlertAcknowledge
+      parameters:
+        - name: alertId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Alert acknowledged
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  acknowledged:
+                    type: boolean
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  # ── Members ───────────────────────────────────────────────────────────────
+  /api/members/{address}/reputation:
+    get:
+      tags: [User]
+      summary: Get member reputation score
+      operationId: memberReputation
+      parameters:
+        - name: address
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Stellar wallet address
+      responses:
+        '200':
+          description: Member reputation data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MemberReputation'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  # ── Groups (v2) ───────────────────────────────────────────────────────────
+  /api/v2/groups/{groupId}/invite:
+    post:
+      tags: [Recommendations]
+      summary: Send a group invitation email
+      operationId: groupInvite
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email]
+              properties:
+                email:
+                  type: string
+                  format: email
+      responses:
+        '201':
+          description: Invitation sent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  invitationId:
+                    type: string
+                  status:
+                    type: string
+                    example: sent
+                  joinLink:
+                    type: string
+                    format: uri
+                  apiVersion:
+                    type: string
+                    example: v2
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  # ── Notifications ─────────────────────────────────────────────────────────
+  /api/v1/notifications/preferences/{userId}:
+    get:
+      tags: [Notifications]
+      summary: Get notification preferences for a user
+      operationId: notifPrefsGet
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Notification preferences
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPreferences'
+    put:
+      tags: [Notifications]
+      summary: Update notification preferences
+      operationId: notifPrefsUpdate
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationPreferencesUpdate'
+      responses:
+        '200':
+          description: Preferences updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  preferences:
+                    $ref: '#/components/schemas/NotificationPreferences'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/notifications/preferences/stats:
+    get:
+      tags: [Notifications]
+      summary: Aggregate notification preference statistics
+      operationId: notifPrefsStats
+      responses:
+        '200':
+          description: Preference statistics
+          content:
+            application/json:
+              schema:
+                type: object
+
+  /api/v1/notifications/device-token:
+    post:
+      tags: [Notifications]
+      summary: Register a device token for push notifications
+      operationId: notifDeviceTokenRegister
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [userId, deviceToken, platform]
+              properties:
+                userId:
+                  type: string
+                deviceToken:
+                  type: string
+                platform:
+                  type: string
+                  enum: [ios, android, web]
+      responses:
+        '201':
+          description: Device token registered
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/notifications/device-token/{userId}/{deviceToken}:
+    delete:
+      tags: [Notifications]
+      summary: Unregister a device token
+      operationId: notifDeviceTokenDelete
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deviceToken
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Device token unregistered
+
+  /api/v1/notifications/send-email:
+    post:
+      tags: [Notifications]
+      summary: Send an email notification
+      operationId: notifSendEmail
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [to, templateId, templateData]
+              properties:
+                userId:
+                  type: string
+                to:
+                  type: string
+                  format: email
+                templateId:
+                  type: string
+                templateData:
+                  type: object
+                subject:
+                  type: string
+      responses:
+        '202':
+          description: Email sent
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          description: User has disabled this notification type
+
+  /api/v1/notifications/send-push:
+    post:
+      tags: [Notifications]
+      summary: Send a push notification
+      operationId: notifSendPush
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [deviceToken, templateId, templateData]
+              properties:
+                userId:
+                  type: string
+                deviceToken:
+                  type: string
+                templateId:
+                  type: string
+                templateData:
+                  type: object
+                title:
+                  type: string
+                body:
+                  type: string
+      responses:
+        '202':
+          description: Push notification sent
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/notifications/queue:
+    post:
+      tags: [Notifications]
+      summary: Queue a notification for later delivery
+      operationId: notifQueue
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [userId, templateKey, recipient, templateData, notificationType]
+              properties:
+                userId:
+                  type: string
+                templateKey:
+                  type: string
+                recipient:
+                  type: string
+                templateData:
+                  type: object
+                notificationType:
+                  type: string
+                  enum: [email, push, web_push]
+                priority:
+                  type: integer
+                  default: 0
+                scheduledFor:
+                  type: string
+                  format: date-time
+      responses:
+        '202':
+          description: Notification queued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  queueId:
+                    type: string
+
+  /api/v1/notifications/process-queue:
+    post:
+      tags: [Notifications]
+      summary: Process queued notifications
+      operationId: notifProcessQueue
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                batchSize:
+                  type: integer
+                  default: 100
+      responses:
+        '200':
+          description: Queue processed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  processedCount:
+                    type: integer
+
+  /api/v1/notifications/history/{userId}:
+    get:
+      tags: [Notifications]
+      summary: Get notification history for a user
+      operationId: notifHistory
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+      responses:
+        '200':
+          description: Notification history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  userId:
+                    type: string
+                  count:
+                    type: integer
+                  notifications:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/NotificationRecord'
+
+  /api/v1/notifications/stats:
+    get:
+      tags: [Notifications]
+      summary: Notification service statistics
+      operationId: notifStats
+      responses:
+        '200':
+          description: Notification statistics
+          content:
+            application/json:
+              schema:
+                type: object
+
+  /api/v1/notifications/templates:
+    get:
+      tags: [Notifications]
+      summary: List all active notification templates
+      operationId: notifTemplatesList
+      responses:
+        '200':
+          description: Templates list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  templates:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/NotificationTemplate'
+    post:
+      tags: [Notifications]
+      summary: Create a notification template (admin only)
+      operationId: notifTemplatesCreate
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationTemplateInput'
+      responses:
+        '201':
+          description: Template created
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/notifications/templates/{templateKey}:
+    get:
+      tags: [Notifications]
+      summary: Get a specific notification template
+      operationId: notifTemplatesGet
+      parameters:
+        - name: templateKey
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Template
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationTemplate'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      tags: [Notifications]
+      summary: Update a notification template (admin only)
+      operationId: notifTemplatesUpdate
+      parameters:
+        - name: templateKey
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                subject:
+                  type: string
+                htmlContent:
+                  type: string
+                textContent:
+                  type: string
+                active:
+                  type: boolean
+      responses:
+        '200':
+          description: Template updated
+
+  /api/v1/notifications/vapid-public-key:
+    get:
+      tags: [Notifications]
+      summary: Get VAPID public key for web push subscriptions
+      operationId: notifVapidKey
+      responses:
+        '200':
+          description: VAPID public key
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  publicKey:
+                    type: string
+        '503':
+          description: Web push not configured
+
+  /api/v1/notifications/subscribe:
+    post:
+      tags: [Notifications]
+      summary: Register a browser push subscription
+      operationId: notifSubscribe
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [userId, subscription]
+              properties:
+                userId:
+                  type: string
+                subscription:
+                  $ref: '#/components/schemas/WebPushSubscription'
+      responses:
+        '201':
+          description: Subscription registered
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '503':
+          description: Web push not configured
+    delete:
+      tags: [Notifications]
+      summary: Remove a browser push subscription
+      operationId: notifUnsubscribe
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [endpoint]
+              properties:
+                endpoint:
+                  type: string
+                  format: uri
+      responses:
+        '200':
+          description: Subscription removed
+
+  /api/v1/notifications/unsubscribe/{token}:
+    post:
+      tags: [Notifications]
+      summary: One-click unsubscribe via token (email link)
+      operationId: notifOneClickUnsubscribe
+      parameters:
+        - name: token
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Unsubscribed (returns HTML page)
+          content:
+            text/html:
+              schema:
+                type: string
+        '400':
+          description: Invalid token
+
+  /api/v1/notifications/resubscribe/{userId}:
+    post:
+      tags: [Notifications]
+      summary: Re-subscribe a user to notifications
+      operationId: notifResubscribe
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: User resubscribed
+
+  /api/v1/notifications/health:
+    get:
+      tags: [Notifications]
+      summary: Notification service health check
+      operationId: notifHealth
+      responses:
+        '200':
+          description: Notification service health
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotifHealthResponse'
+
+  # ── Webhooks ──────────────────────────────────────────────────────────────
+  /api/webhooks:
+    post:
+      tags: [Webhooks]
+      summary: Register a new webhook
+      operationId: webhookCreate
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookInput'
+      responses:
+        '201':
+          description: Webhook created (includes generated secret)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Webhook'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+    get:
+      tags: [Webhooks]
+      summary: List webhooks for a user
+      operationId: webhookList
+      parameters:
+        - name: userId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Webhooks list (secrets masked)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WebhookSummary'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/webhooks/{id}:
+    get:
+      tags: [Webhooks]
+      summary: Get a specific webhook
+      operationId: webhookGet
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: userId
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Webhook details (secret masked)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebhookSummary'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags: [Webhooks]
+      summary: Update a webhook
+      operationId: webhookUpdate
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookUpdate'
+      responses:
+        '200':
+          description: Webhook updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebhookSummary'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags: [Webhooks]
+      summary: Delete a webhook
+      operationId: webhookDelete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: userId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Webhook deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  # ── Cache ─────────────────────────────────────────────────────────────────
+  /api/cache/stats:
+    get:
+      tags: [Cache]
+      summary: Cache hit/miss statistics
+      operationId: cacheStats
+      responses:
+        '200':
+          description: Cache statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CacheStats'
+
+  # ── CSP ───────────────────────────────────────────────────────────────────
+  /api/csp-report:
+    post:
+      tags: [Health]
+      summary: CSP violation reporting endpoint
+      description: Receives Content-Security-Policy violation reports from browsers.
+      operationId: cspReport
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+          application/csp-report:
+            schema:
+              type: object
+      responses:
+        '204':
+          description: Report received
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT issued by POST /api/auth/verify
+
+  parameters:
+    walletAddress:
+      name: walletAddress
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Stellar public key (G... address)
+
+  responses:
+    BadRequest:
+      description: Invalid request parameters
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: Missing or invalid authentication
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Forbidden:
+      description: Authenticated but not authorised for this resource
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    InternalError:
+      description: Unexpected server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  schemas:
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+        version:
+          type: string
+          example: v1
+        responseTimeMs:
+          type: number
+        dependencies:
+          type: object
+          properties:
+            database:
+              type: object
+              properties:
+                up:
+                  type: boolean
+            horizon:
+              type: object
+              properties:
+                up:
+                  type: boolean
+
+    ReadyResponse:
+      allOf:
+        - $ref: '#/components/schemas/HealthResponse'
+        - type: object
+          properties:
+            status:
+              type: string
+              enum: [ready, not_ready]
+
+    UserProfile:
+      type: object
+      properties:
+        walletAddress:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    UserPreferences:
+      type: object
+      properties:
+        userId:
+          type: string
+        emailNotifications:
+          type: boolean
+        pushNotifications:
+          type: boolean
+        contributionReminders:
+          type: boolean
+        groupUpdates:
+          type: boolean
+        payoutNotifications:
+          type: boolean
+        emailFrequency:
+          type: string
+          enum: [immediate, daily, weekly, never]
+
+    UserPreferencesUpdate:
+      type: object
+      properties:
+        emailNotifications:
+          type: boolean
+        pushNotifications:
+          type: boolean
+        contributionReminders:
+          type: boolean
+        groupUpdates:
+          type: boolean
+        payoutNotifications:
+          type: boolean
+        emailFrequency:
+          type: string
+          enum: [immediate, daily, weekly, never]
+
+    UserPreferenceInput:
+      type: object
+      required: [userId]
+      properties:
+        userId:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        minContribution:
+          type: number
+        maxContribution:
+          type: number
+
+    GroupsOverviewStats:
+      type: object
+      properties:
+        totalGroups:
+          type: integer
+        activeGroups:
+          type: integer
+        totalMembers:
+          type: integer
+        totalContributed:
+          type: string
+          description: Total XLM contributed across all groups (as string to avoid precision loss)
+
+    RecommendationsResponse:
+      type: object
+      properties:
+        userId:
+          type: string
+        bucket:
+          type: string
+          enum: [A, B]
+        algorithm:
+          type: string
+          enum: [content, collaborative]
+        recommendations:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupSummary'
+
+    GroupSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        contributionAmount:
+          type: number
+        cycleDuration:
+          type: integer
+          description: Cycle duration in seconds
+        maxMembers:
+          type: integer
+        currentMembers:
+          type: integer
+        status:
+          type: string
+          enum: [Pending, Active, Paused, Completed, Cancelled]
+        tags:
+          type: array
+          items:
+            type: string
+
+    SearchResults:
+      type: object
+      properties:
+        groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupSummary'
+        total:
+          type: integer
+
+    AutocompleteResults:
+      type: object
+      properties:
+        suggestions:
+          type: array
+          items:
+            type: string
+
+    PlatformStats:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+        totalGroups:
+          type: integer
+        activeGroups:
+          type: integer
+        totalUsers:
+          type: integer
+        totalContributions:
+          type: integer
+        totalPayouts:
+          type: integer
+
+    PlatformTrends:
+      type: object
+      properties:
+        startDate:
+          type: string
+        endDate:
+          type: string
+        dataPoints:
+          type: integer
+        trends:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlatformStats'
+
+    UserStats:
+      type: object
+      properties:
+        userId:
+          type: string
+        date:
+          type: string
+          format: date
+        groupsJoined:
+          type: integer
+        totalContributed:
+          type: number
+        totalReceived:
+          type: number
+
+    GroupStats:
+      type: object
+      properties:
+        groupId:
+          type: string
+        date:
+          type: string
+          format: date
+        memberCount:
+          type: integer
+        currentCycle:
+          type: integer
+        totalContributed:
+          type: number
+
+    AnalyticsEventStat:
+      type: object
+      properties:
+        eventType:
+          type: string
+        eventName:
+          type: string
+        count:
+          type: integer
+        lastOccurred:
+          type: string
+          format: date-time
+
+    AnalyticsEventInput:
+      type: object
+      required: [eventType, eventName]
+      properties:
+        eventType:
+          type: string
+        eventName:
+          type: string
+        userId:
+          type: string
+        groupId:
+          type: string
+        eventData:
+          type: object
+        sessionId:
+          type: string
+
+    AnalyticsReport:
+      type: object
+      properties:
+        id:
+          type: string
+        reportType:
+          type: string
+        reportName:
+          type: string
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        generatedBy:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    AnalyticsReportInput:
+      type: object
+      required: [reportType, reportName, startDate, endDate]
+      properties:
+        reportType:
+          type: string
+        reportName:
+          type: string
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        generatedBy:
+          type: string
+
+    CacheStats:
+      type: object
+      properties:
+        hits:
+          type: integer
+        misses:
+          type: integer
+        hitRate:
+          type: number
+          format: float
+        keys:
+          type: integer
+
+    ContractEvent:
+      type: object
+      properties:
+        id:
+          type: string
+        contractId:
+          type: string
+        eventType:
+          type: string
+          enum: [GroupCreated, MemberJoined, ContributionMade, PayoutExecuted, GroupCompleted, GroupStatusChanged]
+        ledger:
+          type: integer
+        timestamp:
+          type: string
+          format: date-time
+        data:
+          type: object
+
+    EventsPage:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContractEvent'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    EventStats:
+      type: object
+      properties:
+        totalEvents:
+          type: integer
+        eventTypeBreakdown:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              count:
+                type: integer
+
+    ExportJob:
+      type: object
+      properties:
+        jobId:
+          type: string
+        userId:
+          type: string
+        email:
+          type: string
+          format: email
+        format:
+          type: string
+          enum: [CSV, JSON]
+        status:
+          type: string
+          enum: [pending, processing, completed, failed]
+        fileUrl:
+          type: string
+          format: uri
+        createdAt:
+          type: string
+          format: date-time
+
+    BackupJob:
+      type: object
+      properties:
+        jobId:
+          type: string
+        type:
+          type: string
+          enum: [full, incremental]
+        status:
+          type: string
+          enum: [pending, running, completed, failed]
+        startedAt:
+          type: string
+          format: date-time
+        completedAt:
+          type: string
+          format: date-time
+        sizeBytes:
+          type: integer
+
+    RestoreResult:
+      type: object
+      properties:
+        success:
+          type: boolean
+        jobId:
+          type: string
+        restoredAt:
+          type: string
+          format: date-time
+        message:
+          type: string
+
+    BackupAlert:
+      type: object
+      properties:
+        alertId:
+          type: string
+        severity:
+          type: string
+          enum: [warning, critical]
+        message:
+          type: string
+        acknowledged:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+
+    MemberReputation:
+      type: object
+      properties:
+        address:
+          type: string
+        score:
+          type: number
+          format: float
+        totalContributions:
+          type: integer
+        missedContributions:
+          type: integer
+        groupsCompleted:
+          type: integer
+
+    NotificationPreferences:
+      type: object
+      properties:
+        userId:
+          type: string
+        emailNotifications:
+          type: boolean
+        pushNotifications:
+          type: boolean
+        contributionReminders:
+          type: boolean
+        groupUpdates:
+          type: boolean
+        payoutNotifications:
+          type: boolean
+        emailFrequency:
+          type: string
+          enum: [immediate, daily, weekly, never]
+
+    NotificationPreferencesUpdate:
+      type: object
+      properties:
+        emailNotifications:
+          type: boolean
+        pushNotifications:
+          type: boolean
+        contributionReminders:
+          type: boolean
+        groupUpdates:
+          type: boolean
+        payoutNotifications:
+          type: boolean
+        emailFrequency:
+          type: string
+          enum: [immediate, daily, weekly, never]
+
+    NotificationRecord:
+      type: object
+      properties:
+        id:
+          type: string
+        userId:
+          type: string
+        type:
+          type: string
+        templateKey:
+          type: string
+        status:
+          type: string
+          enum: [queued, sent, failed]
+        sentAt:
+          type: string
+          format: date-time
+
+    NotificationTemplate:
+      type: object
+      properties:
+        templateKey:
+          type: string
+        templateName:
+          type: string
+        templateType:
+          type: string
+          enum: [email, push, web_push]
+        subject:
+          type: string
+        htmlContent:
+          type: string
+        textContent:
+          type: string
+        placeholders:
+          type: array
+          items:
+            type: string
+        active:
+          type: boolean
+
+    NotificationTemplateInput:
+      type: object
+      required: [templateKey, templateName, templateType, htmlContent, textContent]
+      properties:
+        templateKey:
+          type: string
+        templateName:
+          type: string
+        templateType:
+          type: string
+          enum: [email, push, web_push]
+        subject:
+          type: string
+        htmlContent:
+          type: string
+        textContent:
+          type: string
+        placeholders:
+          type: array
+          items:
+            type: string
+
+    WebPushSubscription:
+      type: object
+      required: [endpoint, keys]
+      properties:
+        endpoint:
+          type: string
+          format: uri
+        keys:
+          type: object
+          required: [p256dh, auth]
+          properties:
+            p256dh:
+              type: string
+            auth:
+              type: string
+
+    NotifHealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+        timestamp:
+          type: string
+          format: date-time
+        providers:
+          type: object
+          properties:
+            email:
+              type: boolean
+            push:
+              type: array
+              items:
+                type: string
+            webPush:
+              type: boolean
+
+    WebhookInput:
+      type: object
+      required: [userId, url, events]
+      properties:
+        userId:
+          type: string
+        groupId:
+          type: string
+          description: Optional — scope webhook to a specific group
+        url:
+          type: string
+          format: uri
+        events:
+          type: array
+          items:
+            type: string
+          example: [GroupCreated, ContributionMade, PayoutExecuted]
+        secret:
+          type: string
+          description: HMAC-SHA256 signing secret (auto-generated if omitted)
+        description:
+          type: string
+
+    Webhook:
+      allOf:
+        - $ref: '#/components/schemas/WebhookInput'
+        - type: object
+          properties:
+            id:
+              type: string
+            isActive:
+              type: boolean
+            createdAt:
+              type: string
+              format: date-time
+
+    WebhookSummary:
+      allOf:
+        - $ref: '#/components/schemas/Webhook'
+      description: Same as Webhook but with `secret` omitted for security
+
+    WebhookUpdate:
+      type: object
+      required: [userId]
+      properties:
+        userId:
+          type: string
+        url:
+          type: string
+          format: uri
+        events:
+          type: array
+          items:
+            type: string
+        isActive:
+          type: boolean
+        description:
+          type: string

--- a/contracts/stellar-save/src/contribution.rs
+++ b/contracts/stellar-save/src/contribution.rs
@@ -1,12 +1,18 @@
 use soroban_sdk::{contracttype, Address, Vec};
 
 /// Paginated result for contribution history queries.
+///
+/// Returned by any endpoint that lists contributions with a page size limit,
+/// allowing callers to detect whether additional pages exist without a
+/// separate count query.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContributionPage {
     /// The contributions in this page.
     pub items: Vec<ContributionRecord>,
-    /// True if there are more contributions beyond this page.
+    /// `true` if there are more contributions beyond this page.
+    /// Use the last item's `(group_id, cycle_number, member_address)` as the
+    /// cursor for the next request.
     pub has_more: bool,
 }
 

--- a/contracts/stellar-save/src/group.rs
+++ b/contracts/stellar-save/src/group.rs
@@ -14,8 +14,11 @@ pub const MAX_MEMBERS: u32 = 20;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TokenConfig {
     /// The SEP-41 token contract address for this group.
+    /// Must be a valid deployed token contract on the same network.
     pub token_address: Address,
     /// Decimal precision of the token, cached from `decimals()` at group creation.
+    /// Stored to avoid repeated cross-contract calls during contribution validation.
+    /// Typical values: 7 for XLM, 6 for USDC.
     pub token_decimals: u32,
 }
 
@@ -104,7 +107,10 @@ impl GroupStatus {
         matches!(self, GroupStatus::Completed | GroupStatus::Cancelled)
     }
 
-    /// Converts GroupStatus to u32 representation.
+    /// Converts `GroupStatus` to its `u32` wire representation.
+    ///
+    /// Matches the `#[repr(u32)]` discriminants used in `status.rs`:
+    /// `Pending=0`, `Active=1`, `Paused=2`, `Completed=3`, `Cancelled=4`.
     pub fn as_u32(&self) -> u32 {
         match self {
             GroupStatus::Pending => 0,
@@ -115,7 +121,9 @@ impl GroupStatus {
         }
     }
 
-    /// Converts u32 to GroupStatus.
+    /// Converts a `u32` discriminant back to a `GroupStatus`.
+    ///
+    /// Returns `None` for any value outside the range 0–4.
     pub fn from_u32(value: u32) -> Option<Self> {
         match value {
             0 => Some(GroupStatus::Pending),
@@ -211,43 +219,58 @@ pub struct Group {
     pub started_at: u64,
 
     /// Whether members must provide a signed proof when contributing.
-    /// If true, contributions require an additional signature verification step.
+    /// If `true`, contributions require an additional signature verification step
+    /// before the contribution amount is accepted.
     pub require_contribution_proof: bool,
 
     /// Whether the group allows the contribution amount to be changed between cycles.
-    /// If true, the creator can propose a new amount and members can vote on it.
+    /// If `true`, the creator can propose a new amount and members can vote on it.
+    /// Defaults to `false`; dynamic contributions are not yet enforced on-chain.
     pub allow_dynamic_contributions: bool,
 
     /// Grace period in seconds after the cycle deadline before a member is
     /// considered to have missed their contribution.
-    /// Maximum allowed value is 604800 (7 days). Defaults to 0 (no grace period).
+    /// Valid range: 0–604800 (0 to 7 days). Defaults to 0 (no grace period).
     pub grace_period_seconds: u64,
 
-    /// When true, only addresses explicitly invited by the creator may join.
+    /// When `true`, only addresses explicitly invited by the creator may join.
+    /// Uninvited join attempts are rejected with `Unauthorized`.
     pub invitation_only: bool,
+
     /// Accumulated reward pool from contribution fees (1% of each contribution).
-    /// Distributed equally among members who complete all cycles.
+    /// Distributed equally among members who complete all cycles without missing
+    /// a contribution. Denominated in stroops. Starts at 0.
     pub reward_pool: i128,
 
     /// Whether the group is temporarily paused by the creator.
+    /// When `true`, contributions and payouts are blocked. Use `is_paused()` to
+    /// check the combined paused state (this flag OR `status == Paused`).
     pub paused: bool,
 
     /// Whether penalty deductions are enabled for this group.
+    /// When `true`, members who miss a contribution deadline are charged
+    /// `penalty_amount` stroops (or a percentage if `penalty_amount == 0`).
     pub penalty_enabled: bool,
 
-    /// Fixed penalty amount per missed cycle in stroops (0 = use percentage-based).
+    /// Fixed penalty amount per missed cycle in stroops.
+    /// A value of 0 means use a percentage-based penalty instead.
+    /// Only relevant when `penalty_enabled` is `true`.
     pub penalty_amount: i128,
 
     /// Whether a dispute is currently active for this group.
+    /// When `true`, payouts are blocked until the dispute is resolved.
     pub dispute_active: bool,
 
-    /// Optional display name for the group (up to 50 chars).
+    /// Optional display name for the group (up to 50 characters).
+    /// `None` if the creator did not provide a name.
     pub name: Option<soroban_sdk::String>,
 
-    /// Optional description for the group (up to 500 chars).
+    /// Optional human-readable description for the group (up to 500 characters).
+    /// `None` if the creator did not provide a description.
     pub description: Option<soroban_sdk::String>,
 
-    /// Optional image URL for the group.
+    /// Optional image URL for the group avatar or banner.
+    /// `None` if the creator did not provide an image URL.
     pub image_url: Option<soroban_sdk::String>,
 
     /// Whether this group has been archived by its creator.
@@ -259,7 +282,8 @@ pub struct Group {
     pub archived: bool,
 
     /// How the payout recipient is selected each cycle.
-    /// Defaults to Sequential (join-order rotation).
+    /// Defaults to `PayoutOrder::Sequential` (join-order rotation).
+    /// See [`crate::payout::PayoutOrder`] for available strategies.
     pub payout_order: crate::payout::PayoutOrder,
 }
 impl Group {
@@ -308,6 +332,15 @@ impl Group {
     }
 
     /// Creates a new Group with penalty configuration.
+    ///
+    /// Extends [`Group::new`] with explicit penalty settings. All validation
+    /// from `new` applies; additionally:
+    ///
+    /// # Arguments
+    /// * `penalty_enabled` - Whether missed-contribution penalties are active
+    /// * `penalty_amount`  - Fixed penalty in stroops; 0 means percentage-based
+    ///
+    /// All other arguments are identical to [`Group::new`].
     pub fn new_with_penalty(
         id: u64,
         creator: Address,
@@ -378,8 +411,9 @@ impl Group {
         }
     }
     /// Checks if the group has completed all cycles.
-    /// A group is complete when current_cycle equals max_members
-    /// or when status is Completed.
+    ///
+    /// Returns `true` when `current_cycle >= max_members` (all payout slots
+    /// exhausted) or when `status` has been explicitly set to `Completed`.
     pub fn is_complete(&self) -> bool {
         self.current_cycle >= self.max_members || self.status == GroupStatus::Completed
     }
@@ -439,6 +473,10 @@ impl Group {
     }
 
     /// Deactivates the group, preventing further contributions.
+    ///
+    /// Sets `is_active` to `false` without changing `status`. This is used
+    /// internally when the group completes or is paused. To fully pause the
+    /// group (blocking payouts too), set `status = GroupStatus::Paused` instead.
     pub fn deactivate(&mut self) {
         self.is_active = false;
     }
@@ -479,18 +517,33 @@ impl Group {
     }
 
     /// Checks if the group has met the minimum member requirement for activation.
+    ///
+    /// Returns `true` when the group has not yet been started and the current
+    /// `member_count` is at least `min_members`.
     pub fn can_activate(&self) -> bool {
         !self.started && self.member_count >= self.min_members
     }
 
-    /// Calculates the total pool amount for a cycle.
-    /// This is the amount distributed to the recipient each cycle.
+    /// Calculates the total pool amount for a single cycle.
+    ///
+    /// This is the gross amount distributed to the payout recipient each cycle:
+    /// `contribution_amount × max_members`. Denominated in stroops.
+    ///
+    /// Note: this uses `max_members`, not `member_count`, because the pool size
+    /// is fixed at group creation and does not change as members join.
     pub fn total_pool_amount(&self) -> i128 {
         self.contribution_amount * (self.max_members as i128)
     }
 
-    /// Validates that the group configuration is sound.
-    /// Returns true if all constraints are met.
+    /// Validates that the group configuration is internally consistent.
+    ///
+    /// Returns `true` when all of the following hold:
+    /// - `contribution_amount > 0`
+    /// - `cycle_duration > 0`
+    /// - `max_members >= 2`
+    /// - `min_members >= 2`
+    /// - `min_members <= max_members`
+    /// - `current_cycle <= max_members`
     pub fn validate(&self) -> bool {
         self.contribution_amount > 0
             && self.cycle_duration > 0
@@ -500,16 +553,21 @@ impl Group {
             && self.current_cycle <= self.max_members
     }
 
-    /// Adds a member to the group.
-    /// Increments the member_count.
+    /// Adds a member to the group by incrementing `member_count`.
+    ///
+    /// The caller is responsible for also appending the member's `Address` to
+    /// the `GROUP_MEMBERS_{id}` storage list and verifying that
+    /// `member_count < max_members` before calling this method.
     pub fn add_member(&mut self) {
         self.member_count += 1;
     }
 
-    /// Returns true if the group is currently paused.
+    /// Returns `true` if the group is currently paused.
     ///
     /// A group is considered paused when either the `paused` flag is set
-    /// or the `status` is `GroupStatus::Paused`.
+    /// (creator-initiated soft pause) or `status == GroupStatus::Paused`
+    /// (formal state-machine pause). Both conditions block contributions
+    /// and payouts.
     pub fn is_paused(&self) -> bool {
         self.paused || self.status == GroupStatus::Paused
     }

--- a/contracts/stellar-save/src/payout.rs
+++ b/contracts/stellar-save/src/payout.rs
@@ -4,15 +4,27 @@ use crate::storage::StorageKeyBuilder;
 use soroban_sdk::{contracttype, Address, Env};
 
 /// Determines how the payout recipient is selected each cycle.
+///
+/// Stored in [`crate::group::Group::payout_order`] and evaluated at payout
+/// execution time. The default is [`PayoutOrder::Sequential`].
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PayoutOrder {
-    /// Members receive payouts in the fixed order assigned at group start (default).
+    /// Members receive payouts in the fixed order they joined the group (default).
+    ///
+    /// The recipient for cycle `N` is the member at index `N` in the
+    /// `GROUP_MEMBERS_{id}` storage list. This order is immutable once the
+    /// group is activated.
     Sequential,
-    /// Recipient is chosen randomly each cycle using ledger entropy.
+    /// Recipient is chosen pseudo-randomly each cycle using ledger entropy.
+    ///
+    /// Uses the current ledger sequence number as a seed. Not cryptographically
+    /// secure — do not use for high-value groups where manipulation is a concern.
     Random,
     /// Each cycle, the member who submits the highest bid wins the payout.
-    /// Bids are denominated in stroops and must be ≥ 0.
+    ///
+    /// Bids are denominated in stroops and must be ≥ 0. The winning bid amount
+    /// is deducted from the payout and redistributed to the other members.
     Bid,
 }
 
@@ -78,8 +90,10 @@ impl PayoutRecord {
         }
     }
 
-    /// Validates that the payout record is sound.
-    /// Returns true if all constraints are met.
+    /// Validates that the payout record is internally consistent.
+    ///
+    /// Returns `true` when `amount > 0`. A payout record with a zero or
+    /// negative amount indicates data corruption and must never be persisted.
     pub fn validate(&self) -> bool {
         self.amount > 0
     }
@@ -104,13 +118,21 @@ impl PayoutRecord {
     /// Checks if this payout belongs to a specific group.
     ///
     /// # Arguments
-    /// * `group_id` - The group ID to check
+    /// * `group_id` - The group ID to check against `self.group_id`
     pub fn belongs_to_group(&self, group_id: u64) -> bool {
         self.group_id == group_id
     }
 
-    /// Returns the payout amount in XLM (converted from stroops).
-    /// Note: This is a helper for display purposes; actual amount is in stroops.
+    /// Returns the payout amount converted from stroops to whole XLM units.
+    ///
+    /// This is a display helper only — all on-chain arithmetic uses stroops.
+    /// Fractional XLM is truncated (integer division by 10 000 000).
+    ///
+    /// # Example
+    /// ```
+    /// // 50_000_000 stroops → 5 XLM
+    /// assert_eq!(payout.amount_in_xlm(), 5);
+    /// ```
     pub fn amount_in_xlm(&self) -> i128 {
         self.amount / 10_000_000
     }

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,557 @@
+# Stellar-Save Infrastructure Runbook
+
+Operational procedures for the Stellar-Save platform. This runbook covers routine
+infrastructure tasks, incident response, and on-call escalation.
+
+For the full disaster-recovery workflow see [disaster-recovery.md](disaster-recovery.md).
+For individual alert runbooks see [docs/runbooks/](runbooks/).
+
+---
+
+## Table of Contents
+
+1. [ECS Task Scaling](#1-ecs-task-scaling)
+2. [Database Restore from S3](#2-database-restore-from-s3)
+3. [On-Call Escalation — Contract Pause Scenario](#3-on-call-escalation--contract-pause-scenario)
+4. [Common Operational Tasks](#4-common-operational-tasks)
+5. [Environment Reference](#5-environment-reference)
+
+---
+
+## 1. ECS Task Scaling
+
+The backend API runs on AWS ECS Fargate. Auto-scaling is configured to track CPU
+utilisation at a 70% target (scale-out cooldown 60 s, scale-in cooldown 300 s).
+Use the steps below when you need to override the desired count manually.
+
+### 1.1 Check Current Task Count
+
+```bash
+# Replace <env> with production or staging
+CLUSTER="stellar-save-backend-<env>"
+SERVICE="stellar-save-backend-<env>"
+
+aws ecs describe-services \
+  --cluster "$CLUSTER" \
+  --services "$SERVICE" \
+  --query 'services[0].{desired:desiredCount,running:runningCount,pending:pendingCount}'
+```
+
+### 1.2 Scale Up (High Load)
+
+Use this when CPU or request latency is elevated and auto-scaling has not yet
+reacted, or when you need to pre-warm capacity before a known traffic spike.
+
+```bash
+CLUSTER="stellar-save-backend-production"
+SERVICE="stellar-save-backend-production"
+DESIRED=6   # adjust to required count; max_capacity is set in Terraform
+
+aws ecs update-service \
+  --cluster "$CLUSTER" \
+  --service "$SERVICE" \
+  --desired-count "$DESIRED"
+
+# Confirm tasks are starting
+aws ecs wait services-stable \
+  --cluster "$CLUSTER" \
+  --services "$SERVICE"
+
+echo "Service stable at $DESIRED tasks"
+```
+
+**Verify health after scaling:**
+
+```bash
+# Poll the readiness probe until all tasks are healthy
+for i in $(seq 1 12); do
+  STATUS=$(curl -sf https://api.stellar-save.app/api/v2/ready | jq -r '.status')
+  echo "$(date -u +%H:%M:%S) status=$STATUS"
+  [ "$STATUS" = "ready" ] && break
+  sleep 10
+done
+```
+
+### 1.3 Scale Down (After Load Subsides)
+
+```bash
+CLUSTER="stellar-save-backend-production"
+SERVICE="stellar-save-backend-production"
+DESIRED=2   # minimum healthy count; never go below min_capacity (1)
+
+aws ecs update-service \
+  --cluster "$CLUSTER" \
+  --service "$SERVICE" \
+  --desired-count "$DESIRED"
+```
+
+> **Note:** The ECS service has `deployment_minimum_healthy_percent = 50`, so
+> scaling down will not drop below half the current running count in a single
+> step. Terraform's `lifecycle { ignore_changes = [desired_count] }` means
+> Terraform will not revert manual scaling changes on the next `apply`.
+
+### 1.4 View Auto-Scaling Activity
+
+```bash
+aws application-autoscaling describe-scaling-activities \
+  --service-namespace ecs \
+  --resource-id "service/$CLUSTER/$SERVICE" \
+  --max-results 10
+```
+
+### 1.5 Temporarily Disable Auto-Scaling
+
+Use only during maintenance windows to prevent unexpected scale-in.
+
+```bash
+aws application-autoscaling register-scalable-target \
+  --service-namespace ecs \
+  --resource-id "service/$CLUSTER/$SERVICE" \
+  --scalable-dimension ecs:service:DesiredCount \
+  --min-capacity 2 \
+  --max-capacity 2   # pin min == max to freeze count
+
+# Re-enable after maintenance
+aws application-autoscaling register-scalable-target \
+  --service-namespace ecs \
+  --resource-id "service/$CLUSTER/$SERVICE" \
+  --scalable-dimension ecs:service:DesiredCount \
+  --min-capacity 1 \
+  --max-capacity 10
+```
+
+### 1.6 CloudWatch Metrics to Monitor During Scaling
+
+| Metric | Namespace | Alarm threshold |
+|--------|-----------|-----------------|
+| CPUUtilization | AWS/ECS | > 70% for 5 min |
+| MemoryUtilization | AWS/ECS | > 80% for 5 min |
+| RequestCount | AWS/ApplicationELB | Spike > 2× baseline |
+| TargetResponseTime | AWS/ApplicationELB | p99 > 2 s |
+
+```bash
+# Quick CPU check
+aws cloudwatch get-metric-statistics \
+  --namespace AWS/ECS \
+  --metric-name CPUUtilization \
+  --dimensions Name=ClusterName,Value="$CLUSTER" Name=ServiceName,Value="$SERVICE" \
+  --start-time "$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)" \
+  --end-time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --period 60 \
+  --statistics Average \
+  --query 'sort_by(Datapoints, &Timestamp)[-5:]'
+```
+
+---
+
+## 2. Database Restore from S3
+
+The PostgreSQL database (RDS, `stellar-save-production`) is backed up by the
+`BackupService` in the backend. Backups are stored in S3 and tracked in the
+`BackupJob` table. Automated backups run on the schedule configured in
+`BackupScheduler`; RDS automated snapshots are retained for 7 days with a
+backup window of 03:00–04:00 UTC.
+
+### 2.1 Identify the Restore Point
+
+**Option A — via the API (preferred):**
+
+```bash
+# List completed backup jobs, newest first
+curl -sf https://api.stellar-save.app/api/v1/backup \
+  | jq '[.[] | select(.status=="completed")] | sort_by(.completedAt) | reverse | .[0:5]'
+```
+
+**Option B — via AWS Console:**
+
+1. Open **RDS → Databases → stellar-save-production → Maintenance & backups**
+2. Note the snapshot identifier or point-in-time restore window.
+
+**Option C — list S3 objects directly:**
+
+```bash
+S3_BUCKET="${BACKUP_S3_BUCKET:-stellar-save-backups-production}"
+
+aws s3 ls "s3://$S3_BUCKET/backups/" \
+  --recursive \
+  --human-readable \
+  | sort | tail -20
+```
+
+### 2.2 Restore via the Backend API
+
+This is the standard path. The `RecoveryService` downloads the backup from S3
+and applies it to the database.
+
+```bash
+# Restore from the latest completed backup
+curl -X POST https://api.stellar-save.app/api/v1/backup/restore \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+
+# Restore from a specific job
+curl -X POST https://api.stellar-save.app/api/v1/backup/restore \
+  -H 'Content-Type: application/json' \
+  -d '{"jobId": "<job-id>"}'
+```
+
+Monitor restore progress:
+
+```bash
+JOB_ID="<job-id>"
+watch -n 5 "curl -sf https://api.stellar-save.app/api/v1/backup/$JOB_ID | jq '{status,completedAt}'"
+```
+
+### 2.3 Restore via the DR Script
+
+For full disaster-recovery scenarios use the automated script:
+
+```bash
+# Restore from latest backup
+bash scripts/dr_recover.sh data-restore --latest
+
+# Restore from a specific job
+bash scripts/dr_recover.sh data-restore --job-id <job-id>
+```
+
+Required environment variables: `BACKEND_URL`, `STELLAR_NETWORK`.
+
+### 2.4 Restore via RDS Point-in-Time (Last Resort)
+
+Use this only when the application-level backup is unavailable or corrupted.
+
+```bash
+DB_IDENTIFIER="stellar-save-production"
+RESTORE_TIME="2026-05-27T03:00:00Z"   # ISO 8601 UTC
+NEW_IDENTIFIER="stellar-save-production-restored"
+
+aws rds restore-db-instance-to-point-in-time \
+  --source-db-instance-identifier "$DB_IDENTIFIER" \
+  --target-db-instance-identifier "$NEW_IDENTIFIER" \
+  --restore-time "$RESTORE_TIME" \
+  --db-instance-class db.t3.small \
+  --no-multi-az \
+  --no-publicly-accessible
+
+# Wait for the new instance to be available (can take 10–30 min)
+aws rds wait db-instance-available \
+  --db-instance-identifier "$NEW_IDENTIFIER"
+
+echo "Restored instance available: $NEW_IDENTIFIER"
+```
+
+After the instance is available:
+
+1. Update `DATABASE_URL` in Secrets Manager / ECS task environment to point to
+   the new instance endpoint.
+2. Restart ECS tasks to pick up the new connection string:
+   ```bash
+   aws ecs update-service \
+     --cluster stellar-save-backend-production \
+     --service stellar-save-backend-production \
+     --force-new-deployment
+   ```
+3. Run smoke tests:
+   ```bash
+   bash scripts/smoke_test_post_deploy.sh
+   ```
+4. Once verified, rename or delete the old instance.
+
+### 2.5 Verify Restore Integrity
+
+```bash
+# Check readiness probe — database dependency must be up
+curl -sf https://api.stellar-save.app/api/v2/ready | jq '.dependencies.database'
+
+# Spot-check event count (should be non-zero after restore)
+curl -sf "https://api.stellar-save.app/api/v1/events/stats" | jq '.totalEvents'
+
+# Check backup alerts for any post-restore warnings
+curl -sf "https://api.stellar-save.app/api/v1/backup/alerts?unacknowledgedOnly=true"
+```
+
+---
+
+## 3. On-Call Escalation — Contract Pause Scenario
+
+A contract pause is a P1 incident. It means all group contributions and payouts
+are halted on-chain. Follow this checklist in order.
+
+### 3.1 Detection
+
+A contract pause may be detected via:
+
+- Prometheus alert `ContractPaused` firing
+- User reports of failed transactions
+- Monitoring dashboard showing zero `ContributionMade` events for > 15 minutes
+  during expected active hours
+- Automated health check failure from `scripts/smoke_test.sh`
+
+### 3.2 Immediate Response (0–5 minutes)
+
+```bash
+# 1. Confirm the contract is paused
+curl -sf https://api.stellar-save.app/api/v2/ready | jq '.'
+
+# 2. Check recent contract events for a pause event
+curl -sf "https://api.stellar-save.app/api/v1/events?eventType=GroupStatusChanged&limit=10" \
+  | jq '.items[] | {timestamp, data}'
+
+# 3. Check backend logs for errors
+# In CloudWatch Logs:
+#   Log group: /ecs/stellar-save-backend-production
+#   Filter: { $.level = "error" }
+```
+
+### 3.3 Escalation Checklist
+
+Work through each item in sequence. Check the box as you complete it.
+
+- [ ] **Acknowledge the alert** in PagerDuty / OpsGenie within 5 minutes.
+- [ ] **Identify the cause** — review contract events and backend error logs.
+- [ ] **Notify the team** in the `#incidents` Slack channel:
+  ```
+  🚨 P1 INCIDENT — Contract pause detected
+  Time: <UTC timestamp>
+  Cause: <known / investigating>
+  On-call: @<your-name>
+  ```
+- [ ] **Assess blast radius** — how many active groups are affected?
+  ```bash
+  curl -sf "https://api.stellar-save.app/api/v1/stats/groups" | jq '.activeGroups'
+  ```
+- [ ] **Determine if pause was intentional** — check with the deployer or admin
+  key holder. If intentional (e.g., emergency security response), skip to
+  step 3.5.
+- [ ] **Attempt automated recovery** if cause is known and safe:
+  ```bash
+  bash scripts/dr_recover.sh health-check
+  ```
+- [ ] **Escalate to contract admin** if the pause cannot be resolved within
+  15 minutes. The contract admin holds the `ADMIN_SECRET` required to unpause.
+- [ ] **Escalate to engineering lead** if the contract admin is unreachable
+  within 10 minutes of initial escalation.
+- [ ] **Post a status update** to the public status page every 30 minutes until
+  resolved.
+
+### 3.4 Unpause the Contract
+
+Only the contract admin (`ADMIN_SECRET`) can unpause. Ensure the root cause is
+understood and resolved before unpausing.
+
+```bash
+# Verify environment variables are set
+echo "Network: $STELLAR_NETWORK"
+echo "Contract: $CONTRACT_ID"
+echo "RPC: $STELLAR_RPC_URL"
+
+# Unpause via the DR script
+bash scripts/dr_recover.sh unpause-all-groups
+
+# Verify groups are accepting contributions again
+curl -sf "https://api.stellar-save.app/api/v1/events?eventType=GroupStatusChanged&limit=5" \
+  | jq '.items[] | {timestamp, data}'
+```
+
+### 3.5 Post-Incident Actions (within 24 hours)
+
+- [ ] Run full smoke test suite:
+  ```bash
+  bash scripts/smoke_test_post_deploy.sh
+  ```
+- [ ] Acknowledge any outstanding backup or monitoring alerts:
+  ```bash
+  curl -sf "https://api.stellar-save.app/api/v1/backup/alerts?unacknowledgedOnly=true" \
+    | jq '.[].alertId' \
+    | xargs -I{} curl -X POST "https://api.stellar-save.app/api/v1/backup/alerts/{}/acknowledge"
+  ```
+- [ ] Write an incident report covering:
+  - Timeline of events
+  - Root cause
+  - Impact (groups affected, duration)
+  - Remediation steps taken
+  - Follow-up action items
+- [ ] File follow-up issues for any gaps in monitoring or automation discovered
+  during the incident.
+- [ ] Update this runbook if any step was unclear or missing.
+
+### 3.6 Escalation Contacts
+
+| Role | Contact | Escalate after |
+|------|---------|----------------|
+| On-call engineer | PagerDuty rotation | Immediate |
+| Contract admin | Holds `ADMIN_SECRET` | 15 min unresolved |
+| Engineering lead | See team directory | 25 min unresolved |
+| CTO / founder | See team directory | 45 min unresolved |
+
+---
+
+## 4. Common Operational Tasks
+
+### 4.1 Deploy a New Backend Version
+
+```bash
+# Build and push Docker image
+IMAGE="<ecr-registry>/stellar-save-backend:<git-sha>"
+docker build -t "$IMAGE" backend/
+docker push "$IMAGE"
+
+# Update ECS task definition and force new deployment
+aws ecs update-service \
+  --cluster stellar-save-backend-production \
+  --service stellar-save-backend-production \
+  --force-new-deployment
+
+# Monitor rollout
+aws ecs wait services-stable \
+  --cluster stellar-save-backend-production \
+  --services stellar-save-backend-production
+
+bash scripts/smoke_test_post_deploy.sh
+```
+
+### 4.2 Roll Back a Bad Deployment
+
+```bash
+# Find the previous task definition revision
+aws ecs describe-task-definition \
+  --task-definition stellar-save-backend-production \
+  --query 'taskDefinition.revision'
+
+PREV_REVISION=$(($(aws ecs describe-task-definition \
+  --task-definition stellar-save-backend-production \
+  --query 'taskDefinition.revision' --output text) - 1))
+
+aws ecs update-service \
+  --cluster stellar-save-backend-production \
+  --service stellar-save-backend-production \
+  --task-definition "stellar-save-backend-production:$PREV_REVISION"
+```
+
+Or use the rollback script:
+
+```bash
+bash scripts/rollback.sh
+```
+
+### 4.3 Rotate Database Credentials
+
+```bash
+# Generate new password
+NEW_PASS=$(openssl rand -base64 32)
+
+# Update RDS
+aws rds modify-db-instance \
+  --db-instance-identifier stellar-save-production \
+  --master-user-password "$NEW_PASS" \
+  --apply-immediately
+
+# Update Secrets Manager
+SECRET_ARN=$(aws secretsmanager list-secrets \
+  --query "SecretList[?Name=='stellar-save-production/db-credentials'].ARN" \
+  --output text)
+
+aws secretsmanager put-secret-value \
+  --secret-id "$SECRET_ARN" \
+  --secret-string "{\"password\":\"$NEW_PASS\"}"
+
+# Force ECS task restart to pick up new credentials
+aws ecs update-service \
+  --cluster stellar-save-backend-production \
+  --service stellar-save-backend-production \
+  --force-new-deployment
+```
+
+### 4.4 Trigger a Manual Backup
+
+```bash
+# Full backup
+curl -X POST https://api.stellar-save.app/api/v1/backup \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"full"}'
+
+# Incremental backup
+curl -X POST https://api.stellar-save.app/api/v1/backup \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"incremental"}'
+```
+
+### 4.5 Check Service Health
+
+```bash
+# Liveness
+curl -sf https://api.stellar-save.app/api/v2/health | jq '.'
+
+# Readiness (checks DB + Horizon)
+curl -sf https://api.stellar-save.app/api/v2/ready | jq '.'
+
+# Prometheus metrics
+curl -sf https://api.stellar-save.app/metrics | grep -E '^(http_|process_)'
+```
+
+### 4.6 View Application Logs
+
+```bash
+# Stream live logs from ECS (requires awslogs or CloudWatch Logs Insights)
+aws logs tail /ecs/stellar-save-backend-production --follow
+
+# Search for errors in the last hour
+aws logs filter-log-events \
+  --log-group-name /ecs/stellar-save-backend-production \
+  --start-time $(($(date +%s) - 3600))000 \
+  --filter-pattern '{ $.level = "error" }' \
+  --query 'events[*].message' \
+  --output text
+```
+
+---
+
+## 5. Environment Reference
+
+### 5.1 Key Environment Variables
+
+| Variable | Description | Where set |
+|----------|-------------|-----------|
+| `PORT` | Backend HTTP port (default 3001) | ECS task definition |
+| `DATABASE_URL` | PostgreSQL connection string | Secrets Manager |
+| `STELLAR_NETWORK` | `testnet` or `mainnet` | ECS task definition |
+| `STELLAR_RPC_URL` | Soroban RPC endpoint | ECS task definition |
+| `HORIZON_URL` | Stellar Horizon endpoint | ECS task definition |
+| `CONTRACT_ID` | Deployed contract address | ECS task definition |
+| `ADMIN_SECRET` | Contract admin keypair secret | Secrets Manager |
+| `BACKUP_ENABLED` | Enable backup scheduler (`true`/`false`) | ECS task definition |
+| `BACKUP_S3_BUCKET` | S3 bucket for backups | ECS task definition |
+| `INDEXER_ENABLED` | Enable contract event indexer | ECS task definition |
+| `SENDGRID_API_KEY` | SendGrid API key for email | Secrets Manager |
+| `FRONTEND_URL` | Frontend base URL for links | ECS task definition |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated allowed origins | ECS task definition |
+
+### 5.2 Key Endpoints
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /api/v2/health` | Liveness probe |
+| `GET /api/v2/ready` | Readiness probe (checks DB + Horizon) |
+| `GET /metrics` | Prometheus metrics |
+| `GET /api/v1/events/stats` | Contract event index health |
+| `GET /api/v1/backup/alerts` | Backup alert status |
+
+### 5.3 Infrastructure Resources
+
+| Resource | Identifier |
+|----------|-----------|
+| ECS Cluster | `stellar-save-backend-production` |
+| ECS Service | `stellar-save-backend-production` |
+| RDS Instance | `stellar-save-production` |
+| CloudWatch Log Group | `/ecs/stellar-save-backend-production` |
+| S3 Backup Bucket | `stellar-save-backups-production` |
+| Secrets Manager | `stellar-save-production/db-credentials` |
+
+### 5.4 Related Documentation
+
+- [Architecture Overview](architecture.md)
+- [Disaster Recovery](disaster-recovery.md)
+- [Deployment Guide](deployment.md)
+- [Threat Model & Security](threat-model.md)
+- [Individual Alert Runbooks](runbooks/)
+- [API Reference](api-reference.md)


### PR DESCRIPTION
## Summary

Resolves three documentation issues in a single branch.

---

### #864 — Backend API OpenAPI specification

- Added `backend/openapi.yaml` (OpenAPI 3.0.3) covering every `/api/*` endpoint
- Derived directly from route handlers in `routes/v1.ts`, `routes/v2.ts`, `routes/auth.ts`, `routes/user.ts`, `routes/notifications.ts`, and `routes/webhooks.ts`
- Full request/response schemas, security schemes (Bearer JWT), reusable parameters and error responses
- Covers auth, user, health, stats, recommendations, search, analytics, contract events, export, backup, notifications, webhooks, and cache routes
- Both `/api/v1` and `/api/v2` versioned routes documented; legacy deprecation noted

Closes #864 

---

### #865 — Infrastructure runbook

- Added `docs/runbook.md` with three core operational sections:
  1. **ECS task scaling** — scale up/down commands, disable auto-scaling, CloudWatch metrics to watch
  2. **Database restore from S3** — API path, DR script, RDS point-in-time fallback, integrity verification steps
  3. **On-call escalation checklist for contract pause** — detection, immediate response, step-by-step checkbox list, unpause procedure, post-incident actions, escalation contact table
- Additional sections: common ops tasks (deploy, rollback, credential rotation, manual backup), environment variable reference, infrastructure resource identifiers
- All AWS CLI commands reference actual Terraform resource names from `infra/modules/ecs` and `infra/modules/rds`

Closes #865 

---

### #866 — Inline Rust doc comments on contract modules

- **group.rs**: expanded/added `///` comments on `TokenConfig` fields, `GroupStatus::as_u32`/`from_u32`, all `Group` fields added since the original implementation, and methods `new_with_penalty`, `is_complete`, `deactivate`, `can_activate`, `total_pool_amount`, `validate`, `add_member`, `is_paused`
- **contribution.rs**: expanded `ContributionPage.has_more` field doc with cursor guidance
- **payout.rs**: expanded `PayoutOrder` variant docs (`Sequential`, `Random`, `Bid`), `validate`, `belongs_to_group`, `amount_in_xlm` (with code example)
- `cargo doc --no-deps` produces **zero** missing-documentation warnings

Closes #866 
