### PR TITLE
feat(ci): add contract WASM size check to CI pipeline

### DIFF
--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -46,3 +46,32 @@ jobs:
 
       - name: Clippy (deny warnings)
         run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Check contract WASM size
+        id: size_check
+        run: |
+          WASM=target/wasm32-unknown-unknown/release/stellar_save.wasm
+          SIZE=$(wc -c < "$WASM")
+          LIMIT=$((60 * 1024))
+          echo "size=$SIZE" >> "$GITHUB_OUTPUT"
+          echo "Contract size: $SIZE bytes (limit: $LIMIT bytes)"
+          if [ "$SIZE" -gt "$LIMIT" ]; then
+            echo "ERROR: Contract size $SIZE bytes exceeds 60KB limit ($LIMIT bytes)"
+            exit 1
+          fi
+
+      - name: Post contract size as PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const size = ${{ steps.size_check.outputs.size }};
+            const limit = 60 * 1024;
+            const pct = ((size / limit) * 100).toFixed(1);
+            const status = size <= limit ? '✅ Within limit' : '❌ Exceeds limit';
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Contract Size Report\n| | |\n|---|---|\n| **Size** | ${size} bytes |\n| **Limit** | ${limit} bytes (60 KB) |\n| **Usage** | ${pct}% |\n| **Status** | ${status} |`
+            });


### PR DESCRIPTION
## Summary

Adds a contract size check step to `contract-ci.yml` that enforces the Soroban 64KB WASM limit.

## Changes

- Runs `wc -c` on `stellar_save.wasm` after the build step
- Fails the workflow if size exceeds **60KB** (4KB buffer below the 64KB Soroban limit)
- Posts a size report table as a PR comment for tracking over time

## Example PR comment

| | |
|---|---|
| **Size** | 45123 bytes |
| **Limit** | 61440 bytes (60 KB) |
| **Usage** | 73.4% |
| **Status** | ✅ Within limit |

Closes #855