### PR TITLE
refactor(contracts): add reusable membership guard and cycle-timestam…

### DIFF
--- a/contracts/stellar-save/src/auth.rs
+++ b/contracts/stellar-save/src/auth.rs
@@ -37,12 +37,33 @@ pub fn require_creator(caller: &Address, group: &Group) -> Result<(), StellarSav
 /// Require caller authentication and verify caller is a member of the group.
 pub fn require_member(env: &Env, group_id: u64, caller: &Address) -> Result<(), StellarSaveError> {
     caller.require_auth();
-    let member_key = StorageKeyBuilder::member_profile(group_id, caller.clone());
-    let is_member = env.storage().persistent().has(&member_key);
-    if !is_member {
+    if !is_active_member(env, group_id, caller) {
         return Err(StellarSaveError::NotMember);
     }
     Ok(())
+}
+
+/// Checks whether `address` holds a member profile for `group_id`.
+///
+/// This is the single, canonical membership check used by all call sites
+/// across the contract. It performs a constant-time storage `has()` without
+/// deserialising the full `MemberProfile`, keeping gas costs minimal.
+///
+/// # Arguments
+/// * `env`      - Soroban environment
+/// * `group_id` - Group to check membership in
+/// * `address`  - Address to test
+///
+/// # Returns
+/// `true` if a `MemberProfile` exists for `(group_id, address)`, `false`
+/// otherwise (including non-existent groups or zero `group_id`).
+///
+/// # Note
+/// This function does **not** require caller authentication — it is a pure
+/// read-only query. For guarded write operations, use `require_member`.
+pub fn is_active_member(env: &Env, group_id: u64, address: &Address) -> bool {
+    let member_key = StorageKeyBuilder::member_profile(group_id, address.clone());
+    env.storage().persistent().has(&member_key)
 }
 
 #[cfg(test)]
@@ -81,6 +102,17 @@ mod tests {
         );
     }
 
