### PR TITLE
perf: set chunkSizeWarningLimit to 100KB for code splitting enforcement

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
     },
   },
   build: {
+    chunkSizeWarningLimit: 100,
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
Implement frontend code splitting (#897)

Enforces the 100KB per-chunk budget introduced by lazy-loading all page components.

Changes
- Set chunkSizeWarningLimit: 100 in vite.config.ts — Vite now warns at build time if any route chunk exceeds 100KB

What was already in place
- All page components lazy-loaded via React.lazy() in routes.tsx
- <Suspense> fallback in AppRouter and App
- manualChunks splitting heavy vendors (react, @mui/material, @stellar/stellar-sdk, i18next) into separate chunks
- rollup-plugin-visualizer writing dist/stats.html with gzip/brotli sizes for verification

Verification
bash
cd frontend && npm run build
# open dist/stats.html to inspect per-chunk gzip sizes


Closes #897 