### PR TITLE
docs: add self-hosting guide

### DIFF
--- a/docs/localization-contributor-guide.md
+++ b/docs/localization-contributor-guide.md
@@ -1,0 +1,132 @@
+# Localization and Translation Contributor Guide
+
+This guide helps non-developers contribute translations for Stellar-Save across the web app, mobile surfaces, and notification templates.
+
+## Scope
+
+Stellar-Save currently uses a shared locale model for the web frontend and a separate notification i18n service for backend-generated emails and push copy. The main translation sources are:
+
+- Frontend locale files in [frontend/src/i18n/locales](../frontend/src/i18n/locales)
+- Frontend language registration in [frontend/src/i18n/index.ts](../frontend/src/i18n/index.ts)
+- Backend notification translations in [backend/src/lib/i18n.ts](../backend/src/lib/i18n.ts)
+
+## Supported locales
+
+### Web and frontend
+
+The frontend currently supports these locales:
+
+| Code | Locale | Status |
+|---|---|---|
+| `en` | English | Default and fallback |
+| `fr` | Français | Supported |
+| `yo` | Yorùbá | Supported |
+| `ar` | العربية | Supported |
+| `fa` | فارسی | Supported |
+| `sw` | Kiswahili | Supported |
+
+### Notifications and backend templates
+
+Backend notifications currently support:
+
+| Code | Locale | Status |
+|---|---|---|
+| `en` | English | Default and fallback |
+| `fr` | Français | Supported |
+| `yo` | Yorùbá | Supported |
+
+## File structure and conventions
+
+### Frontend locale files
+
+Each locale is a JSON file in the frontend locale folder:
+
+```text
+frontend/src/i18n/locales/
+  en.json
+  fr.json
+  yo.json
+  ar.json
+  fa.json
+  sw.json
+```
+
+Conventions:
+
+- Keep the JSON structure nested by feature or page area.
+- Preserve the existing keys exactly; do not rename them.
+- Use the English file as the source of truth.
+- Keep translations UTF-8 and valid JSON.
+- Preserve interpolation variables such as `{{name}}`, `{{balance}}`, and `{{count}}` exactly.
+- Do not translate product names, currency codes, wallet names, or technical identifiers.
+
+### Backend notification templates
+
+Notification content lives in the backend i18n module. The supported locale list and translation map are defined in [backend/src/lib/i18n.ts](../backend/src/lib/i18n.ts).
+
+Conventions:
+
+- Add a translation for every notification key in every supported locale.
+- Keep placeholders such as `{{groupName}}` or `{{amount}}` intact.
+- Prefer short, clear wording for push notifications and email subjects.
+
+## How to add a new locale
+
+1. Copy the English frontend locale file as a starting point:
+   ```bash
+   cp frontend/src/i18n/locales/en.json frontend/src/i18n/locales/<code>.json
+   ```
+2. Translate every value in the new file. Leave the keys unchanged.
+3. Register the locale in [frontend/src/i18n/index.ts](../frontend/src/i18n/index.ts):
+   - import the new JSON file
+   - add it to the `SUPPORTED_LANGUAGES` array
+   - add it to the `resources` object
+4. If the locale should also be used for backend notifications, update [backend/src/lib/i18n.ts](../backend/src/lib/i18n.ts) and add the locale to the supported list.
+5. Verify the locale by running the relevant tests and checking the language selector in the app.
+
+## How to update an existing locale
+
+1. Open the English source file and find the key you want to change.
+2. Update the matching entry in the target locale file.
+3. If a new key was added in English, add the same key to every other locale file.
+4. Keep the same nesting structure and variable placeholders.
+
+## Review process for translations
+
+1. Use the English file as the reference source.
+2. Check that the translation is natural, clear, and consistent with the product vocabulary.
+3. Confirm that placeholders and punctuation remain correct.
+4. Verify that the translation is not too long for UI labels or buttons.
+5. Submit the change in a pull request with:
+   - the locale file changes
+   - any registration updates
+   - a short note describing the language and scope of the update
+
+## Verification checklist
+
+Use this checklist before submitting a translation change:
+
+- [ ] The JSON file is valid and parses correctly.
+- [ ] The locale appears in the frontend language list when the app is run.
+- [ ] The translation loads without falling back to English unexpectedly.
+- [ ] Variables such as `{{name}}` and `{{count}}` still render correctly.
+- [ ] Buttons, labels, and notification copy fit the available UI space.
+- [ ] Backend notification templates include the locale if the locale is intended for notifications.
+
+## Desired locales
+
+The project already supports a strong base of global languages. Desired future additions include:
+
+- Portuguese (`pt`)
+- Spanish (`es`)
+- Arabic (`ar`) and Persian (`fa`) are already included in the frontend, but may still need additional coverage work.
+- Additional community-driven locales can be proposed through the normal contributor workflow.
+
+## Quick reference
+
+If you are only making a small translation update, follow this short path:
+
+1. Find the English key.
+2. Edit the matching translation in the target locale file.
+3. Save and run the app or tests.
+4. Submit the change for review.

