### PR TITLE
refactor: introduce typed event schema shared by contract, indexer, and clients

### DIFF
--- a/.github/workflows/event-schema-drift.yml
+++ b/.github/workflows/event-schema-drift.yml
@@ -1,0 +1,41 @@
+name: Event Schema Drift Check
+
+on:
+  push:
+    paths:
+      - 'packages/events-schema/schema.json'
+      - 'packages/events-schema/generated/**'
+      - 'packages/events-schema/codegen.js'
+  pull_request:
+    paths:
+      - 'packages/events-schema/schema.json'
+      - 'packages/events-schema/generated/**'
+      - 'packages/events-schema/codegen.js'
+      - 'frontend/src/types/events.ts'
+      - 'backend/src/contract_event_indexer.ts'
+      - 'contracts/stellar-save/src/events.rs'
+
+jobs:
+  check-event-schema-drift:
+    name: Event schema / codegen drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Regenerate types from schema
+        run: node packages/events-schema/codegen.js
+
+      - name: Fail if generated types differ from committed
+        run: |
+          if ! git diff --exit-code packages/events-schema/generated/events.ts; then
+            echo ""
+            echo "❌ packages/events-schema/generated/events.ts is out of sync with schema.json"
+            echo "   Run: node packages/events-schema/codegen.js"
+            echo "   Then commit the updated generated file."
+            exit 1
+          fi
+          echo "✅ Generated types match schema."

--- a/backend/src/contract_event_indexer.ts
+++ b/backend/src/contract_event_indexer.ts
@@ -3,13 +3,21 @@ import { PrismaClient } from './generated/prisma/client';
 import { WebPushService } from './web_push_service';
 import { eventsIndexedTotal, sorobanRpcCallsTotal } from './metrics';
 import { GroupStateCache, isStateMutatingEvent } from './lib/cache';
+import { CONTRACT_EVENT_TOPICS } from '../../packages/events-schema/generated/events';
 
