### PR TITLE
feat(infra): add staging Terraform workspace

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,69 @@
+name: Deploy Staging
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'infra/**'
+      - '.github/workflows/deploy-staging.yml'
+
+env:
+  TF_VERSION: "1.8.5"
+  AWS_REGION: "us-east-1"
+  TF_WORKING_DIR: infra/envs/staging
+
+jobs:
+  plan:
+    name: Terraform Plan (staging)
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform init
+        run: terraform init -input=false -backend-config=../../environments/staging.backend.hcl
+        working-directory: ${{ env.TF_WORKING_DIR }}
+
+      - name: Terraform plan
+        id: plan
+        run: |
+          terraform plan -no-color -input=false \
+            -var-file=../../environments/staging.tfvars \
+            -out=tfplan 2>&1 | tee plan.txt
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          TF_VAR_acm_certificate_arn: ${{ vars.STAGING_ACM_CERT_ARN }}
+          TF_VAR_vpc_id: ${{ secrets.STAGING_VPC_ID }}
+          TF_VAR_private_subnet_ids: ${{ secrets.STAGING_PRIVATE_SUBNET_IDS }}
+          TF_VAR_db_username: ${{ secrets.STAGING_DB_USERNAME }}
+          TF_VAR_db_password: ${{ secrets.STAGING_DB_PASSWORD }}
+
+      - name: Comment plan on PR
+        uses: actions/github-script@v7
+        if: always()
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('${{ env.TF_WORKING_DIR }}/plan.txt', 'utf8');
+            const truncated = plan.length > 60000 ? plan.slice(0, 60000) + '\n...(truncated)' : plan;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Terraform Plan — staging\n\`\`\`hcl\n${truncated}\n\`\`\``
+            });

--- a/infra/environments/staging.backend.hcl
+++ b/infra/environments/staging.backend.hcl
@@ -1,0 +1,11 @@
+# infra/environments/staging.backend.hcl
+# Partial backend configuration for the staging workspace.
+# Usage: terraform init -backend-config=../../environments/staging.backend.hcl
+#
+# The S3 bucket and DynamoDB table are created by infra/bootstrap/main.tf.
+
+bucket         = "stellar-save-terraform-state"
+key            = "staging/terraform.tfstate"
+region         = "us-east-1"
+dynamodb_table = "stellar-save-terraform-locks"
+encrypt        = true

--- a/infra/environments/staging.tfvars
+++ b/infra/environments/staging.tfvars
@@ -1,0 +1,17 @@
+# infra/environments/staging.tfvars
+# Variable values for the staging environment.
+# Usage: terraform plan -var-file=../../environments/staging.tfvars
+#        terraform apply -var-file=../../environments/staging.tfvars
+
+aws_region = "us-east-1"
+
+# RDS — reduced scale for pre-release testing
+db_instance_class  = "db.t3.micro"
+allocated_storage  = 20
+multi_az           = false
+
+# Frontend
+domain_names = ["staging.stellar-save.app"]
+
+# Stellar network
+stellar_network = "testnet"


### PR DESCRIPTION
## Summary

Sets up a separate staging Terraform workspace that mirrors production infrastructure at reduced scale for pre-release testing.

## Changes

- `infra/environments/staging.tfvars` — variable values for staging: `db.t3.micro`, no multi-AZ, testnet, `staging.stellar-save.app`
- `infra/environments/staging.backend.hcl` — partial backend config pointing to the shared `stellar-save-terraform-state` S3 bucket with key `staging/terraform.tfstate`
- `.github/workflows/deploy-staging.yml` — dedicated workflow triggered on PRs to `main` for `infra/**` changes; runs `terraform plan` and posts the output as a PR comment

## Testing

Workflow triggers on this PR itself (infra path filter). Plan will run against the staging environment.

Closes #857