--- a/docs/performance-scaling-guide.md
+++ b/docs/performance-scaling-guide.md
@@ -1,0 +1,128 @@
+# Performance Tuning and Scaling Guide
+
+This guide documents the scaling characteristics of Stellar-Save and the practical tuning levers that operators and contributors can use to keep the system responsive.
+
+## Architecture overview
+
+Stellar-Save uses three main layers that affect throughput and latency:
+
+1. The Stellar Soroban contract, which stores group state and executes core financial operations.
+2. The backend services, which expose APIs and process analytics, notifications, and indexing work.
+3. The event indexer and cache layer, which reduce repeated reads and keep dashboards up to date.
+
+The main scaling concerns are therefore:
+
+- contract gas usage and storage growth
+- backend cache hit rate and request latency
+- indexer throughput and event backlog
+- database read/write pressure and connection saturation
+
+## Caching strategy and invalidation model
+
+### Backend cache layers
+
+The backend uses Redis-backed caching for analytics and API responses. The cache helpers in [backend/src/redis.ts](../backend/src/redis.ts) and [backend/src/analytics_middleware.ts](../backend/src/analytics_middleware.ts) provide the basic primitives:
+
+- `get` and `set` for TTL-based key/value caching
+- `del`/`delPattern` for targeted invalidation
+- middleware that caches read-heavy analytics endpoints for a fixed TTL
+
+Typical TTLs in the current implementation:
+
+| Use case | TTL |
+|---|---:|
+| General analytics cache | 1 hour |
+| Landing-page stats cache | 5 minutes |
+| Contract state cache entries | configurable, short-lived |
+
+### Invalidation rules
+
+Cache entries should be invalidated when state-changing events occur. The contract event indexer is wired to invalidate relevant backend cache entries when mutation events are processed, as shown in [backend/src/contract_event_indexer.ts](../backend/src/contract_event_indexer.ts).
+
+Recommended invalidation patterns:
+
+- Invalidate per-group state when a contribution, payout, or membership event arrives.
+- Invalidate contract-wide aggregates when a new group is created or a major state transition happens.
+- Invalidate analytics caches after bulk writes or backfills.
+
+## Database scaling and indexing
+
+### Read/write pattern
+
+The backend and analytics services depend on a relational database for transactional state and on the contract event indexer for on-chain history. For production deployments, the safest path is:
+
+- keep the primary database for writes
+- add read replicas for analytics dashboards and reporting workloads
+- separate heavy reporting and bulk export jobs from the main application path
+
+### Indexing throughput tuning
+
+The event indexer should be tuned around three operational limits:
+
+- ledger processing rate from the RPC endpoint
+- database write throughput
+- downstream notification and analytics fan-out costs
+
+Recommended tuning steps:
+
+1. Increase the indexer worker concurrency only if the database can sustain it.
+2. Batch writes and commit in larger chunks where possible to reduce transaction overhead.
+3. Throttle or queue backfills during peak hours so user-facing traffic is not starved.
+4. Monitor the lag between the latest processed ledger and the current chain height.
+
+### Capacity guidance
+
+A practical starting point for a modest production deployment is:
+
+- 1 primary database instance
+- 1 read replica for dashboard/reporting traffic
+- 1 Redis instance for API and analytics cache
+- indexer workers sized to keep lag under a few minutes under normal conditions
+
+## Contract gas characteristics and optimization patterns
+
+The contract gas model is documented in [docs/performance-optimization.md](../docs/performance-optimization.md). The most important observations are:
+
+- write-heavy operations such as `join_group` are the most expensive and should be treated as premium operations
+- storage reads and writes dominate the cost profile
+- payout and membership lookups are effectively O(1) when the reverse index is used
+
+Optimization patterns that matter most:
+
+- minimize redundant storage reads in a single invocation
+- use compact types and avoid unnecessary storage keys
+- keep group sizes bounded to reduce iteration overhead
+- use the payout-position reverse index rather than scanning all members
+- prefer batched or paginated reads for large lists
+
+## Capacity planning from load-test results
+
+The existing performance docs provide a useful baseline for capacity planning:
+
+- a small group with 10 members and 10 cycles has a measured storage footprint in the low- to mid-kilobyte range
+- storage grows roughly linearly with the number of members and cycles
+- the dominant growth term comes from per-member contribution records
+
+For planning purposes:
+
+- assume the database and indexer will need to scale as the product of members × cycles grows
+- plan for more aggressive cache invalidation and read replica capacity when analytics traffic increases
+- set alert thresholds for contract event backlog, cache miss rate, and database replication lag
+
+## Recommended operating thresholds
+
+| Metric | Suggested alert threshold |
+|---|---:|
+| Redis cache hit rate | below 85% |
+| Indexer ledger lag | above 5 minutes |
+| Database CPU | above 70% sustained |
+| API p95 latency | above 800 ms |
+| Contract event backlog | growing continuously for 10+ minutes |
+
+## Practical rollout checklist
+
+- [ ] Confirm Redis is available and reachable from the backend.
+- [ ] Enable cache invalidation for all state-mutating contract events.
+- [ ] Add read-replica traffic splitting for analytics endpoints.
+- [ ] Track indexer lag and backlog in monitoring.
+- [ ] Run a load test before increasing the number of workers or replicas.