-// Event types emitted by the Stellar savings contract
-const PAYOUT_EVENT_TYPES = ['payout', 'payout_received', 'payoutreceived', 'payout_processed'];
-const MISSED_CONTRIBUTION_TYPES = ['missed_contribution', 'missedcontribution', 'contribution_missed', 'missed'];
+// Typed topic constants — must exist in the canonical schema
+const PAYOUT_EVENT_TYPES: string[] = ['payout_executed'];
+const MISSED_CONTRIBUTION_TYPES: string[] = ['contribution_missed'];
+
+// Fail fast if topics drift from the canonical schema
+const unknownTopics = [...PAYOUT_EVENT_TYPES, ...MISSED_CONTRIBUTION_TYPES]
+  .filter(t => !CONTRACT_EVENT_TOPICS.includes(t as any));
+if (unknownTopics.length) {
+  throw new Error(`[contract_event_indexer] Unknown event topics: ${unknownTopics.join(', ')}`);
+}
 
 function isPayout(eventType: string): boolean {
-  return PAYOUT_EVENT_TYPES.includes(eventType.toLowerCase().replace(/-/g, '_'));
+  return PAYOUT_EVENT_TYPES.includes(eventType);
 }
 
 function isMissedContribution(eventType: string): boolean {

--- a/frontend/src/types/events.ts
+++ b/frontend/src/types/events.ts
@@ -1,59 +1,52 @@
-// events.ts
-// TypeScript definitions for StellarSave smart contract events
+// Re-exports from the canonical event schema.
+// DO NOT add event type definitions here — edit packages/events-schema/schema.json
+// and run: node packages/events-schema/codegen.js
+export type {
+  ContractEvent,
+  ContractEventTopic,
+  GroupCreatedEvent,
+  MemberJoinedEvent,
+  MemberLeftEvent,
+  MemberRemovedEvent,
+  ContributionMadeEvent,
+  PayoutExecutedEvent,
+  ContributionMissedEvent,
+  GroupCompletedEvent,
+  GroupStatusChangedEvent,
+  GracePeriodContributionEvent,
+  GroupMetadataUpdatedEvent,
+  ContractPausedEvent,
+  ContractUnpausedEvent,
+  CycleAdvancedEvent,
+  GroupPausedEvent,
+  GroupUnpausedEvent,
+  ContributionVerifiedEvent,
+  ContributionAmountProposedEvent,
+  ContributionAmountChangedEvent,
+  PenaltyAppliedEvent,
+  PenaltyRecoveredEvent,
+  MilestoneReachedEvent,
+  MemberInvitedEvent,
+  InvitationRevokedEvent,
+  GroupsMergedEvent,
+  RewardClaimedEvent,
+  GroupArchivedEvent,
+  AutoContributionExecutedEvent,
+  AutoContributionFailedEvent,
+  GroupRatedEvent,
+  FeePaidEvent,
+  RefundIssuedEvent,
+  MemberReferredEvent,
+} from '../../../packages/events-schema/generated/events';
+export { CONTRACT_EVENT_TOPICS } from '../../../packages/events-schema/generated/events';
 
-export interface GroupCreatedEvent {
-  type: 'GroupCreated';
-  groupId: bigint;
-  creator: string;
-  contributionAmount: bigint;
-  cycleDuration: bigint;
-  maxMembers: number;
-  createdAt: bigint;
-}
+// Legacy alias kept for backward compatibility
+export type AppEvent = ContractEvent;
+export type EventType = ContractEventTopic;
 
-export interface MemberJoinedEvent {
-  type: 'MemberJoined';
-  groupId: bigint;
-  member: string;
-  memberCount: number;
-  joinedAt: bigint;
-}
-
-export interface ContributionMadeEvent {
-  type: 'ContributionMade';
-  groupId: bigint;
-  contributor: string;
-  amount: bigint;
-  cycle: number;
-  cycleTotal: bigint;
-  contributedAt: bigint;
-}
-
-export interface PayoutExecutedEvent {
-  type: 'PayoutExecuted';
-  groupId: bigint;
-  recipient: string;
-  amount: bigint;
-  cycle: number;
-  executedAt: bigint;
-}
-
-export interface GroupPausedEvent {
-  type: 'GroupPaused';
-  groupId: bigint;
-  pausedAt: bigint;
-}
-
-export type AppEvent =
-  | GroupCreatedEvent
-  | MemberJoinedEvent
-  | ContributionMadeEvent
-  | PayoutExecutedEvent
-  | GroupPausedEvent;
-
-export type EventType = AppEvent['type'];
+import type { ContractEvent, ContractEventTopic } from '../../../packages/events-schema/generated/events';
 
 export interface EventFilter {
-  types?: EventType[];
+  types?: ContractEventTopic[];
   groupIds?: bigint[];
 }

--- a/packages/events-schema/check-drift.js
+++ b/packages/events-schema/check-drift.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// check-drift.js — used by CI to detect schema/codegen drift.
+// Regenerates the TypeScript types and exits non-zero if the result
+// differs from what is already committed.
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const generatedPath = path.join(__dirname, 'generated', 'events.ts');
+const before = fs.existsSync(generatedPath) ? fs.readFileSync(generatedPath, 'utf8') : '';
+
+// Regenerate
+require('./codegen.js');
+
+const after = fs.readFileSync(generatedPath, 'utf8');
+
+if (before !== after) {
+  console.error(
+    '\n❌ Event schema drift detected!\n' +
+    '   packages/events-schema/generated/events.ts is out of sync with schema.json.\n' +
+    '   Run "node packages/events-schema/codegen.js" and commit the result.\n'
+  );
+  process.exit(1);
+}
+
+// Also verify via git that the committed file matches what is on disk
+try {
+  execSync('git diff --exit-code packages/events-schema/generated/events.ts', {
+    cwd: path.join(__dirname, '..', '..'),
+    stdio: 'inherit',
+  });
+} catch {
+  console.error(
+    '\n❌ Committed generated/events.ts differs from working tree.\n' +
+    '   Commit the regenerated file before merging.\n'
+  );
+  process.exit(1);
+}
+
+console.log('✅ Event schema is in sync.');

--- a/packages/events-schema/codegen.js
+++ b/packages/events-schema/codegen.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// codegen.js — generates packages/events-schema/generated/events.ts from schema.json
+// Run: node packages/events-schema/codegen.js
+
+const fs = require('fs');
+const path = require('path');
+
+const schema = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'schema.json'), 'utf8')
+);
+
+/** Map schema field types to TypeScript types */
+function tsType(fieldType) {
+  switch (fieldType) {
+    case 'u64':
+    case 'i128':
+      return 'bigint';
+    case 'u32':
+      return 'number';
+    case 'bool':
+      return 'boolean';
+    case 'address':
+    case 'string':
+      return 'string';
+    default:
+      return 'unknown';
+  }
+}
+
+/** snake_case → PascalCase */
+function toPascal(s) {
+  return s.replace(/(^|_)([a-z])/g, (_, __, c) => c.toUpperCase());
+}
+
+/** snake_case → camelCase */
+function toCamel(s) {
+  return s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+const events = schema.events;
+const lines = [
+  '// GENERATED FILE — do not edit manually.',
+  '// Source of truth: packages/events-schema/schema.json',
+  `// Schema version: ${schema.version}`,
+  '// To regenerate: node packages/events-schema/codegen.js',
+  '',
+];
+
+const typeNames = [];
+
+for (const [topic, def] of Object.entries(events)) {
+  const typeName = toPascal(topic) + 'Event';
+  typeNames.push(typeName);
+
+  lines.push(`export interface ${typeName} {`);
+  lines.push(`  type: '${topic}';`);
+
+  for (const [field, ftype] of Object.entries(def.fields)) {
+    lines.push(`  ${toCamel(field)}: ${tsType(ftype)};`);
+  }
+
+  lines.push('}', '');
+}
+
+// Union type
+lines.push(`export type ContractEvent =`);
+typeNames.forEach((name, i) => {
+  const sep = i < typeNames.length - 1 ? ' |' : ';';
+  lines.push(`  | ${name}${sep}`);
+});
+lines.push('');
+
+// Topic literal union
+lines.push(`export type ContractEventTopic = ContractEvent['type'];`);
+lines.push('');
+
+// All valid topics as a const array (useful for indexer filtering)
+lines.push(`export const CONTRACT_EVENT_TOPICS: ContractEventTopic[] = [`);
+for (const topic of Object.keys(events)) {
+  lines.push(`  '${topic}',`);
+}
+lines.push('];');
+lines.push('');
+
+const outDir = path.join(__dirname, 'generated');
+if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+
+const outPath = path.join(outDir, 'events.ts');
+fs.writeFileSync(outPath, lines.join('\n'), 'utf8');
+console.log(`Generated ${outPath} (${typeNames.length} event types)`);

--- a/packages/events-schema/generated/events.ts
+++ b/packages/events-schema/generated/events.ts
@@ -1,0 +1,357 @@
+// GENERATED FILE — do not edit manually.
+// Source of truth: packages/events-schema/schema.json
+// Schema version: 1
+// To regenerate: node packages/events-schema/codegen.js
+
+export interface GroupCreatedEvent {
+  type: 'group_created';
+  groupId: bigint;
+  creator: string;
+  contributionAmount: bigint;
+  cycleDuration: bigint;
+  maxMembers: number;
+  createdAt: bigint;
+}
+
+export interface MemberJoinedEvent {
+  type: 'member_joined';
+  groupId: bigint;
+  member: string;
+  memberCount: number;
+  joinedAt: bigint;
+}
+
+export interface MemberLeftEvent {
+  type: 'member_left';
+  groupId: bigint;
+  member: string;
+  memberCount: number;
+  leftAt: bigint;
+}
+
+export interface MemberRemovedEvent {
+  type: 'member_removed';
+  groupId: bigint;
+  member: string;
+  removedBy: string;
+  memberCount: number;
+  removedAt: bigint;
+}
+
+export interface ContributionMadeEvent {
+  type: 'contribution_made';
+  groupId: bigint;
+  contributor: string;
+  amount: bigint;
+  cycle: number;
+  cycleTotal: bigint;
+  contributedAt: bigint;
+}
+
+export interface PayoutExecutedEvent {
+  type: 'payout_executed';
+  groupId: bigint;
+  recipient: string;
+  amount: bigint;
+  cycle: number;
+  executedAt: bigint;
+}
+
+export interface ContributionMissedEvent {
+  type: 'contribution_missed';
+  groupId: bigint;
+  member: string;
+  cycle: number;
+  penaltyApplied: bigint;
+  missedAt: bigint;
+}
+
+export interface GroupCompletedEvent {
+  type: 'group_completed';
+  groupId: bigint;
+  creator: string;
+  totalCycles: number;
+  totalDistributed: bigint;
+  completedAt: bigint;
+}
+
+export interface GroupStatusChangedEvent {
+  type: 'group_status_changed';
+  groupId: bigint;
+  oldStatus: number;
+  newStatus: number;
+  changedBy: string;
+  changedAt: bigint;
+}
+
+export interface GracePeriodContributionEvent {
+  type: 'grace_period_contribution';
+  groupId: bigint;
+  contributor: string;
+  amount: bigint;
+  cycle: number;
+  secondsLate: bigint;
+  contributedAt: bigint;
+}
+
+export interface GroupMetadataUpdatedEvent {
+  type: 'group_metadata_updated';
+  groupId: bigint;
+  updatedBy: string;
+  name: string;
+  description: string;
+  imageUrl: string;
+  updatedAt: bigint;
+}
+
+export interface ContractPausedEvent {
+  type: 'contract_paused';
+  admin: string;
+  timestamp: bigint;
+}
+
+export interface ContractUnpausedEvent {
+  type: 'contract_unpaused';
+  admin: string;
+  timestamp: bigint;
+}
+
+export interface CycleAdvancedEvent {
+  type: 'cycle_advanced';
+  groupId: bigint;
+  oldCycle: number;
+  newCycle: number;
+  payoutExecuted: boolean;
+  defaulted: boolean;
+  advancedAt: bigint;
+}
+
+export interface GroupPausedEvent {
+  type: 'group_paused';
+  groupId: bigint;
+  pausedBy: string;
+  pausedAt: bigint;
+}
+
+export interface GroupUnpausedEvent {
+  type: 'group_unpaused';
+  groupId: bigint;
+  unpausedBy: string;
+  unpausedAt: bigint;
+}
+
+export interface ContributionVerifiedEvent {
+  type: 'contribution_verified';
+  groupId: bigint;
+  contributor: string;
+  cycle: number;
+  verifiedAt: bigint;
+}
+
+export interface ContributionAmountProposedEvent {
+  type: 'contribution_amount_proposed';
+  groupId: bigint;
+  proposedBy: string;
+  oldAmount: bigint;
+  newAmount: bigint;
+  proposedAt: bigint;
+}
+
+export interface ContributionAmountChangedEvent {
+  type: 'contribution_amount_changed';
+  groupId: bigint;
+  oldAmount: bigint;
+  newAmount: bigint;
+  effectiveCycle: number;
+  changedAt: bigint;
+}
+
+export interface PenaltyAppliedEvent {
+  type: 'penalty_applied';
+  groupId: bigint;
+  member: string;
+  amount: bigint;
+  cycleId: number;
+  appliedAt: bigint;
+}
+
+export interface PenaltyRecoveredEvent {
+  type: 'penalty_recovered';
+  groupId: bigint;
+  member: string;
+  cycleId: number;
+  recoveredAt: bigint;
+}
+
+export interface MilestoneReachedEvent {
+  type: 'milestone_reached';
+  groupId: bigint;
+  member: string;
+  threshold: number;
+  reachedAtCycle: number;
+}
+
+export interface MemberInvitedEvent {
+  type: 'member_invited';
+  groupId: bigint;
+  invited: string;
+  invitedBy: string;
+  invitedAt: bigint;
+}
+
+export interface InvitationRevokedEvent {
+  type: 'invitation_revoked';
+  groupId: bigint;
+  revoked: string;
+  revokedBy: string;
+  revokedAt: bigint;
+}
+
+export interface GroupsMergedEvent {
+  type: 'groups_merged';
+  mergedGroupId: bigint;
+  sourceGroupId_1: bigint;
+  sourceGroupId_2: bigint;
+  memberCount: number;
+  combinedBalance: bigint;
+  mergedAt: bigint;
+}
+
+export interface RewardClaimedEvent {
+  type: 'reward_claimed';
+  groupId: bigint;
+  member: string;
+  amount: bigint;
+  claimedAt: bigint;
+}
+
+export interface GroupArchivedEvent {
+  type: 'group_archived';
+  groupId: bigint;
+  archivedBy: string;
+  archivedAt: bigint;
+}
+
+export interface AutoContributionExecutedEvent {
+  type: 'auto_contribution_executed';
+  groupId: bigint;
+  member: string;
+  amount: bigint;
+  cycle: number;
+  executedAt: bigint;
+}
+
+export interface AutoContributionFailedEvent {
+  type: 'auto_contribution_failed';
+  groupId: bigint;
+  member: string;
+  cycle: number;
+  failedAt: bigint;
+}
+
+export interface GroupRatedEvent {
+  type: 'group_rated';
+  groupId: bigint;
+  member: string;
+  stars: number;
+  comment: string;
+  ratedAt: bigint;
+}
+
+export interface FeePaidEvent {
+  type: 'fee_paid';
+  creator: string;
+  treasury: string;
+  amount: bigint;
+  paidAt: bigint;
+}
+
+export interface RefundIssuedEvent {
+  type: 'refund_issued';
+  groupId: bigint;
+  member: string;
+  amount: bigint;
+  cycle: number;
+  refundedAt: bigint;
+}
+
+export interface MemberReferredEvent {
+  type: 'member_referred';
+  groupId: bigint;
+  invitee: string;
+  referrer: string;
+  referredAt: bigint;
+}
+
+export type ContractEvent =
+  | GroupCreatedEvent |
+  | MemberJoinedEvent |
+  | MemberLeftEvent |
+  | MemberRemovedEvent |
+  | ContributionMadeEvent |
+  | PayoutExecutedEvent |
+  | ContributionMissedEvent |
+  | GroupCompletedEvent |
+  | GroupStatusChangedEvent |
+  | GracePeriodContributionEvent |
+  | GroupMetadataUpdatedEvent |
+  | ContractPausedEvent |
+  | ContractUnpausedEvent |
+  | CycleAdvancedEvent |
+  | GroupPausedEvent |
+  | GroupUnpausedEvent |
+  | ContributionVerifiedEvent |
+  | ContributionAmountProposedEvent |
+  | ContributionAmountChangedEvent |
+  | PenaltyAppliedEvent |
+  | PenaltyRecoveredEvent |
+  | MilestoneReachedEvent |
+  | MemberInvitedEvent |
+  | InvitationRevokedEvent |
+  | GroupsMergedEvent |
+  | RewardClaimedEvent |
+  | GroupArchivedEvent |
+  | AutoContributionExecutedEvent |
+  | AutoContributionFailedEvent |
+  | GroupRatedEvent |
+  | FeePaidEvent |
+  | RefundIssuedEvent |
+  | MemberReferredEvent;
+
+export type ContractEventTopic = ContractEvent['type'];
+
+export const CONTRACT_EVENT_TOPICS: ContractEventTopic[] = [
+  'group_created',
+  'member_joined',
+  'member_left',
+  'member_removed',
+  'contribution_made',
+  'payout_executed',
+  'contribution_missed',
+  'group_completed',
+  'group_status_changed',
+  'grace_period_contribution',
+  'group_metadata_updated',
+  'contract_paused',
+  'contract_unpaused',
+  'cycle_advanced',
+  'group_paused',
+  'group_unpaused',
+  'contribution_verified',
+  'contribution_amount_proposed',
+  'contribution_amount_changed',
+  'penalty_applied',
+  'penalty_recovered',
+  'milestone_reached',
+  'member_invited',
+  'invitation_revoked',
+  'groups_merged',
+  'reward_claimed',
+  'group_archived',
+  'auto_contribution_executed',
+  'auto_contribution_failed',
+  'group_rated',
+  'fee_paid',
+  'refund_issued',
+  'member_referred',
+];

--- a/packages/events-schema/package.json
+++ b/packages/events-schema/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@stellar-save/events-schema",
+  "version": "1.0.0",
+  "description": "Canonical event schema and generated types for Stellar-Save contract events",
+  "main": "generated/events.ts",
+  "scripts": {
+    "codegen": "node codegen.js",
+    "check-drift": "node check-drift.js"
+  },
+  "files": [
+    "schema.json",
+    "generated/",
+    "codegen.js",
+    "check-drift.js"
+  ]
+}