+    /// Build a minimal valid MemberProfile for test setup.
+    fn make_profile(env: &Env, address: Address, group_id: u64) -> crate::types::MemberProfile {
+        crate::types::MemberProfile {
+            address,
+            group_id,
+            payout_position: 0,
+            joined_at: 1000,
+            auto_contribute_enabled: false,
+        }
+    }
+
     #[test]
     fn test_auth_member_guard() {
         let env = Env::default();
@@ -91,11 +123,7 @@ mod tests {
         env.mock_all_auths();
 
         let member_key = StorageKeyBuilder::member_profile(group_id, member.clone());
-        let profile = crate::types::MemberProfile {
-            address: member.clone(),
-            joined_at: 1000,
-            status: crate::types::MemberStatus::Active,
-        };
+        let profile = make_profile(&env, member.clone(), group_id);
         env.storage().persistent().set(&member_key, &profile);
 
         // Positive case
@@ -106,6 +134,69 @@ mod tests {
             require_member(&env, group_id, &non_member),
             Err(StellarSaveError::NotMember)
         );
+    }
+
+    // ── is_active_member edge-case tests ─────────────────────────────────────
+
+    #[test]
+    fn test_is_active_member_returns_true_for_stored_profile() {
+        let env = Env::default();
+        let address = Address::generate(&env);
+        let group_id = 42u64;
+
+        let key = StorageKeyBuilder::member_profile(group_id, address.clone());
+        env.storage().persistent().set(&key, &make_profile(&env, address.clone(), group_id));
+
+        assert!(is_active_member(&env, group_id, &address));
+    }
+
+    #[test]
+    fn test_is_active_member_returns_false_for_non_member() {
+        let env = Env::default();
+        let address = Address::generate(&env);
+        let group_id = 42u64;
+
+        // No profile stored
+        assert!(!is_active_member(&env, group_id, &address));
+    }
+
+    #[test]
+    fn test_is_active_member_non_existent_group_returns_false() {
+        let env = Env::default();
+        let address = Address::generate(&env);
+        // group_id 9999 was never created
+        assert!(!is_active_member(&env, 9999, &address));
+    }
+
+    #[test]
+    fn test_is_active_member_zero_group_id_returns_false() {
+        let env = Env::default();
+        let address = Address::generate(&env);
+        // group_id 0 is invalid — no member profile can be stored there
+        assert!(!is_active_member(&env, 0, &address));
+    }
+
+    #[test]
+    fn test_is_active_member_no_auth_required() {
+        // Calling is_active_member without mock_all_auths must not panic.
+        let env = Env::default();
+        let address = Address::generate(&env);
+        // Should succeed (returns false) without any authentication setup
+        assert!(!is_active_member(&env, 1, &address));
+    }
+
+    #[test]
+    fn test_is_active_member_different_group_same_address_isolated() {
+        let env = Env::default();
+        let address = Address::generate(&env);
+
+        // Store profile only for group 1
+        let key = StorageKeyBuilder::member_profile(1, address.clone());
+        env.storage().persistent().set(&key, &make_profile(&env, address.clone(), 1));
+
+        assert!(is_active_member(&env, 1, &address));
+        // Group 2 should return false even though address is in group 1
+        assert!(!is_active_member(&env, 2, &address));
     }
 
     #[test]

--- a/contracts/stellar-save/src/contract.rs
+++ b/contracts/stellar-save/src/contract.rs
@@ -24,6 +24,22 @@ pub struct StellarSaveContract;
 
 #[contractimpl]
 impl StellarSaveContract {
+    /// Returns the current ledger timestamp as Unix epoch seconds.
+    ///
+    /// This is the canonical time source for all time-dependent logic in the
+    /// contract. It performs no storage reads or writes, does not check
+    /// authorization, and does not inspect pause state.
+    ///
+    /// Internal callers that currently call `env.ledger().timestamp()` inline
+    /// may delegate to this function to make the time source explicit and
+    /// auditable in one place.
+    ///
+    /// # Returns
+    /// The current ledger timestamp as `u64` (Unix epoch seconds).
+    pub fn get_current_timestamp(env: Env) -> u64 {
+        env.ledger().timestamp()
+    }
+
     /// Validates that a contribution amount matches the group's required contribution amount.
     ///
     /// This helper function ensures that members contribute the exact amount specified

--- a/contracts/stellar-save/src/helpers.rs
+++ b/contracts/stellar-save/src/helpers.rs
@@ -434,6 +434,48 @@ mod tests {
         assert_eq!(result, Ok(max_members - 1));
     }
 
+    #[test]
+    fn test_calculate_current_cycle_clock_skew_returns_zero() {
+        // Guard: if current_time < started_at (e.g. due to clock skew) → Ok(0), no panic.
+        let env = Env::default();
+        let started_at: u64 = 5000;
+        let cycle_duration: u64 = 604800;
+
+        let creator = Address::generate(&env);
+        let mut group = Group::new(1, creator, 1_000_000, cycle_duration, 5, 2, started_at, 0);
+        group.member_count = 2;
+        group.activate(started_at);
+        store_group(&env, &group);
+
+        // Set ledger time to before started_at
+        env.ledger().set_timestamp(started_at - 1);
+        let result = calculate_current_cycle(&env, 1);
+        assert_eq!(result, Ok(0));
+    }
+
+    #[test]
+    fn test_calculate_current_cycle_exactly_one_second_before_first_boundary() {
+        // Boundary: exactly (cycle_duration - 1) seconds elapsed → still cycle 0
+        let env = Env::default();
+        let started_at: u64 = 1000;
+        let cycle_duration: u64 = 86400; // 1 day
+
+        let creator = Address::generate(&env);
+        let mut group = Group::new(1, creator, 1_000_000, cycle_duration, 5, 2, started_at, 0);
+        group.member_count = 2;
+        group.activate(started_at);
+        store_group(&env, &group);
+
+        env.ledger().set_timestamp(started_at + cycle_duration - 1);
+        let result = calculate_current_cycle(&env, 1);
+        assert_eq!(result, Ok(0));
+
+        // Exactly at the boundary → cycle 1
+        env.ledger().set_timestamp(started_at + cycle_duration);
+        let result = calculate_current_cycle(&env, 1);
+        assert_eq!(result, Ok(1));
+    }
+
     // --- round_contribution_amount tests ---
 
     #[test]

--- a/contracts/stellar-save/src/lib.rs
+++ b/contracts/stellar-save/src/lib.rs
@@ -50,7 +50,7 @@ pub mod milestones;
 // mod upgrade_tests;
 
 // ── Re-exports ────────────────────────────────────────────────────────────────
-pub use auth::{require_admin, require_creator, require_member};
+pub use auth::{is_active_member, require_admin, require_creator, require_member};
 pub use contract::{StellarSaveContract, StellarSaveContractClient};
 pub use contribution::{ContributionPage, ContributionRecord};
 pub use error::{ContractResult, ErrorCategory, StellarSaveError};

--- a/contracts/stellar-save/src/milestones.rs
+++ b/contracts/stellar-save/src/milestones.rs
@@ -1,3 +1,4 @@
+use crate::auth::is_active_member;
 use crate::error::StellarSaveError;
 use crate::storage::StorageKeyBuilder;
 use soroban_sdk::{contracttype, Address, Env, Vec};
@@ -120,8 +121,7 @@ pub fn get_member_milestones(
         .ok_or(StellarSaveError::GroupNotFound)?;
 
     // Verify member belongs to the group
-    let member_key = StorageKeyBuilder::member_profile(group_id, member.clone());
-    if !env.storage().persistent().has(&member_key) {
+    if !is_active_member(env, group_id, &member) {
         return Err(StellarSaveError::NotMember);
     }
 

--- a/contracts/stellar-save/src/payout_executor.rs
+++ b/contracts/stellar-save/src/payout_executor.rs
@@ -17,6 +17,7 @@
 //! The design follows a permissionless execution model where any address can trigger
 //! payout execution once preconditions are met.
 
+use crate::auth::is_active_member;
 use crate::error::StellarSaveError;
 use crate::events::EventEmitter;
 use crate::group::{Group, GroupStatus};
@@ -253,8 +254,7 @@ fn verify_recipient_eligibility(
     current_cycle: u32,
 ) -> Result<(), StellarSaveError> {
     // Check 1: Verify recipient is a current member of the group
-    let member_key = StorageKeyBuilder::member_profile(group_id, recipient.clone());
-    if !env.storage().persistent().has(&member_key) {
+    if !is_active_member(env, group_id, recipient) {
         return Err(StellarSaveError::NotMember);
     }
 

--- a/contracts/stellar-save/src/penalty.rs
+++ b/contracts/stellar-save/src/penalty.rs
@@ -12,7 +12,7 @@
 
 use soroban_sdk::{contracttype, Address, Env};
 
-use crate::{error::StellarSaveError, events::EventEmitter, storage::StorageKeyBuilder};
+use crate::{auth::is_active_member, error::StellarSaveError, events::EventEmitter, storage::StorageKeyBuilder};
 
 // ─── Type Aliases ─────────────────────────────────────────────────────────────
 
@@ -153,8 +153,7 @@ pub fn apply_penalty(
         .ok_or(StellarSaveError::GroupNotFound)?;
 
     // 2. Verify member belongs to the group
-    let member_key = StorageKeyBuilder::member_profile(group_id, member.clone());
-    if !env.storage().persistent().has(&member_key) {
+    if !is_active_member(env, group_id, &member) {
         return Err(StellarSaveError::NotMember);
     }
 
@@ -241,8 +240,7 @@ pub fn recover_penalty(
         .ok_or(StellarSaveError::GroupNotFound)?;
 
     // 2. Verify member
-    let member_key = StorageKeyBuilder::member_profile(group_id, member.clone());
-    if !env.storage().persistent().has(&member_key) {
+    if !is_active_member(env, group_id, &member) {
         return Err(StellarSaveError::NotMember);
     }
 

--- a/contracts/stellar-save/src/rating.rs
+++ b/contracts/stellar-save/src/rating.rs
@@ -10,6 +10,7 @@
 use soroban_sdk::{contracttype, Address, Env, String};
 
 use crate::{
+    auth::is_active_member,
     error::StellarSaveError,
     events::EventEmitter,
     group::Group,
@@ -99,8 +100,7 @@ pub fn rate_group(
     }
 
     // 3. Caller must be a member
-    let profile_key = StorageKeyBuilder::member_profile(group_id, caller.clone());
-    if !env.storage().persistent().has(&profile_key) {
+    if !is_active_member(env, group_id, &caller) {
         return Err(StellarSaveError::NotMember);
     }
 


### PR DESCRIPTION
…p utility

Issue #1324 — group-membership-check guard:
- Add is_active_member(env, group_id, address) -> bool to auth.rs as the single canonical O(1) membership check (storage has(), no auth)
- Update require_member() to delegate to is_active_member()
- Replace all ad-hoc inline member_profile has() checks in: penalty.rs (apply_penalty, recover_penalty), rating.rs (rate_group), milestones.rs (get_member_milestones), payout_executor.rs (verify_recipient_eligibility)
- Re-export is_active_member from lib.rs
- Add 6 unit tests (stored member, non-member, non-existent group, zero group_id, no-auth, group isolation); fix pre-existing MemberStatus::Active field ref in test_auth_member_guard

Issue #1323 — shared cycle-timestamp utility:
- Add get_current_timestamp(env) -> u64 to StellarSaveContract as the canonical public ledger-time accessor (no auth/storage/pause)
- calculate_current_cycle() was already in helpers.rs; verified and extended with 2 new boundary tests: test_calculate_current_cycle_clock_skew_returns_zero, test_calculate_current_cycle_exactly_one_second_before_first_boundary

Closes #1324, #1323

## Summary

<!-- What does this PR do? One or two sentences. -->

## Motivation

<!-- Why is this change needed? Link to the issue it resolves. -->

Closes #

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — code restructuring, no behaviour change
- [ ] `test` — tests only
- [ ] `chore` — build, deps, tooling
- [ ] `perf` — performance improvement
- [ ] Breaking change (existing behaviour changes)

## Changes

<!-- List the key changes made. Be specific enough that a reviewer knows where to look. -->

-
-

## Testing

<!-- Describe how you tested this. Include commands a reviewer can run to verify. -->

**Smart contract:**
```bash
cargo test -p stellar-save
```

**Frontend:**
```bash
cd frontend && npm test run
```

**Manual steps (if applicable):**

1.
2.

## Checklist

- [ ] `cargo fmt` run (Rust changes)
- [ ] `cargo clippy -- -D warnings` passes (Rust changes)
- [ ] `npm run lint` passes (frontend changes)
- [ ] Tests added or updated for new/changed behaviour
- [ ] CI is green
- [ ] Documentation updated (if behaviour changed)
- [ ] No secrets or `.env` files staged

## Screenshots / recordings

<!-- For UI changes, include before/after screenshots or a short screen recording. Delete this section if not applicable. -->
closes #1324 
closes #1323 