--- a/docs/self-hosting-guide.md
+++ b/docs/self-hosting-guide.md
@@ -1,0 +1,98 @@
+# Self-Hosting Guide for the Full Stack
+
+This guide helps a third party stand up a complete Stellar-Save deployment from infrastructure through the frontend and backend.
+
+## 1. Prerequisites
+
+Before you begin, prepare the following:
+
+- a Kubernetes or container-hosting environment for the backend and frontend
+- a PostgreSQL-compatible database
+- a Redis instance for caching and analytics middleware
+- access to a Stellar RPC endpoint for testnet or mainnet
+- a wallet or key pair for contract deployment
+- storage for persistent artifacts such as backups or uploads
+
+## 2. Infrastructure prerequisites
+
+Recommended baseline:
+
+- 1 application backend instance
+- 1 frontend deployment
+- 1 Redis instance
+- 1 PostgreSQL primary with optional read replica
+- 1 worker or cron job for the contract event indexer
+
+Terraform flow:
+
+1. Review the infrastructure definitions in the repo under the infra directory.
+2. Set the required environment variables for the target environment.
+3. Run the Terraform init/apply flow for the target environment.
+4. Capture the generated outputs for the database endpoint, Redis endpoint, and service URLs.
+
+Example flow:
+
+```bash
+cd infra
+terraform init
+terraform plan -var-file=environments/<env>.tfvars
+terraform apply -var-file=environments/<env>.tfvars
+```
+
+## 3. Contract deployment and configuration
+
+1. Build and deploy the Soroban contract using the deployment scripts and network settings in the repo.
+2. Record the deployed contract ID and network details.
+3. Configure the backend and frontend to use the deployed contract address.
+4. Ensure the contract deployment account has enough funds for the network.
+
+Required contract-related configuration:
+
+- `CONTRACT_ID`
+- `STELLAR_NETWORK`
+- `STELLAR_RPC_URL`
+- contract deployment secret or key material
+
+## 4. Backend and frontend deployment
+
+### Backend
+
+The backend needs the following environment variables:
+
+- `DATABASE_URL`
+- `REDIS_HOST`
+- `REDIS_PORT`
+- `JWT_SECRET`
+- `STELLAR_RPC_URL`
+- `CONTRACT_ID`
+- `NOTIFICATION_*` secrets if email or push delivery is enabled
+
+Deploy the backend service and verify that it can connect to the database and Redis.
+
+### Frontend
+
+The frontend should receive the backend API URL and contract configuration via environment variables:
+
+- `VITE_API_URL`
+- `VITE_CONTRACT_ID`
+- `VITE_STELLAR_NETWORK`
+
+## 5. Smoke-test checklist
+
+After the first deployment, verify the core flows in a fresh environment:
+
+- [ ] The frontend loads successfully.
+- [ ] The backend health endpoint responds.
+- [ ] The contract can be read from the configured network.
+- [ ] A user can create or join a group.
+- [ ] A contribution can be submitted successfully.
+- [ ] A payout flow completes without a contract error.
+- [ ] Notifications and emails are emitted where enabled.
+- [ ] Cache and indexer metrics are visible and healthy.
+
+## 6. Operational notes
+
+- Keep deployment secrets in a secure secret store rather than in source control.
+- Rotate keys and secret material on a regular basis.
+- Monitor contract event lag, cache hit rate, and database health after each deployment.
+- Use the staging or testnet environment first, then promote to production.