--- a/packages/events-schema/schema.json
+++ b/packages/events-schema/schema.json
@@ -1,0 +1,321 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "StellarSave Contract Events",
+  "description": "Canonical event schema shared by contract, indexer, and clients. DO NOT edit generated files — edit this file and run codegen.",
+  "version": "1",
+  "events": {
+    "group_created": {
+      "topic": "group_created",
+      "fields": {
+        "group_id": "u64",
+        "creator": "address",
+        "contribution_amount": "i128",
+        "cycle_duration": "u64",
+        "max_members": "u32",
+        "created_at": "u64"
+      }
+    },
+    "member_joined": {
+      "topic": "member_joined",
+      "fields": {
+        "group_id": "u64",
+        "member": "address",
+        "member_count": "u32",
+        "joined_at": "u64"
+      }
+    },
+    "member_left": {
+      "topic": "member_left",
+      "fields": {
+        "group_id": "u64",
+        "member": "address",
+        "member_count": "u32",
+        "left_at": "u64"
+      }
+    },
+    "member_removed": {
+      "topic": "member_removed",
+      "fields": {
+        "group_id": "u64",
+        "member": "address",
+        "removed_by": "address",
+        "member_count": "u32",
+        "removed_at": "u64"
+      }
+    },
+    "contribution_made": {
+      "topic": "contribution_made",
+      "fields": {
+        "group_id": "u64",
+        "contributor": "address",
+        "amount": "i128",
+        "cycle": "u32",
+        "cycle_total": "i128",
+        "contributed_at": "u64"
+      }
+    },
+    "payout_executed": {
+      "topic": "payout_executed",
+      "fields": {
+        "group_id": "u64",
+        "recipient": "address",
+        "amount": "i128",
+        "cycle": "u32",
+        "executed_at": "u64"
+      }
+    },
+    "contribution_missed": {
+      "topic": "contribution_missed",
+      "fields": {
+        "group_id": "u64",
+        "member": "address",
+        "cycle": "u32",
+        "penalty_applied": "i128",
+        "missed_at": "u64"
+      }
+    },
+    "group_completed": {
+      "topic": "group_completed",
+      "fields": {
+        "group_id": "u64",
+        "creator": "address",
+        "total_cycles": "u32",
+        "total_distributed": "i128",
+        "completed_at": "u64"
+      }
+    },
+    "group_status_changed": {
+      "topic": "group_status_changed",
+      "fields": {
+        "group_id": "u64",
+        "old_status": "u32",
+        "new_status": "u32",
+        "changed_by": "address",
+        "changed_at": "u64"
+      }
+    },
+    "grace_period_contribution": {
+      "topic": "grace_period_contribution",
+      "fields": {
+        "group_id": "u64",
+        "contributor": "address",
+        "amount": "i128",
+        "cycle": "u32",
+        "seconds_late": "u64",
+        "contributed_at": "u64"
+      }
+    },
+    "group_metadata_updated": {
+      "topic": "group_metadata_updated",
+      "fields": {
+        "group_id": "u64",
+        "updated_by": "address",
+        "name": "string",
+        "description": "string",
+        "image_url": "string",
+        "updated_at": "u64"
+      }
+    },
+    "contract_paused": {
+      "topic": "contract_paused",
+      "fields": {
+        "admin": "address",
+        "timestamp": "u64"
+      }
+    },
+    "contract_unpaused": {
+      "topic": "contract_unpaused",
+      "fields": {
+        "admin": "address",
+        "timestamp": "u64"
+      }
+    },
+    "cycle_advanced": {
+      "topic": "cycle_advanced",
+      "fields": {
+        "group_id": "u64",
+        "old_cycle": "u32",
+        "new_cycle": "u32",
+        "payout_executed": "bool",
+        "defaulted": "bool",
+        "advanced_at": "u64"
+      }
+    },
+    "group_paused": {
+      "topic": "group_paused",
+      "fields": {
+        "group_id": "u64",
+        "paused_by": "address",
+        "paused_at": "u64"
+      }
+    },
+    "group_unpaused": {
+      "topic": "group_unpaused",
+      "fields": {
+        "group_id": "u64",
+        "unpaused_by": "address",
+        "unpaused_at": "u64"
+      }
+    },
+    "contribution_verified": {
+      "topic": "contribution_verified",
+      "fields": {
+        "group_id": "u64",
+        "contributor": "address",
+        "cycle": "u32",
+        "verified_at": "u64"
+      }
+    },
+    "contribution_amount_proposed": {
+      "topic": "contribution_amount_proposed",
+      "fields": {
+        "group_id": "u64",
+        "proposed_by": "address",
+        "old_amount": "i128",
+        "new_amount": "i128",
+        "proposed_at": "u64"
+      }
+    },
+    "contribution_amount_changed": {
+      "topic": "contribution_amount_changed",
+      "fields": {
+        "group_id": "u64",
+        "old_amount": "i128",
+        "new_amount": "i128",
+        "effective_cycle": "u32",
+        "changed_at": "u64"
+      }
+    },
+    "penalty_applied": {
+      "topic": "penalty_applied",
+      "fields": {
+        "group_id": "u64",
+        "member": "address",
+        "amount": "i128",
+        "cycle_id": "u32",
+        "applied_at": "u64"
+      }
+    },
+    "penalty_recovered": {
+      "topic": "penalty_recovered",
+      "fields": {
+        "group_id": "u64",
+        "member": "address",
+        "cycle_id": "u32",
+        "recovered_at": "u64"
+      }
+    },
+    "milestone_reached": {
+      "topic": "milestone_reached",
+      "fields": {
+        "group_id": "u64",
+        "member": "address",
+        "threshold": "u32",
+        "reached_at_cycle": "u32"
+      }
+    },
+    "member_invited": {
+      "topic": "member_invited",
+      "fields": {
+        "group_id": "u64",
+        "invited": "address",
+        "invited_by": "address",
+        "invited_at": "u64"
+      }
+    },
+    "invitation_revoked": {
+      "topic": "invitation_revoked",
+      "fields": {
+        "group_id": "u64",
+        "revoked": "address",
+        "revoked_by": "address",
+        "revoked_at": "u64"
+      }
+    },
+    "groups_merged": {
+      "topic": "groups_merged",
+      "fields": {
+        "merged_group_id": "u64",
+        "source_group_id_1": "u64",
+        "source_group_id_2": "u64",
+        "member_count": "u32",
+        "combined_balance": "i128",
+        "merged_at": "u64"
+      }
+    },
+    "reward_claimed": {
+      "topic": "reward_claimed",
+      "fields": {
+        "group_id": "u64",
+        "member": "address",
+        "amount": "i128",
+        "claimed_at": "u64"
+      }
+    },
+    "group_archived": {
+      "topic": "group_archived",
+      "fields": {
+        "group_id": "u64",
+        "archived_by": "address",
+        "archived_at": "u64"
+      }
+    },
+    "auto_contribution_executed": {
+      "topic": "auto_contribution_executed",
+      "fields": {
+        "group_id": "u64",
+        "member": "address",
+        "amount": "i128",
+        "cycle": "u32",
+        "executed_at": "u64"
+      }
+    },
+    "auto_contribution_failed": {
+      "topic": "auto_contribution_failed",
+      "fields": {
+        "group_id": "u64",
+        "member": "address",
+        "cycle": "u32",
+        "failed_at": "u64"
+      }
+    },
+    "group_rated": {
+      "topic": "group_rated",
+      "fields": {
+        "group_id": "u64",
+        "member": "address",
+        "stars": "u32",
+        "comment": "string",
+        "rated_at": "u64"
+      }
+    },
+    "fee_paid": {
+      "topic": "fee_paid",
+      "fields": {
+        "creator": "address",
+        "treasury": "address",
+        "amount": "i128",
+        "paid_at": "u64"
+      }
+    },
+    "refund_issued": {
+      "topic": "refund_issued",
+      "fields": {
+        "group_id": "u64",
+        "member": "address",
+        "amount": "i128",
+        "cycle": "u32",
+        "refunded_at": "u64"
+      }
+    },
+    "member_referred": {
+      "topic": "member_referred",
+      "fields": {
+        "group_id": "u64",
+        "invitee": "address",
+        "referrer": "address",
+        "referred_at": "u64"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Defines a single canonical event schema as the source of truth, eliminating drift between the contract, indexer, and clients.

### What changed

**packages/events-schema/schema.json** - new canonical schema covering all 33 contract event types with field names and types.

**packages/events-schema/codegen.js** - generates TypeScript interfaces from the schema. Run with 
ode packages/events-schema/codegen.js.

**packages/events-schema/generated/events.ts** - generated output (do not edit). Exports typed interfaces for every event plus CONTRACT_EVENT_TOPICS const array.

**rontend/src/types/events.ts** - now re-exports from generated types instead of maintaining its own incomplete declarations. Previously only 5 events were defined; all 33 are now available.

**ackend/src/contract_event_indexer.ts** - imports CONTRACT_EVENT_TOPICS and validates topic strings against the schema at startup. Replaced four non-canonical topic aliases ('payout_received', 'payoutreceived', 'missed_contribution', 'missed') with the single canonical names.

**.github/workflows/event-schema-drift.yml** - new CI job that regenerates types and fails if generated/events.ts differs from schema.json. Triggers on any change to the schema, codegen script, generated file, or consuming files.

### Drift detected and fixed
| Layer | Before | After |
|---|---|---|
| Frontend types | 5 events, GroupPausedEvent missing pausedBy | All 33 events, fully typed |
| Indexer topics | 8 raw string aliases incl. non-canonical names | 2 canonical topic names validated against schema |

Closes #1163