--- a/docs/storage-layout-v4-guide.md
+++ b/docs/storage-layout-v4-guide.md
@@ -1,0 +1,82 @@
+# Storage Layout and Data Model Guide for v4.0 Features
+
+This document extends the existing storage-layout guidance for the v4.0 capabilities around escrow, insurance, governance, badges, and recovery.
+
+## Scope and conventions
+
+The storage layout conventions in [docs/storage-layout.md](../docs/storage-layout.md) remain the same:
+
+- each storage key has a clear type and lifecycle
+- persistent storage is used for durable group and member state
+- instance storage remains the home for contract-wide configuration and counters
+- temporary storage is reserved for short-lived guards and rate-limit state
+
+## New v4.0 storage areas
+
+### Escrow storage
+
+| Key | Type | Purpose | Lifecycle |
+|---|---|---|---|
+| `EscrowBalance(group_id)` | `i128` | Tracks funds held in escrow for a specific group | Created when escrow is first funded; updated on deposits and releases |
+| `EscrowStatus(group_id)` | `u32` | Marks whether the escrow is pending, active, or released | Changes with escrow lifecycle transitions |
+
+### Insurance storage
+
+| Key | Type | Purpose | Lifecycle |
+|---|---|---|---|
+| `InsurancePool(group_id)` | `i128` | Maintains the insurance pool balance for a group | Grows from premiums or reserves; shrinks on claims |
+| `InsuranceClaim(group_id, member)` | `bool` | Tracks whether a member has already claimed insurance for a given group | Created when a claim is submitted; persists until the claim window closes |
+
+### Governance storage
+
+| Key | Type | Purpose | Lifecycle |
+|---|---|---|---|
+| `GovernanceProposal(group_id, proposal_id)` | `Proposal` | Stores the proposal payload, voting window, and outcome | Created on proposal submission; updated through voting and execution |
+| `GovernanceVote(group_id, proposal_id, member)` | `bool` | Tracks whether a member has voted for a proposal | Created on first vote; remains for the proposal lifecycle |
+
+### Badge storage
+
+| Key | Type | Purpose | Lifecycle |
+|---|---|---|---|
+| `BadgeAward(group_id, member)` | `u32` | Stores the badge bitmask or award count earned by a member | Updated when badge thresholds are crossed |
+| `BadgeThresholds()` | `Vec<u32>` | Stores the threshold sequence for achievement badges | Static once deployed, unless thresholds are reconfigured |
+
+### Recovery storage
+
+| Key | Type | Purpose | Lifecycle |
+|---|---|---|---|
+| `RecoveryRequest(group_id, member)` | `RecoveryRequest` | Stores recovery initiation details and approval state | Created on recovery start; cleared after finalization |
+| `RecoverySigner(group_id, member, signer)` | `bool` | Marks whether a signer is authorized for recovery | Created when signers are added; removed when revoked |
+
+## Storage relationship diagram
+
+```text
+ContractConfig
+  └── Group[group_id]
+        ├── EscrowBalance(group_id)
+        ├── EscrowStatus(group_id)
+        ├── InsurancePool(group_id)
+        ├── InsuranceClaim(group_id, member)
+        ├── GovernanceProposal(group_id, proposal_id)
+        ├── GovernanceVote(group_id, proposal_id, member)
+        ├── BadgeAward(group_id, member)
+        ├── RecoveryRequest(group_id, member)
+        └── RecoverySigner(group_id, member, signer)
+```
+
+## Migration implications
+
+Each addition has an operational migration impact:
+
+- Escrow fields should be initialized for existing groups to preserve compatibility with any historical escrow state.
+- Insurance state should be defaulted to zero or absent for existing groups until the feature is enabled.
+- Governance proposals and votes should be absent by default and should not break existing groups that never use governance.
+- Badge data should be calculated lazily or backfilled rather than assumed to exist for all historical members.
+- Recovery state should be opt-in and should not require any existing group to pre-populate signers.
+
+## Review checklist
+
+- [ ] Every new storage key has a documented type and purpose.
+- [ ] The lifecycle is described from creation to teardown.
+- [ ] Migration or backfill considerations are noted.
+- [ ] The storage layout remains consistent with the rest of the documentation.


### PR DESCRIPTION
## Summary
- add a full-stack self-hosting guide covering prerequisites, Terraform flow, contract deployment, service deployment, and smoke tests

Fixes #1130