### PR TITLE
fix(a11y): audit and fix focus-trap/ARIA gaps in modal components

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,11 +8,8 @@
       "name": "stellar-save-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@capacitor/android": "^8.4.1",
         "@capacitor/app": "^8.1.0",
-        "@capacitor/cli": "^8.4.1",
-        "@capacitor/core": "^8.4.1",
-        "@capacitor/ios": "^8.4.1",
+        "@creit.tech/stellar-wallets-kit": "^2.2.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.3.9",
@@ -83,6 +80,16 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="
+    },
+    "node_modules/@albedo-link/intent": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@albedo-link/intent/-/intent-0.12.0.tgz",
+      "integrity": "sha512-UlGBhi0qASDYOjLrOL4484vQ26Ee3zTK2oAgvPMClOs+1XNk3zbs3dECKZv+wqeSI8SkHow8mXLTa16eVh+dQA=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -723,21 +730,66 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@base-org/account": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@base-org/account/-/account-2.4.0.tgz",
+      "integrity": "sha512-A4Umpi8B9/pqR78D1Yoze4xHyQaujioVRqqO3d6xuDFw9VRtjg6tK3bPlwE0aW+nVH/ntllCpPa2PbI8Rnjcug==",
+      "optional": true,
+      "dependencies": {
+        "@coinbase/cdp-sdk": "^1.0.0",
+        "@noble/hashes": "1.4.0",
+        "clsx": "1.2.1",
+        "eventemitter3": "5.0.1",
+        "idb-keyval": "6.2.1",
+        "ox": "0.6.9",
+        "preact": "10.24.2",
+        "viem": "^2.31.7",
+        "zustand": "5.0.3"
+      }
+    },
+    "node_modules/@base-org/account/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "optional": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@base-org/account/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@base-org/account/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "optional": true
+    },
+    "node_modules/@base-org/account/node_modules/preact": {
+      "version": "10.24.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.2.tgz",
+      "integrity": "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@capacitor/android": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.4.1.tgz",
-      "integrity": "sha512-igtDCJ7QQn0P2qHFD9p4KXaa6V1b2PRNt+MxjVwtjTm/BJvqmiazOJq6rPjwFSZnfHm6iFoZk8TfzHd44pyBGw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@capacitor/core": "^8.4.0"
-      }
     },
     "node_modules/@capacitor/app": {
       "version": "8.1.0",
@@ -748,177 +800,315 @@
         "@capacitor/core": ">=8.0.0"
       }
     },
-    "node_modules/@capacitor/cli": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.4.1.tgz",
-      "integrity": "sha512-t7F2s7fFHCq113xgrggrmK6ctV0/8E5YfLNVLfPHp4GCTDO+tly9fZvWPf2/sOI8lMm18dLT43qbXLRTz/OZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ionic/cli-framework-output": "^2.2.8",
-        "@ionic/utils-subprocess": "^3.0.1",
-        "@ionic/utils-terminal": "^2.3.5",
-        "commander": "^12.1.0",
-        "debug": "^4.4.0",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^11.2.0",
-        "kleur": "^4.1.5",
-        "native-run": "^2.0.3",
-        "open": "^8.4.0",
-        "plist": "^3.1.0",
-        "prompts": "^2.4.2",
-        "rimraf": "^6.0.1",
-        "semver": "^7.6.3",
-        "tar": "^7.5.3",
-        "tslib": "^2.8.1",
-        "xml2js": "^0.6.2"
-      },
-      "bin": {
-        "cap": "bin/capacitor",
-        "capacitor": "bin/capacitor"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@capacitor/cli/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@capacitor/cli/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@capacitor/cli/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@capacitor/cli/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@capacitor/cli/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@capacitor/cli/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@capacitor/cli/node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@capacitor/cli/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@capacitor/cli/node_modules/rimraf": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
-      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "glob": "^13.0.3",
-        "package-json-from-dist": "^1.0.1"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@capacitor/core": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.4.1.tgz",
       "integrity": "sha512-xqhOGLbTAYeOWK+IDUNSjQJAPapQjRHrIcgk9PYp52or9zFTaaMko31uNi16N6W+CRJ8VrRram6fOYILkBG2Hg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@capacitor/ios": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.4.1.tgz",
-      "integrity": "sha512-EgcAk7NYheHMTyP3CUrA65qKs4D2UEAKgw44HI6Uk3dTw6KjLQkdLOQWvbeRncHaZ2gklfOojUoc5DlSw2lhYg==",
-      "license": "MIT",
+    "node_modules/@coinbase/cdp-sdk": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/@coinbase/cdp-sdk/-/cdp-sdk-1.54.0.tgz",
+      "integrity": "sha512-FfIJVEKAXgmr+dkXn/NBQO04/pps+oIgqEIdcmG67WZh+m07OsVnvSBEqEvbFO+VjSdaQAKu69EpO3NdHJd2Iw==",
+      "optional": true,
+      "dependencies": {
+        "@solana-program/system": "^0.10.0",
+        "@solana-program/token": "^0.9.0",
+        "@solana/kit": "^5.5.1",
+        "abitype": "1.0.6",
+        "axios": "1.16.0",
+        "axios-retry": "^4.5.0",
+        "bs58": "^6.0.0",
+        "jose": "^6.2.0",
+        "md5": "^2.3.0",
+        "uncrypto": "^0.1.3",
+        "viem": "^2.47.0",
+        "zod": "^3.25.76"
+      },
       "peerDependencies": {
-        "@capacitor/core": "^8.4.0"
+        "@x402/core": "^2.19.0",
+        "@x402/evm": "^2.19.0",
+        "@x402/extensions": "^2.19.0",
+        "@x402/svm": "^2.19.0"
+      },
+      "peerDependenciesMeta": {
+        "@x402/core": {
+          "optional": true
+        },
+        "@x402/evm": {
+          "optional": true
+        },
+        "@x402/extensions": {
+          "optional": true
+        },
+        "@x402/svm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/abitype": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
+      "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@creit.tech/stellar-wallets-kit/-/stellar-wallets-kit-2.2.0.tgz",
+      "integrity": "sha512-GUXS0HUggxWiK2c3sNi5vnIE/40iVQqIpH7OBca6s0BUOk3GCTmZrcaep4AhNxkuWpqOCQ78i29PVr7F/0xWvA==",
+      "dependencies": {
+        "@albedo-link/intent": "0.12.0",
+        "@creit.tech/xbull-wallet-connect": "0.4.0",
+        "@hot-wallet/sdk": "1.0.11",
+        "@ledgerhq/hw-app-str": "7.2.8",
+        "@ledgerhq/hw-transport": "6.31.12",
+        "@ledgerhq/hw-transport-webusb": "6.29.12",
+        "@lobstrco/signer-extension-api": "2.0.0",
+        "@preact/signals": "2.9.0",
+        "@reown/appkit": "1.8.19",
+        "@stellar/freighter-api": "6.0.0",
+        "@stellar/stellar-base": "14.0.1",
+        "@trezor/connect-plugin-stellar": "9.2.6",
+        "@trezor/connect-web": "9.7.2",
+        "@twind/core": "1.1.3",
+        "@twind/preset-autoprefix": "1.0.7",
+        "@twind/preset-tailwind": "1.1.4",
+        "@walletconnect/sign-client": "2.23.0",
+        "@walletconnect/types": "2.23.9",
+        "htm": "3.1.1",
+        "preact": "^10.29.0"
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@stellar/freighter-api": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-6.0.0.tgz",
+      "integrity": "sha512-8CTQcKQmTq/wL715ZUzn1x1POpR0eYhYPKEiaeA7AT0WYBOauOGTxfWPFtSidX3ohAlJZP5HFXy1kG29cVjqxw==",
+      "dependencies": {
+        "buffer": "6.0.3",
+        "semver": "7.7.1"
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@stellar/stellar-base": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-14.0.1.tgz",
+      "integrity": "sha512-mI6Kjh9hGWDA1APawQTtCbR7702dNT/8Te1uuRFPqqdoAKBk3WpXOQI3ZSZO+5olW7BSHpmVG5KBPZpIpQxIvw==",
+      "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
+      "dependencies": {
+        "@noble/curves": "^1.9.6",
+        "@stellar/js-xdr": "^3.1.2",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.3.1",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.4.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@stellar/stellar-sdk": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.3.0.tgz",
+      "integrity": "sha512-8+GHcZLp+mdin8gSjcgfb/Lb6sSMYRX6Nf/0LcSJxvjLQR0XHpjGzOiRbYb2jSXo51EnA6kAV5j+4Pzh5OUKUg==",
+      "peer": true,
+      "dependencies": {
+        "@stellar/stellar-base": "^13.1.0",
+        "axios": "^1.8.4",
+        "bignumber.js": "^9.3.0",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@stellar/stellar-sdk/node_modules/@stellar/stellar-base": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.1.0.tgz",
+      "integrity": "sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==",
+      "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
+      "peer": true,
+      "dependencies": {
+        "@stellar/js-xdr": "^3.1.2",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.1.2",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.3.6",
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "sodium-native": "^4.3.3"
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@trezor/connect-plugin-stellar": {
+      "version": "9.2.6",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-plugin-stellar/-/connect-plugin-stellar-9.2.6.tgz",
+      "integrity": "sha512-RA0Q4GHaf1mFxgSX183yyH+5tWEgS1j+sfe9KiUyIn/VnpXeUnaCpQuKMomAjGXQ5oNuvikTOdHYOqsvuEdOyw==",
+      "dependencies": {
+        "@trezor/utils": "9.5.0"
+      },
+      "peerDependencies": {
+        "@stellar/stellar-sdk": "^13.3.0",
+        "@trezor/connect": "9.x.x",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@twind/core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@twind/core/-/core-1.1.3.tgz",
+      "integrity": "sha512-/B/aNFerMb2IeyjSJy3SJxqVxhrT77gBDknLMiZqXIRr4vNJqiuhx7KqUSRzDCwUmyGuogkamz+aOLzN6MeSLw==",
+      "funding": [
+        {
+          "type": "Open Collective",
+          "url": "https://opencollective.com/twind"
+        },
+        {
+          "type": "Github Sponsor",
+          "url": "https://github.com/sponsors/tw-in-js"
+        },
+        {
+          "type": "Ko-fi",
+          "url": "https://ko-fi.com/twind"
+        }
+      ],
+      "dependencies": {
+        "csstype": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.8.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@twind/preset-autoprefix": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@twind/preset-autoprefix/-/preset-autoprefix-1.0.7.tgz",
+      "integrity": "sha512-3wmHO0pG/CVxYBNZUV0tWcL7CP0wD5KpyWAQE/KOalWmOVBj+nH6j3v6Y3I3pRuMFaG5DC78qbYbhA1O11uG3w==",
+      "funding": [
+        {
+          "type": "Open Collective",
+          "url": "https://opencollective.com/twind"
+        },
+        {
+          "type": "Github Sponsor",
+          "url": "https://github.com/sponsors/tw-in-js"
+        },
+        {
+          "type": "Ko-fi",
+          "url": "https://ko-fi.com/twind"
+        }
+      ],
+      "dependencies": {
+        "style-vendorizer": "^2.2.3"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "@twind/core": "^1.1.0",
+        "typescript": "^4.8.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@twind/preset-tailwind": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@twind/preset-tailwind/-/preset-tailwind-1.1.4.tgz",
+      "integrity": "sha512-zv85wrP/DW4AxgWrLfH7kyGn/KJF3K04FMLVl2AjoxZGYdCaoZDkL8ma3hzaKQ+WGgBFRubuB/Ku2Rtv/wjzVw==",
+      "funding": [
+        {
+          "type": "Open Collective",
+          "url": "https://opencollective.com/twind"
+        },
+        {
+          "type": "Github Sponsor",
+          "url": "https://github.com/sponsors/tw-in-js"
+        },
+        {
+          "type": "Ko-fi",
+          "url": "https://ko-fi.com/twind"
+        }
+      ],
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "@twind/core": "^1.1.0",
+        "typescript": "^4.8.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@creit.tech/xbull-wallet-connect": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@creit.tech/xbull-wallet-connect/-/xbull-wallet-connect-0.4.0.tgz",
+      "integrity": "sha512-LrCUIqUz50SkZ4mv2hTqSmwews8CNRYVoZ9+VjLsK/1U8PByzXTxv1vZyenj6avRTG86ifpoeihz7D3D5YIDrQ==",
+      "dependencies": {
+        "rxjs": "^7.5.5",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1192,6 +1382,16 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
+    },
+    "node_modules/@emurgo/cardano-serialization-lib-browser": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-browser/-/cardano-serialization-lib-browser-13.2.1.tgz",
+      "integrity": "sha512-7RfX1gI16Vj2DgCp/ZoXqyLAakWo6+X95ku/rYGbVzuS/1etrlSiJmdbmdm+eYmszMlGQjrtOJQeVLXoj4L/Ag=="
+    },
+    "node_modules/@emurgo/cardano-serialization-lib-nodejs": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-13.2.0.tgz",
+      "integrity": "sha512-Bz1zLGEqBQ0BVkqt1OgMxdBOE3BdUWUd7Ly9Ecr/aUwkA8AV1w1XzBMe4xblmJHnB1XXNlPH4SraXCvO+q0Mig=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
@@ -1790,6 +1990,129 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@ethereumjs/common": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-10.1.2.tgz",
+      "integrity": "sha512-whWnhqAxwpDy4zWkM6rqMzb8nioZJpiys01N57+HDyanvK5IRzodV5tdMRDt66PD5vDjl2c9K5UcB039gU2Oyw==",
+      "dependencies": {
+        "@ethereumjs/util": "^10.1.2",
+        "eventemitter3": "^5.0.1"
+      }
+    },
+    "node_modules/@ethereumjs/rlp": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-10.1.2.tgz",
+      "integrity": "sha512-T5Zt6C2pd02Wd88Q9A5/UX+He1Q2Y1LntHxz/038tfbUMiqby4fYSSTLEDx+TEfJqw1BsJSBY/TSu6goUzlk+w==",
+      "bin": {
+        "rlp": "bin/rlp.cjs"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ethereumjs/tx": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-10.1.2.tgz",
+      "integrity": "sha512-bAYK3YaYkk+auzxGfZSRVDbLHvboJNTx8/tV6jaqgPVlrA1QKEEADDEp/EGz+KI4NQmTGxEtXZ8tV/WjniRNww==",
+      "dependencies": {
+        "@ethereumjs/common": "^10.1.2",
+        "@ethereumjs/rlp": "^10.1.2",
+        "@ethereumjs/util": "^10.1.2",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ethereumjs/tx/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@ethereumjs/tx/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@ethereumjs/util": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-10.1.2.tgz",
+      "integrity": "sha512-UPBgXtHHfQugoXOSAoeG3jdmPbl37cwV9y3XqTPAnw8tJj8np14TPV2uc5lOs7C2LMF9Ubn66zyaiYxgwGppng==",
+      "dependencies": {
+        "@ethereumjs/rlp": "^10.1.2",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ethereumjs/util/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@ethereumjs/util/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fivebinaries/coin-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@fivebinaries/coin-selection/-/coin-selection-3.0.0.tgz",
+      "integrity": "sha512-h25Pn1ZA7oqQBQDodGAgIsQt66T2wDge9onBKNqE66WNWL0KJiKJbpij8YOLo5AAlEIg5IS7EB1QjBgDOIg6DQ==",
+      "dependencies": {
+        "@emurgo/cardano-serialization-lib-browser": "^13.2.0",
+        "@emurgo/cardano-serialization-lib-nodejs": "13.2.0"
+      }
+    },
+    "node_modules/@hot-wallet/sdk": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@hot-wallet/sdk/-/sdk-1.0.11.tgz",
+      "integrity": "sha512-qRDH/4yqnRCnk7L/Qd0/LDOKDUKWcFgvf6eRELJkP0OgxIe65i/iXaG+u2lL0mLbTGkiWYk67uAvEerNUv2gzA==",
+      "dependencies": {
+        "@near-js/crypto": "^1.4.0",
+        "@near-js/utils": "^1.0.0",
+        "@near-wallet-selector/core": "^8.9.13",
+        "@solana/wallet-adapter-base": "^0.9.23",
+        "@solana/web3.js": "^1.95.0",
+        "borsh": "^2.0.0",
+        "js-sha256": "^0.11.0",
+        "sha1": "^1.1.1",
+        "uuid4": "^2.0.3"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2622,206 +2945,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@ionic/cli-framework-output": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@ionic/cli-framework-output/-/cli-framework-output-2.2.8.tgz",
-      "integrity": "sha512-TshtaFQsovB4NWRBydbNFawql6yul7d5bMiW1WYYf17hd99V6xdDdk3vtF51bw6sLkxON3bDQpWsnUc9/hVo3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@ionic/utils-terminal": "2.3.5",
-        "debug": "^4.0.0",
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@ionic/utils-array": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-2.1.6.tgz",
-      "integrity": "sha512-0JZ1Zkp3wURnv8oq6Qt7fMPo5MpjbLoUoa9Bu2Q4PJuSDWM8H8gwF3dQO7VTeUj3/0o1IB1wGkFWZZYgUXZMUg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.0.0",
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@ionic/utils-fs": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.7.tgz",
-      "integrity": "sha512-2EknRvMVfhnyhL1VhFkSLa5gOcycK91VnjfrTB0kbqkTFCOXyXgVLI5whzq7SLrgD9t1aqos3lMMQyVzaQ5gVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/fs-extra": "^8.0.0",
-        "debug": "^4.0.0",
-        "fs-extra": "^9.0.0",
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@ionic/utils-fs/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@ionic/utils-object": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.6.tgz",
-      "integrity": "sha512-vCl7sl6JjBHFw99CuAqHljYJpcE88YaH2ZW4ELiC/Zwxl5tiwn4kbdP/gxi2OT3MQb1vOtgAmSNRtusvgxI8ww==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.0.0",
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@ionic/utils-process": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-2.1.12.tgz",
-      "integrity": "sha512-Jqkgyq7zBs/v/J3YvKtQQiIcxfJyplPgECMWgdO0E1fKrrH8EF0QGHNJ9mJCn6PYe2UtHNS8JJf5G21e09DfYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@ionic/utils-object": "2.1.6",
-        "@ionic/utils-terminal": "2.3.5",
-        "debug": "^4.0.0",
-        "signal-exit": "^3.0.3",
-        "tree-kill": "^1.2.2",
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@ionic/utils-process/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
-    "node_modules/@ionic/utils-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-3.1.7.tgz",
-      "integrity": "sha512-eSELBE7NWNFIHTbTC2jiMvh1ABKGIpGdUIvARsNPMNQhxJB3wpwdiVnoBoTYp+5a6UUIww4Kpg7v6S7iTctH1w==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.0.0",
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@ionic/utils-subprocess": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-3.0.1.tgz",
-      "integrity": "sha512-cT4te3AQQPeIM9WCwIg8ohroJ8TjsYaMb2G4ZEgv9YzeDqHZ4JpeIKqG2SoaA3GmVQ3sOfhPM6Ox9sxphV/d1A==",
-      "license": "MIT",
-      "dependencies": {
-        "@ionic/utils-array": "2.1.6",
-        "@ionic/utils-fs": "3.1.7",
-        "@ionic/utils-process": "2.1.12",
-        "@ionic/utils-stream": "3.1.7",
-        "@ionic/utils-terminal": "2.3.5",
-        "cross-spawn": "^7.0.3",
-        "debug": "^4.0.0",
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@ionic/utils-terminal": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.5.tgz",
-      "integrity": "sha512-3cKScz9Jx2/Pr9ijj1OzGlBDfcmx7OMVBt4+P1uRR0SSW4cm1/y3Mo4OY3lfkuaYifMNBW8Wz6lQHbs1bihr7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/slice-ansi": "^4.0.0",
-        "debug": "^4.0.0",
-        "signal-exit": "^3.0.3",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "tslib": "^2.0.1",
-        "untildify": "^4.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@ionic/utils-terminal/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/@ionic/utils-terminal/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
-    "node_modules/@ionic/utils-terminal/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@ionic/utils-terminal/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@ionic/utils-terminal/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2838,18 +2961,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -2919,6 +3030,102 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@ledgerhq/devices": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.6.1.tgz",
+      "integrity": "sha512-PQR2fyWz7P/wMFHY9ZLz17WgFdxC/Im0RVDcWXpp24+iRQRyxhQeX2iG4mBKUzfaAW6pOIEiWt+vmJh88QP9rQ==",
+      "dependencies": {
+        "@ledgerhq/errors": "^6.26.0",
+        "@ledgerhq/logs": "^6.13.0",
+        "rxjs": "^7.8.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/@ledgerhq/errors": {
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.37.0.tgz",
+      "integrity": "sha512-T5yiKI5UX7ugeocdTF3TUsCIN2BH41Bio4ZeN410YFjFOf3es08n/5JyMzzKwzRgP0blG3HfBf7s7vJKqCSAeg=="
+    },
+    "node_modules/@ledgerhq/hw-app-str": {
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-str/-/hw-app-str-7.2.8.tgz",
+      "integrity": "sha512-VHICY9jyZW5LM/8zc/mSbW7fS2bAC1OTVOtRwdQLEDn6Gv9UaNcCWjaHI1UKAnDUqYX7DUQuIPiTP1b4O+mtUQ==",
+      "dependencies": {
+        "@ledgerhq/errors": "^6.26.0",
+        "@ledgerhq/hw-transport": "^6.31.12",
+        "bip32-path": "^0.4.2"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport": {
+      "version": "6.31.12",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.31.12.tgz",
+      "integrity": "sha512-FO5LRIXYC8ELtaohlO8qK0b3TfHUNBZ3+CXKPHiHj2jJwrxPf4s5kcgBYrmzuf1C/1vfrMOjzyty6OgrMIbU6Q==",
+      "dependencies": {
+        "@ledgerhq/devices": "8.6.1",
+        "@ledgerhq/errors": "^6.26.0",
+        "@ledgerhq/logs": "^6.13.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webusb": {
+      "version": "6.29.12",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-6.29.12.tgz",
+      "integrity": "sha512-mMGKPYAUz9MNcURe+hSTSHwqPwCli6D0lCl15Z4hDOpcqhZ26vwoeWVKeQp53NNCetHOl0lauPkN43Gt9pIggg==",
+      "dependencies": {
+        "@ledgerhq/devices": "8.6.1",
+        "@ledgerhq/errors": "^6.26.0",
+        "@ledgerhq/hw-transport": "^6.31.12",
+        "@ledgerhq/logs": "^6.13.0"
+      }
+    },
+    "node_modules/@ledgerhq/logs": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.17.0.tgz",
+      "integrity": "sha512-yra33g5q/AU7+PwAws+GaVpQGUuxnDREjVBnviJjcaJLVKuLzI4pnj8Bd3nY3fypM5k1yZEYKEXfUuGFUjP2+w=="
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ=="
+    },
+    "node_modules/@lit/react": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
+      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
+      "optional": true,
+      "peerDependencies": {
+        "@types/react": "17 || 18 || 19"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@lobstrco/signer-extension-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@lobstrco/signer-extension-api/-/signer-extension-api-2.0.0.tgz",
+      "integrity": "sha512-jwlVyzMFF296iaNgMWn1lu+EU6BeUD4mgPurEsy8EygYNCrjA8igLpsDlXhfvXhst9tX5w4wRuTDX+FZtpfCug=="
+    },
+    "node_modules/@mobily/ts-belt": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@mobily/ts-belt/-/ts-belt-3.13.1.tgz",
+      "integrity": "sha512-K5KqIhPI/EoCTbA6CGbrenM9s41OouyK8A03fGJJcla/zKucsgLbz8HNbeseoLarRPgyWJsUyCYqFhI7t3Ra9Q==",
+      "engines": {
+        "node": ">= 10.*"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.2.tgz",
+      "integrity": "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
@@ -3210,6 +3417,333 @@
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@near-js/accounts": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@near-js/accounts/-/accounts-1.4.1.tgz",
+      "integrity": "sha512-ni3QT9H3NdrbVVKyx56yvz93r89Dvpc/vgVtiIK2OdXjkK6jcj+UKMDRQ6F7rd9qJOInLkHZbVBtcR6j1CXLjw==",
+      "peer": true,
+      "dependencies": {
+        "@near-js/crypto": "1.4.2",
+        "@near-js/providers": "1.0.3",
+        "@near-js/signers": "0.2.2",
+        "@near-js/transactions": "1.3.3",
+        "@near-js/types": "0.3.1",
+        "@near-js/utils": "1.1.0",
+        "@noble/hashes": "1.7.1",
+        "borsh": "1.0.0",
+        "depd": "2.0.0",
+        "is-my-json-valid": "^2.20.6",
+        "lru_map": "0.4.1",
+        "near-abi": "0.2.0"
+      }
+    },
+    "node_modules/@near-js/accounts/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "peer": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@near-js/accounts/node_modules/borsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
+      "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
+      "peer": true
+    },
+    "node_modules/@near-js/crypto": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@near-js/crypto/-/crypto-1.4.2.tgz",
+      "integrity": "sha512-GRfchsyfWvSAPA1gI9hYhw5FH94Ac1BUo+Cmp5rSJt/V0K3xVzCWgOQxvv4R3kDnWjaXJEuAmpEEnr4Bp3FWrA==",
+      "dependencies": {
+        "@near-js/types": "0.3.1",
+        "@near-js/utils": "1.1.0",
+        "@noble/curves": "1.8.1",
+        "borsh": "1.0.0",
+        "randombytes": "2.1.0",
+        "secp256k1": "5.0.1"
+      }
+    },
+    "node_modules/@near-js/crypto/node_modules/@noble/curves": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "dependencies": {
+        "@noble/hashes": "1.7.1"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@near-js/crypto/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@near-js/crypto/node_modules/borsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
+      "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ=="
+    },
+    "node_modules/@near-js/keystores": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@near-js/keystores/-/keystores-0.2.2.tgz",
+      "integrity": "sha512-DLhi/3a4qJUY+wgphw2Jl4S+L0AKsUYm1mtU0WxKYV5OBwjOXvbGrXNfdkheYkfh3nHwrQgtjvtszX6LrRXLLw==",
+      "peer": true,
+      "dependencies": {
+        "@near-js/crypto": "1.4.2",
+        "@near-js/types": "0.3.1"
+      }
+    },
+    "node_modules/@near-js/keystores-browser": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@near-js/keystores-browser/-/keystores-browser-0.2.2.tgz",
+      "integrity": "sha512-Pxqm7WGtUu6zj32vGCy9JcEDpZDSB5CCaLQDTQdF3GQyL0flyRv2I/guLAgU5FLoYxU7dJAX9mslJhPW7P2Bfw==",
+      "peer": true,
+      "dependencies": {
+        "@near-js/crypto": "1.4.2",
+        "@near-js/keystores": "0.2.2"
+      }
+    },
+    "node_modules/@near-js/keystores-node": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@near-js/keystores-node/-/keystores-node-0.1.2.tgz",
+      "integrity": "sha512-MWLvTszZOVziiasqIT/LYNhUyWqOJjDGlsthOsY6dTL4ZcXjjmhmzrbFydIIeQr+CcEl5wukTo68ORI9JrHl6g==",
+      "peer": true,
+      "dependencies": {
+        "@near-js/crypto": "1.4.2",
+        "@near-js/keystores": "0.2.2"
+      }
+    },
+    "node_modules/@near-js/providers": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@near-js/providers/-/providers-1.0.3.tgz",
+      "integrity": "sha512-VJMboL14R/+MGKnlhhE3UPXCGYvMd1PpvF9OqZ9yBbulV7QVSIdTMfY4U1NnDfmUC2S3/rhAEr+3rMrIcNS7Fg==",
+      "peer": true,
+      "dependencies": {
+        "@near-js/transactions": "1.3.3",
+        "@near-js/types": "0.3.1",
+        "@near-js/utils": "1.1.0",
+        "borsh": "1.0.0",
+        "exponential-backoff": "^3.1.2"
+      },
+      "optionalDependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
+    "node_modules/@near-js/providers/node_modules/borsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
+      "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
+      "peer": true
+    },
+    "node_modules/@near-js/providers/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@near-js/providers/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@near-js/providers/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@near-js/providers/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@near-js/signers": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@near-js/signers/-/signers-0.2.2.tgz",
+      "integrity": "sha512-M6ib+af9zXAPRCjH2RyIS0+RhCmd9gxzCeIkQ+I2A3zjgGiEDkBZbYso9aKj8Zh2lPKKSH7h+u8JGymMOSwgyw==",
+      "peer": true,
+      "dependencies": {
+        "@near-js/crypto": "1.4.2",
+        "@near-js/keystores": "0.2.2",
+        "@noble/hashes": "1.3.3"
+      }
+    },
+    "node_modules/@near-js/signers/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "peer": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@near-js/transactions": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@near-js/transactions/-/transactions-1.3.3.tgz",
+      "integrity": "sha512-1AXD+HuxlxYQmRTLQlkVmH+RAmV3HwkAT8dyZDu+I2fK/Ec9BQHXakOJUnOBws3ihF+akQhamIBS5T0EXX/Ylw==",
+      "peer": true,
+      "dependencies": {
+        "@near-js/crypto": "1.4.2",
+        "@near-js/signers": "0.2.2",
+        "@near-js/types": "0.3.1",
+        "@near-js/utils": "1.1.0",
+        "@noble/hashes": "1.7.1",
+        "borsh": "1.0.0"
+      }
+    },
+    "node_modules/@near-js/transactions/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "peer": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@near-js/transactions/node_modules/borsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
+      "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
+      "peer": true
+    },
+    "node_modules/@near-js/types": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@near-js/types/-/types-0.3.1.tgz",
+      "integrity": "sha512-8qIA7ynAEAuVFNAQc0cqz2xRbfyJH3PaAG5J2MgPPhD18lu/tCGd6pzYg45hjhtiJJRFDRjh/FUWKS+ZiIIxUw=="
+    },
+    "node_modules/@near-js/utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@near-js/utils/-/utils-1.1.0.tgz",
+      "integrity": "sha512-5XWRq7xpu8Wud9pRXe2U347KXyi0mXofedUY2DQ9TaqiZUcMIaN9xj7DbCs2v6dws3pJyYrT1KWxeNp5fSaY3w==",
+      "dependencies": {
+        "@near-js/types": "0.3.1",
+        "@scure/base": "^1.2.0",
+        "depd": "2.0.0",
+        "mustache": "4.0.0"
+      }
+    },
+    "node_modules/@near-js/utils/node_modules/mustache": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.0.tgz",
+      "integrity": "sha512-FJgjyX/IVkbXBXYUwH+OYwQKqWpFPLaLVESd70yHjSDunwzV2hZOoTBvPf4KLoxesUzzyfTH6F784Uqd7Wm5yA==",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "node_modules/@near-js/wallet-account": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@near-js/wallet-account/-/wallet-account-1.3.3.tgz",
+      "integrity": "sha512-GDzg/Kz0GBYF7tQfyQQQZ3vviwV8yD+8F2lYDzsWJiqIln7R1ov0zaXN4Tii86TeS21KPn2hHAsVu3Y4txa8OQ==",
+      "peer": true,
+      "dependencies": {
+        "@near-js/accounts": "1.4.1",
+        "@near-js/crypto": "1.4.2",
+        "@near-js/keystores": "0.2.2",
+        "@near-js/providers": "1.0.3",
+        "@near-js/signers": "0.2.2",
+        "@near-js/transactions": "1.3.3",
+        "@near-js/types": "0.3.1",
+        "@near-js/utils": "1.1.0",
+        "borsh": "1.0.0"
+      }
+    },
+    "node_modules/@near-js/wallet-account/node_modules/borsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
+      "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
+      "peer": true
+    },
+    "node_modules/@near-wallet-selector/core": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/@near-wallet-selector/core/-/core-8.10.2.tgz",
+      "integrity": "sha512-MH8sg6XHyylq2ZXxnOjrKHMCmuRgFfpfdC816fW0R8hctZiXZ0lmfLvgG1xfA2BAxrVytiU1g3dcE97/P5cZqg==",
+      "dependencies": {
+        "borsh": "1.0.0",
+        "events": "3.3.0",
+        "js-sha256": "0.9.0",
+        "rxjs": "7.8.1"
+      },
+      "peerDependencies": {
+        "near-api-js": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@near-wallet-selector/core/node_modules/borsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
+      "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ=="
+    },
+    "node_modules/@near-wallet-selector/core/node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
+    "node_modules/@near-wallet-selector/core/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/curves": {
@@ -3655,6 +4189,14 @@
         "node": ">=14"
       }
     },
+    "node_modules/@phosphor-icons/webcomponents": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/webcomponents/-/webcomponents-2.1.5.tgz",
+      "integrity": "sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==",
+      "dependencies": {
+        "lit": "^3"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3699,6 +4241,83 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@preact/signals": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.9.0.tgz",
+      "integrity": "sha512-hYrY0KyUqkDgOl1qba/JGn6y81pXnurn21PMaxfcMwdncdZ3M/oVdmpTvEnsGjh48dIwDVc7bjWHqIsngSjYug==",
+      "dependencies": {
+        "@preact/signals-core": "^1.14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": ">= 10.25.0 || >=11.0.0-0"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
@@ -3733,6 +4352,159 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@reown/appkit": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.8.19.tgz",
+      "integrity": "sha512-wB+xatkRbOy0AY1cZxxtcKzzPk3l3CTFulDbaISLVmZI6ZnQrOFuLnYc285zGsC6DB4d6bmwYUh89zcMLa4PvQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-pay": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@reown/appkit-scaffold-ui": "1.8.19",
+        "@reown/appkit-ui": "1.8.19",
+        "@reown/appkit-utils": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "@walletconnect/universal-provider": "2.23.7",
+        "bs58": "6.0.0",
+        "semver": "7.7.2",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      },
+      "optionalDependencies": {
+        "@lit/react": "1.0.8"
+      }
+    },
+    "node_modules/@reown/appkit-common": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.19.tgz",
+      "integrity": "sha512-z5wDrYjUGY7YbM4b14NHVo54WKZ5++PQtGkcsXhiOP39yAVijubBQD8BfHs/Pu2fSFqnqLIFoCVvIEfNWWccRw==",
+      "dependencies": {
+        "big.js": "6.2.2",
+        "dayjs": "1.11.13",
+        "viem": ">=2.45.0"
+      }
+    },
+    "node_modules/@reown/appkit-common/node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
+    },
+    "node_modules/@reown/appkit-controllers": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.19.tgz",
+      "integrity": "sha512-JFNT8CfAVit9FJXh596Ye4U8A/oIapW+Y0KQqjB59DXyTCDZbxZDB32rULBQrSkZ6PufTEa239Dil4kABCQKtg==",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      }
+    },
+    "node_modules/@reown/appkit-pay": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.19.tgz",
+      "integrity": "sha512-HO/tQT0TbTQO3eONxNNPJAOZAOzUiHvjM0Mty1rFFeRBH68auiqQxQi2YFNMs014gNkRN+cb84VYau7+MCC0fQ==",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-ui": "1.8.19",
+        "@reown/appkit-utils": "1.8.19",
+        "lit": "3.3.0",
+        "valtio": "2.1.7"
+      }
+    },
+    "node_modules/@reown/appkit-polyfills": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.19.tgz",
+      "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
+      "dependencies": {
+        "buffer": "6.0.3"
+      }
+    },
+    "node_modules/@reown/appkit-scaffold-ui": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.19.tgz",
+      "integrity": "sha512-Ak767x0VzeDIXb0wbzkl19kx6udw7vkb1EU0SAweG3iKc9BunW87Rfcd48/YimzMZycJaYmlbtfmqQQDYs6Few==",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-pay": "1.8.19",
+        "@reown/appkit-ui": "1.8.19",
+        "@reown/appkit-utils": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "lit": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit-ui": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.19.tgz",
+      "integrity": "sha512-fCAwW8yyyC3JcgKLBPvCtYuDGC4H8anO7u4LTaAXGEzdcU5H+IrCgNFSPNK7NuTSmgXm1TnoYxPxRFKNiNwFdA==",
+      "dependencies": {
+        "@phosphor-icons/webcomponents": "2.1.5",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "lit": "3.3.0",
+        "qrcode": "1.5.3"
+      }
+    },
+    "node_modules/@reown/appkit-utils": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.19.tgz",
+      "integrity": "sha512-VQPgUMTFqoh4UD3EDZSw9wyMkyZsmIVmu8CdQ2FUxIuqYW4fLd0VIpkDeO64MMhSv8b0X8Vd6m4+eGcqSwlUAg==",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "@wallet-standard/wallet": "1.1.0",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      },
+      "optionalDependencies": {
+        "@base-org/account": "2.4.0",
+        "@safe-global/safe-apps-provider": "0.18.6",
+        "@safe-global/safe-apps-sdk": "9.1.0"
+      },
+      "peerDependencies": {
+        "valtio": "2.1.7"
+      }
+    },
+    "node_modules/@reown/appkit-wallet": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.19.tgz",
+      "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@walletconnect/logger": "3.0.2",
+        "zod": "3.22.4"
+      }
+    },
+    "node_modules/@reown/appkit-wallet/node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@restart/hooks": {
@@ -4134,6 +4906,69 @@
         "win32"
       ]
     },
+    "node_modules/@safe-global/safe-apps-provider": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.6.tgz",
+      "integrity": "sha512-4LhMmjPWlIO8TTDC2AwLk44XKXaK6hfBTWyljDm0HQ6TWlOEijVWNrt2s3OCVMSxlXAcEzYfqyu1daHZooTC2Q==",
+      "optional": true,
+      "dependencies": {
+        "@safe-global/safe-apps-sdk": "^9.1.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@safe-global/safe-apps-sdk": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-9.1.0.tgz",
+      "integrity": "sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==",
+      "optional": true,
+      "dependencies": {
+        "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
+        "viem": "^2.1.1"
+      }
+    },
+    "node_modules/@safe-global/safe-gateway-typescript-sdk": {
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.23.1.tgz",
+      "integrity": "sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "optional": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -4332,6 +5167,1156 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@solana-program/system": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.10.0.tgz",
+      "integrity": "sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==",
+      "optional": true,
+      "peerDependencies": {
+        "@solana/kit": "^5.0"
+      }
+    },
+    "node_modules/@solana-program/token": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.9.0.tgz",
+      "integrity": "sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==",
+      "optional": true,
+      "peerDependencies": {
+        "@solana/kit": "^5.0"
+      }
+    },
+    "node_modules/@solana/accounts": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
+      "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-5.5.1.tgz",
+      "integrity": "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==",
+      "optional": true,
+      "dependencies": {
+        "@solana/assertions": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-5.5.1.tgz",
+      "integrity": "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/buffer-layout": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
+      "dependencies": {
+        "buffer": "~6.0.3"
+      },
+      "engines": {
+        "node": ">=5.10"
+      }
+    },
+    "node_modules/@solana/codecs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
+      "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/options": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-5.5.1.tgz",
+      "integrity": "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-5.5.1.tgz",
+      "integrity": "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-5.5.1.tgz",
+      "integrity": "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-5.5.1.tgz",
+      "integrity": "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-5.5.1.tgz",
+      "integrity": "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==",
+      "optional": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.2"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/errors/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "optional": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/commander": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-5.5.1.tgz",
+      "integrity": "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-5.5.1.tgz",
+      "integrity": "sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-5.5.1.tgz",
+      "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-5.5.1.tgz",
+      "integrity": "sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-5.5.1.tgz",
+      "integrity": "sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==",
+      "optional": true,
+      "dependencies": {
+        "@solana/assertions": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
+      "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
+      "optional": true,
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instruction-plans": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/plugin-core": "5.5.1",
+        "@solana/programs": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/signers": "5.5.1",
+        "@solana/sysvars": "5.5.1",
+        "@solana/transaction-confirmation": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/nominal-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-5.5.1.tgz",
+      "integrity": "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-5.5.1.tgz",
+      "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
+      "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-core": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-5.5.1.tgz",
+      "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.5.1.tgz",
+      "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-5.5.1.tgz",
+      "integrity": "sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-5.5.1.tgz",
+      "integrity": "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/fast-stable-stringify": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-transport-http": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-5.5.1.tgz",
+      "integrity": "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-5.5.1.tgz",
+      "integrity": "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-5.5.1.tgz",
+      "integrity": "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-5.5.1.tgz",
+      "integrity": "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-5.5.1.tgz",
+      "integrity": "sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/fast-stable-stringify": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions-api": "5.5.1",
+        "@solana/rpc-subscriptions-channel-websocket": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/subscribable": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-5.5.1.tgz",
+      "integrity": "sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-5.5.1.tgz",
+      "integrity": "sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/subscribable": "5.5.1",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-5.5.1.tgz",
+      "integrity": "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/subscribable": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-5.5.1.tgz",
+      "integrity": "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-5.5.1.tgz",
+      "integrity": "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "undici-types": "^7.19.2"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/undici-types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.29.0.tgz",
+      "integrity": "sha512-vamA8dGlzMwhpyYpQp9d8vka3o4D/yn5I7ez7Or+msDA4bZ8Uh+Zy91WvWf3I73gDAkFha9JcYRqm2li0Npfgg==",
+      "optional": true
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-5.5.1.tgz",
+      "integrity": "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.5.1.tgz",
+      "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/subscribable": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-5.5.1.tgz",
+      "integrity": "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
+      "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
+      "optional": true,
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-5.5.1.tgz",
+      "integrity": "sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-5.5.1.tgz",
+      "integrity": "sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-5.5.1.tgz",
+      "integrity": "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/wallet-adapter-base": {
+      "version": "0.9.27",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-base/-/wallet-adapter-base-0.9.27.tgz",
+      "integrity": "sha512-kXjeNfNFVs/NE9GPmysBRKQ/nf+foSaq3kfVSeMcO/iVgigyRmB551OjU3WyAolLG/1jeEfKLqF9fKwMCRkUqg==",
+      "dependencies": {
+        "@solana/wallet-standard-features": "^1.3.0",
+        "@wallet-standard/base": "^1.1.0",
+        "@wallet-standard/features": "^1.1.0",
+        "eventemitter3": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.98.0"
+      }
+    },
+    "node_modules/@solana/wallet-standard-features": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.4.0.tgz",
+      "integrity": "sha512-f0tAdqwM2aL6CiFbIgt9h5zKFp+mgY/iNGwoxPMTj9VSTeQj7d1GGSmWhZw0XWoZ4N/1tnKTKmYFq+Dyq08jRw==",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0",
+        "@wallet-standard/features": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@solana/web3.js": {
+      "version": "1.98.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
+      "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "@noble/curves": "^1.4.2",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "@solana/codecs-numbers": "^2.1.0",
+        "agentkeepalive": "^4.5.0",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.1",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^2.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/@solana/web3.js/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@solana/web3.js/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -4711,6 +6696,14 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -4840,6 +6833,2752 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@trezor/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-evILW5XJEmfPlf0TY1duOLtGJ47pdGeSKVE3P75ODEUsRNxtPVqlkOUBPmYpCxPnzS8XDmkatT8lf9/DF0G6nA==",
+      "dependencies": {
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/utils": "9.5.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link/-/blockchain-link-2.6.2.tgz",
+      "integrity": "sha512-HMz+Dm6nMflqRkaebMqpv3uNnVkRrb6lD2HKTHNBGhjVbqf0wRzJ8JoQ08wn/sF00ljJZz8pGnpcMYHJNxE+wQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana-program/compute-budget": "^0.8.0",
+        "@solana-program/stake": "^0.2.1",
+        "@solana-program/token": "^0.5.1",
+        "@solana-program/token-2022": "^0.4.2",
+        "@solana/kit": "^2.3.0",
+        "@solana/rpc-types": "^2.3.0",
+        "@stellar/stellar-sdk": "14.2.0",
+        "@trezor/blockchain-link-types": "1.5.1",
+        "@trezor/blockchain-link-utils": "1.5.2",
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/utils": "9.5.0",
+        "@trezor/utxo-lib": "2.5.0",
+        "@trezor/websocket-client": "1.3.0",
+        "@types/web": "^0.0.197",
+        "crypto-browserify": "3.12.0",
+        "socks-proxy-agent": "8.0.5",
+        "stream-browserify": "^3.0.0",
+        "xrpl": "4.4.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-types": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-types/-/blockchain-link-types-1.5.1.tgz",
+      "integrity": "sha512-Idavz6LwLBW8sXc69fh5AJEnl666EDl2Nt3io7updvBgOR0/P12I900DgjNhCKtiWuv66A33/5RE7zLcj3lfnw==",
+      "dependencies": {
+        "@trezor/utils": "9.5.0",
+        "@trezor/utxo-lib": "2.5.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-utils/-/blockchain-link-utils-1.5.2.tgz",
+      "integrity": "sha512-OSS5OEE98FMnYfjoEALPjBt7ebjC/FKnq3HOolHdEWXBpVlXZNN2+Vo1R9J6WbZUU087sHuUTJJy/GJYWY13Tg==",
+      "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
+        "@stellar/stellar-sdk": "14.2.0",
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/protobuf": "1.5.2",
+        "@trezor/utils": "9.5.0",
+        "xrpl": "4.4.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils/node_modules/@stellar/stellar-sdk": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-14.2.0.tgz",
+      "integrity": "sha512-7nh2ogzLRMhfkIC0fGjn1LHUzk3jqVw8tjAuTt5ADWfL9CSGBL18ILucE9igz2L/RU2AZgeAvhujAnW91Ut/oQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@stellar/stellar-base": "^14.0.1",
+        "axios": "^1.12.2",
+        "bignumber.js": "^9.3.1",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils/node_modules/@trezor/protobuf": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.2.tgz",
+      "integrity": "sha512-zViaL1jKue8DUTVEDg0C/lMipqNMd/Z3kr29/+MeZOoupjaXIQ2Lqp3WAMe8hvNTKKX8aNQH9JrbapJ6w9FMXw==",
+      "dependencies": {
+        "@trezor/schema-utils": "1.4.0",
+        "long": "5.2.5",
+        "protobufjs": "7.4.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils/node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana-program/compute-budget": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.8.0.tgz",
+      "integrity": "sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==",
+      "peer": true,
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana-program/stake": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/stake/-/stake-0.2.1.tgz",
+      "integrity": "sha512-ssNPsJv9XHaA+L7ihzmWGYcm/+XYURQ8UA3wQMKf6ccEHyHOUgoglkkDU/BoA0+wul6HxZUN0tHFymC0qFw6sg==",
+      "peer": true,
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana-program/token": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.5.1.tgz",
+      "integrity": "sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==",
+      "peer": true,
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana-program/token-2022": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@solana-program/token-2022/-/token-2022-0.4.2.tgz",
+      "integrity": "sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw==",
+      "peer": true,
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0",
+        "@solana/sysvars": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/accounts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.3.0.tgz",
+      "integrity": "sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/addresses": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.3.0.tgz",
+      "integrity": "sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/assertions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.3.0.tgz",
+      "integrity": "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.3.0.tgz",
+      "integrity": "sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/options": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-data-structures": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.3.0.tgz",
+      "integrity": "sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-strings": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.3.0.tgz",
+      "integrity": "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/fast-stable-stringify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.3.0.tgz",
+      "integrity": "sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/functional": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.3.0.tgz",
+      "integrity": "sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/instructions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.3.0.tgz",
+      "integrity": "sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/keys": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.3.0.tgz",
+      "integrity": "sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/kit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.3.0.tgz",
+      "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/programs": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/signers": "2.3.0",
+        "@solana/sysvars": "2.3.0",
+        "@solana/transaction-confirmation": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/nominal-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-2.3.0.tgz",
+      "integrity": "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/options": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.3.0.tgz",
+      "integrity": "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/programs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.3.0.tgz",
+      "integrity": "sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/promises": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.3.0.tgz",
+      "integrity": "sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.3.0.tgz",
+      "integrity": "sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-api": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-transport-http": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.3.0.tgz",
+      "integrity": "sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-parsed-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.3.0.tgz",
+      "integrity": "sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.3.0.tgz",
+      "integrity": "sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-spec-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.3.0.tgz",
+      "integrity": "sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-subscriptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.3.0.tgz",
+      "integrity": "sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions-api": "2.3.0",
+        "@solana/rpc-subscriptions-channel-websocket": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-subscriptions-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.3.0.tgz",
+      "integrity": "sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.3.0.tgz",
+      "integrity": "sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.3.0.tgz",
+      "integrity": "sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-transformers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.3.0.tgz",
+      "integrity": "sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-transport-http": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.3.0.tgz",
+      "integrity": "sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "undici-types": "^7.11.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.3.0.tgz",
+      "integrity": "sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/signers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.3.0.tgz",
+      "integrity": "sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/subscribable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.3.0.tgz",
+      "integrity": "sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/sysvars": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.3.0.tgz",
+      "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/transaction-confirmation": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.3.0.tgz",
+      "integrity": "sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/transaction-messages": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.3.0.tgz",
+      "integrity": "sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/transactions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.3.0.tgz",
+      "integrity": "sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@stellar/stellar-sdk": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-14.2.0.tgz",
+      "integrity": "sha512-7nh2ogzLRMhfkIC0fGjn1LHUzk3jqVw8tjAuTt5ADWfL9CSGBL18ILucE9igz2L/RU2AZgeAvhujAnW91Ut/oQ==",
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "@stellar/stellar-base": "^14.0.1",
+        "axios": "^1.12.2",
+        "bignumber.js": "^9.3.1",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "peer": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@trezor/connect": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.7.3.tgz",
+      "integrity": "sha512-oAOfvJHT8tPqOXTmCOhn8uTZcoqSDuWAiWXQegx7C46tq+NLg+enkYXxUYEHq/9PmfZAOrUT9VMxZDsXM2thkA==",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/common": "^10.1.0",
+        "@ethereumjs/tx": "^10.1.0",
+        "@fivebinaries/coin-selection": "3.0.0",
+        "@mobily/ts-belt": "^3.13.1",
+        "@noble/hashes": "^1.6.1",
+        "@scure/bip39": "^1.5.1",
+        "@solana-program/compute-budget": "^0.8.0",
+        "@solana-program/system": "^0.7.0",
+        "@solana-program/token": "^0.5.1",
+        "@solana-program/token-2022": "^0.4.2",
+        "@solana/kit": "^2.3.0",
+        "@trezor/blockchain-link": "2.6.2",
+        "@trezor/blockchain-link-types": "1.5.1",
+        "@trezor/blockchain-link-utils": "1.5.2",
+        "@trezor/connect-analytics": "1.4.0",
+        "@trezor/connect-common": "0.5.1",
+        "@trezor/crypto-utils": "1.2.0",
+        "@trezor/device-authenticity": "1.1.2",
+        "@trezor/device-utils": "1.2.0",
+        "@trezor/env-utils": "^1.5.0",
+        "@trezor/protobuf": "1.5.3",
+        "@trezor/protocol": "1.3.1",
+        "@trezor/schema-utils": "1.4.0",
+        "@trezor/transport": "1.6.3",
+        "@trezor/type-utils": "1.2.0",
+        "@trezor/utils": "9.5.0",
+        "@trezor/utxo-lib": "2.5.0",
+        "blakejs": "^1.2.1",
+        "bs58": "^6.0.0",
+        "bs58check": "^4.0.0",
+        "cbor": "^10.0.10",
+        "cross-fetch": "^4.0.0",
+        "jws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-analytics": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-analytics/-/connect-analytics-1.4.0.tgz",
+      "integrity": "sha512-hy2J2oeIhRC/e1bOWXo5dsVMVnDwO2UKnxhR6FD8PINR3jgM6PWAXc6k33WJsBcyiTzwMP7/xPysLcgNJH5o4w==",
+      "dependencies": {
+        "@trezor/analytics": "1.5.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-common": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.5.1.tgz",
+      "integrity": "sha512-wdpVCwdylBh4SBO5Ys40tB/d59UlfjmxgBHDkkLgaR+JcqkthCfiw5VlUrV9wu65lquejAZhA5KQL4mUUUhCow==",
+      "dependencies": {
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/type-utils": "1.2.0",
+        "@trezor/utils": "9.5.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-web/-/connect-web-9.7.2.tgz",
+      "integrity": "sha512-r4wMnQ51KO1EaMpO8HLB95E+4s+aaZE9Vjx1dHYaD+Xj40LR7OJmR6DyDKuF0Ioji3Jxx1MwZCaFfvA+0JW+Sg==",
+      "dependencies": {
+        "@trezor/connect": "9.7.2",
+        "@trezor/connect-common": "0.5.1",
+        "@trezor/utils": "9.5.0",
+        "@trezor/websocket-client": "1.3.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana-program/compute-budget": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.8.0.tgz",
+      "integrity": "sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana-program/stake": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/stake/-/stake-0.2.1.tgz",
+      "integrity": "sha512-ssNPsJv9XHaA+L7ihzmWGYcm/+XYURQ8UA3wQMKf6ccEHyHOUgoglkkDU/BoA0+wul6HxZUN0tHFymC0qFw6sg==",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana-program/system": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.7.0.tgz",
+      "integrity": "sha512-FKTBsKHpvHHNc1ATRm7SlC5nF/VdJtOSjldhcyfMN9R7xo712Mo2jHIzvBgn8zQO5Kg0DcWuKB7268Kv1ocicw==",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana-program/token": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.5.1.tgz",
+      "integrity": "sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana-program/token-2022": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@solana-program/token-2022/-/token-2022-0.4.2.tgz",
+      "integrity": "sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw==",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0",
+        "@solana/sysvars": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/accounts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.3.0.tgz",
+      "integrity": "sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/addresses": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.3.0.tgz",
+      "integrity": "sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==",
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/assertions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.3.0.tgz",
+      "integrity": "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/codecs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.3.0.tgz",
+      "integrity": "sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/options": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/codecs-data-structures": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.3.0.tgz",
+      "integrity": "sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/codecs-strings": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.3.0.tgz",
+      "integrity": "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/fast-stable-stringify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.3.0.tgz",
+      "integrity": "sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/functional": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.3.0.tgz",
+      "integrity": "sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/instructions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.3.0.tgz",
+      "integrity": "sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/keys": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.3.0.tgz",
+      "integrity": "sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==",
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/kit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.3.0.tgz",
+      "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/programs": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/signers": "2.3.0",
+        "@solana/sysvars": "2.3.0",
+        "@solana/transaction-confirmation": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/nominal-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-2.3.0.tgz",
+      "integrity": "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/options": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.3.0.tgz",
+      "integrity": "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/programs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.3.0.tgz",
+      "integrity": "sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/promises": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.3.0.tgz",
+      "integrity": "sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/rpc": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.3.0.tgz",
+      "integrity": "sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-api": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-transport-http": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/rpc-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.3.0.tgz",
+      "integrity": "sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/rpc-parsed-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.3.0.tgz",
+      "integrity": "sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/rpc-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.3.0.tgz",
+      "integrity": "sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/rpc-spec-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.3.0.tgz",
+      "integrity": "sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/rpc-subscriptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.3.0.tgz",
+      "integrity": "sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions-api": "2.3.0",
+        "@solana/rpc-subscriptions-channel-websocket": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/rpc-subscriptions-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.3.0.tgz",
+      "integrity": "sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.3.0.tgz",
+      "integrity": "sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.3.0.tgz",
+      "integrity": "sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/rpc-transformers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.3.0.tgz",
+      "integrity": "sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/rpc-transport-http": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.3.0.tgz",
+      "integrity": "sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "undici-types": "^7.11.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/rpc-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.3.0.tgz",
+      "integrity": "sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/signers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.3.0.tgz",
+      "integrity": "sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/subscribable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.3.0.tgz",
+      "integrity": "sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/sysvars": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.3.0.tgz",
+      "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/transaction-confirmation": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.3.0.tgz",
+      "integrity": "sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/transaction-messages": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.3.0.tgz",
+      "integrity": "sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@solana/transactions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.3.0.tgz",
+      "integrity": "sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@stellar/stellar-sdk": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-14.2.0.tgz",
+      "integrity": "sha512-7nh2ogzLRMhfkIC0fGjn1LHUzk3jqVw8tjAuTt5ADWfL9CSGBL18ILucE9igz2L/RU2AZgeAvhujAnW91Ut/oQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@stellar/stellar-base": "^14.0.1",
+        "axios": "^1.12.2",
+        "bignumber.js": "^9.3.1",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/blockchain-link": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link/-/blockchain-link-2.6.1.tgz",
+      "integrity": "sha512-SPwxkihOMI0o79BOy0RkfgVL2meuJhIe1yWHCeR8uoqf5KGblUyeXxvNCy6w8ckJ9LRpM1+bZhsUODuNs3083Q==",
+      "dependencies": {
+        "@solana-program/compute-budget": "^0.8.0",
+        "@solana-program/stake": "^0.2.1",
+        "@solana-program/token": "^0.5.1",
+        "@solana-program/token-2022": "^0.4.2",
+        "@solana/kit": "^2.3.0",
+        "@solana/rpc-types": "^2.3.0",
+        "@stellar/stellar-sdk": "14.2.0",
+        "@trezor/blockchain-link-types": "1.5.0",
+        "@trezor/blockchain-link-utils": "1.5.1",
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/utils": "9.5.0",
+        "@trezor/utxo-lib": "2.5.0",
+        "@trezor/websocket-client": "1.3.0",
+        "@types/web": "^0.0.197",
+        "crypto-browserify": "3.12.0",
+        "socks-proxy-agent": "8.0.5",
+        "stream-browserify": "^3.0.0",
+        "xrpl": "4.4.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/blockchain-link/node_modules/@trezor/blockchain-link-types": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-types/-/blockchain-link-types-1.5.0.tgz",
+      "integrity": "sha512-wD6FKKxNr89MTWYL+NikRkBcWXhiWNFR0AuDHW6GHmlCEHhKu/hAvQtcER8X5jt/Wd0hSKNZqtHBXJ1ZkpJ6rg==",
+      "dependencies": {
+        "@trezor/utils": "9.5.0",
+        "@trezor/utxo-lib": "2.5.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/blockchain-link/node_modules/@trezor/blockchain-link-utils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-utils/-/blockchain-link-utils-1.5.1.tgz",
+      "integrity": "sha512-2tDGLEj5jzydjsJQONGTWVmCDDy6FTZ4ytr1/2gE6anyYEJU8MbaR+liTt3UvcP5jwZTNutwYLvZixRfrb8JpA==",
+      "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
+        "@stellar/stellar-sdk": "14.2.0",
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/protobuf": "1.5.1",
+        "@trezor/utils": "9.5.0",
+        "xrpl": "4.4.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/blockchain-link/node_modules/@trezor/protobuf": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.1.tgz",
+      "integrity": "sha512-nAkaCCAqLpErBd+IuKeG5MpbyLR/2RMgCw18TWc80m1Ws/XgQirhHY9Jbk6gLImTXb9GTrxP0+MDSahzd94rSA==",
+      "dependencies": {
+        "@trezor/schema-utils": "1.4.0",
+        "long": "5.2.5",
+        "protobufjs": "7.4.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/connect": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.7.2.tgz",
+      "integrity": "sha512-Sn6F4mNH+yi2vAHy29kwhs50bRLn92drg3znm3pkY+8yEBxI4MmuP8sKYjdgUEJnQflWh80KlcvEDeVa4olVRA==",
+      "dependencies": {
+        "@ethereumjs/common": "^10.1.0",
+        "@ethereumjs/tx": "^10.1.0",
+        "@fivebinaries/coin-selection": "3.0.0",
+        "@mobily/ts-belt": "^3.13.1",
+        "@noble/hashes": "^1.6.1",
+        "@scure/bip39": "^1.5.1",
+        "@solana-program/compute-budget": "^0.8.0",
+        "@solana-program/system": "^0.7.0",
+        "@solana-program/token": "^0.5.1",
+        "@solana-program/token-2022": "^0.4.2",
+        "@solana/kit": "^2.3.0",
+        "@trezor/blockchain-link": "2.6.1",
+        "@trezor/blockchain-link-types": "1.5.1",
+        "@trezor/blockchain-link-utils": "1.5.2",
+        "@trezor/connect-analytics": "1.4.0",
+        "@trezor/connect-common": "0.5.1",
+        "@trezor/crypto-utils": "1.2.0",
+        "@trezor/device-authenticity": "1.1.2",
+        "@trezor/device-utils": "1.2.0",
+        "@trezor/env-utils": "^1.5.0",
+        "@trezor/protobuf": "1.5.2",
+        "@trezor/protocol": "1.3.0",
+        "@trezor/schema-utils": "1.4.0",
+        "@trezor/transport": "1.6.2",
+        "@trezor/type-utils": "1.2.0",
+        "@trezor/utils": "9.5.0",
+        "@trezor/utxo-lib": "2.5.0",
+        "blakejs": "^1.2.1",
+        "bs58": "^6.0.0",
+        "bs58check": "^4.0.0",
+        "cbor": "^10.0.10",
+        "cross-fetch": "^4.0.0",
+        "jws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/protobuf": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.2.tgz",
+      "integrity": "sha512-zViaL1jKue8DUTVEDg0C/lMipqNMd/Z3kr29/+MeZOoupjaXIQ2Lqp3WAMe8hvNTKKX8aNQH9JrbapJ6w9FMXw==",
+      "dependencies": {
+        "@trezor/schema-utils": "1.4.0",
+        "long": "5.2.5",
+        "protobufjs": "7.4.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/protocol": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@trezor/protocol/-/protocol-1.3.0.tgz",
+      "integrity": "sha512-rmrxbDrdgxTouBPbZcSeqU7ba/e5WVT1dxvxxEntHqRdTiDl7d3VK+BErCrlyol8EH5YCqEF3/rXt0crSOfoFw==",
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/transport": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.6.2.tgz",
+      "integrity": "sha512-w0HlD1fU+qTGO3tefBGHF/YS/ts/TWFja9FGIJ4+7+Z9NphvIG06HGvy2HzcD9AhJy9pvDeIsyoM2TTZTiyjkQ==",
+      "dependencies": {
+        "@trezor/protobuf": "1.5.2",
+        "@trezor/protocol": "1.3.0",
+        "@trezor/type-utils": "1.2.0",
+        "@trezor/utils": "9.5.0",
+        "cross-fetch": "^4.0.0",
+        "usb": "^2.15.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana-program/compute-budget": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.8.0.tgz",
+      "integrity": "sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==",
+      "peer": true,
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana-program/system": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.7.0.tgz",
+      "integrity": "sha512-FKTBsKHpvHHNc1ATRm7SlC5nF/VdJtOSjldhcyfMN9R7xo712Mo2jHIzvBgn8zQO5Kg0DcWuKB7268Kv1ocicw==",
+      "peer": true,
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana-program/token": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.5.1.tgz",
+      "integrity": "sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==",
+      "peer": true,
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana-program/token-2022": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@solana-program/token-2022/-/token-2022-0.4.2.tgz",
+      "integrity": "sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw==",
+      "peer": true,
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0",
+        "@solana/sysvars": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/accounts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.3.0.tgz",
+      "integrity": "sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/addresses": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.3.0.tgz",
+      "integrity": "sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/assertions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.3.0.tgz",
+      "integrity": "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/codecs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.3.0.tgz",
+      "integrity": "sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/options": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/codecs-data-structures": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.3.0.tgz",
+      "integrity": "sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/codecs-strings": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.3.0.tgz",
+      "integrity": "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/fast-stable-stringify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.3.0.tgz",
+      "integrity": "sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/functional": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.3.0.tgz",
+      "integrity": "sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/instructions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.3.0.tgz",
+      "integrity": "sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/keys": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.3.0.tgz",
+      "integrity": "sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/kit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.3.0.tgz",
+      "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/programs": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/signers": "2.3.0",
+        "@solana/sysvars": "2.3.0",
+        "@solana/transaction-confirmation": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/nominal-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-2.3.0.tgz",
+      "integrity": "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/options": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.3.0.tgz",
+      "integrity": "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/programs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.3.0.tgz",
+      "integrity": "sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/promises": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.3.0.tgz",
+      "integrity": "sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.3.0.tgz",
+      "integrity": "sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-api": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-transport-http": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.3.0.tgz",
+      "integrity": "sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-parsed-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.3.0.tgz",
+      "integrity": "sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.3.0.tgz",
+      "integrity": "sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-spec-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.3.0.tgz",
+      "integrity": "sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-subscriptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.3.0.tgz",
+      "integrity": "sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions-api": "2.3.0",
+        "@solana/rpc-subscriptions-channel-websocket": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-subscriptions-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.3.0.tgz",
+      "integrity": "sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.3.0.tgz",
+      "integrity": "sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.3.0.tgz",
+      "integrity": "sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-transformers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.3.0.tgz",
+      "integrity": "sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-transport-http": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.3.0.tgz",
+      "integrity": "sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "undici-types": "^7.11.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.3.0.tgz",
+      "integrity": "sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/signers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.3.0.tgz",
+      "integrity": "sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/subscribable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.3.0.tgz",
+      "integrity": "sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/sysvars": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.3.0.tgz",
+      "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/transaction-confirmation": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.3.0.tgz",
+      "integrity": "sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/transaction-messages": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.3.0.tgz",
+      "integrity": "sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/transactions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.3.0.tgz",
+      "integrity": "sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "peer": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@trezor/crypto-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@trezor/crypto-utils/-/crypto-utils-1.2.0.tgz",
+      "integrity": "sha512-9i1NrfW1IE6JO910ut7xrx4u5LxE++GETbpJhWLj4P5xpuGDDSDLEn/MXaYisls2DpE897aOrGPaa1qyt8V6tw==",
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/device-authenticity": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@trezor/device-authenticity/-/device-authenticity-1.1.2.tgz",
+      "integrity": "sha512-313uSXYR4XKDv3CjtCpgHA+yEe9xxqN7EFl/D68FEn70SPsuWI0+2zUvjPPh6TIOh/EcLv7hCO/QTHUAGd7ZWQ==",
+      "dependencies": {
+        "@noble/curves": "^2.0.1",
+        "@trezor/crypto-utils": "1.2.0",
+        "@trezor/protobuf": "1.5.2",
+        "@trezor/schema-utils": "1.4.0",
+        "@trezor/utils": "9.5.0"
+      }
+    },
+    "node_modules/@trezor/device-authenticity/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@trezor/device-authenticity/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@trezor/device-authenticity/node_modules/@trezor/protobuf": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.2.tgz",
+      "integrity": "sha512-zViaL1jKue8DUTVEDg0C/lMipqNMd/Z3kr29/+MeZOoupjaXIQ2Lqp3WAMe8hvNTKKX8aNQH9JrbapJ6w9FMXw==",
+      "dependencies": {
+        "@trezor/schema-utils": "1.4.0",
+        "long": "5.2.5",
+        "protobufjs": "7.4.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/device-authenticity/node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@trezor/device-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@trezor/device-utils/-/device-utils-1.2.0.tgz",
+      "integrity": "sha512-Aqp7pIooFTx21zRUtTI6i1AS4d9Lrx7cclvksh2nJQF9WJvbzuCXshEGkLoOsHwhQrCl3IXfbGuMdA12yDenPA=="
+    },
+    "node_modules/@trezor/env-utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.5.0.tgz",
+      "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
+      "dependencies": {
+        "ua-parser-js": "^2.0.4"
+      },
+      "peerDependencies": {
+        "expo-constants": "*",
+        "expo-localization": "*",
+        "react-native": "*",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "expo-constants": {
+          "optional": true
+        },
+        "expo-localization": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trezor/protobuf": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.3.tgz",
+      "integrity": "sha512-ZYQtapkT2NaiVrAgb91Zprnk3uhl2Wca0bsnJcWgE7vwzqKegjrSorRnkZLqLTKTbCaT6sgkCYtM2hPl4Hqw5Q==",
+      "peer": true,
+      "dependencies": {
+        "@trezor/schema-utils": "1.4.0",
+        "long": "5.2.5",
+        "protobufjs": "7.5.5"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/protocol": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@trezor/protocol/-/protocol-1.3.1.tgz",
+      "integrity": "sha512-uNJ83n38+BM+AJKsWza1ocvQ206d6NXJQ8/g+DelPLTj5c37Rj6hFiY5Nb5zgM7DBnq6T8Aa2K8t4TVCzHT1qg==",
+      "peer": true,
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/schema-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@trezor/schema-utils/-/schema-utils-1.4.0.tgz",
+      "integrity": "sha512-K7upSeh7VDrORaIC4KAxYVW93XNlohmUnH5if/5GKYmTdQSRp1nBkO6Jm+Z4hzIthdnz/1aLgnbeN3bDxWLRxA==",
+      "dependencies": {
+        "@sinclair/typebox": "^0.33.7",
+        "ts-mixer": "^6.0.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/schema-utils/node_modules/@sinclair/typebox": {
+      "version": "0.33.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.24.tgz",
+      "integrity": "sha512-91up4t0BLjfkCZ4Ap/BcgaPrMaX6n0I2YRu+kc03xGhLy9G3N05nbTpnK8q7GXdv0PxwUoxi67A8o3Wr5U7j3w=="
+    },
+    "node_modules/@trezor/transport": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.6.3.tgz",
+      "integrity": "sha512-GEi9KfiJsBgT/MCGNDIn9RDeXceLaAPjJT/GCayirXaCr3KnlpZCs6LGYkrjqapxiBm73nxM+BctKBKhpUl2cQ==",
+      "peer": true,
+      "dependencies": {
+        "@trezor/protobuf": "1.5.3",
+        "@trezor/protocol": "1.3.1",
+        "@trezor/type-utils": "1.2.0",
+        "@trezor/utils": "9.5.0",
+        "cross-fetch": "^4.0.0",
+        "usb": "^2.15.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/type-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@trezor/type-utils/-/type-utils-1.2.0.tgz",
+      "integrity": "sha512-+E2QntxkyQuYfQQyl8RvT01tq2i5Dp/LFUOXuizF+KVOqsZBjBY43j5hewcCO3+MokD7deDiPyekbUEN5/iVlw=="
+    },
+    "node_modules/@trezor/utils": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.5.0.tgz",
+      "integrity": "sha512-kdyMyDbxzvOZmwBNvTjAK+C/kzyOz8T4oUbFvq+KaXn5mBFf1uf8rq5X2HkxgdYRPArtHS3PxLKsfkNCdhCYtQ==",
+      "dependencies": {
+        "bignumber.js": "^9.3.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/utxo-lib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/utxo-lib/-/utxo-lib-2.5.0.tgz",
+      "integrity": "sha512-Fa2cZh0037oX6AHNLfpFIj65UR/OoX0ZJTocFuQASe77/1PjZHysf6BvvGfmzuFToKfrAQ+DM/1Sx+P/vnyNmA==",
+      "dependencies": {
+        "@trezor/utils": "9.5.0",
+        "bech32": "^2.0.0",
+        "bip66": "^2.0.0",
+        "bitcoin-ops": "^1.4.1",
+        "blake-hash": "^2.0.0",
+        "blakejs": "^1.2.1",
+        "bn.js": "^5.2.2",
+        "bs58": "^6.0.0",
+        "bs58check": "^4.0.0",
+        "cashaddrjs": "0.4.4",
+        "create-hmac": "^1.1.7",
+        "int64-buffer": "^1.1.0",
+        "pushdata-bitcoin": "^1.0.1",
+        "tiny-secp256k1": "^1.1.7",
+        "typeforce": "^1.18.0",
+        "varuint-bitcoin": "2.0.0",
+        "wif": "^5.0.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/websocket-client": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@trezor/websocket-client/-/websocket-client-1.3.0.tgz",
+      "integrity": "sha512-9KQSaVc3NtmM6rFFj1e+9bM0C5mVKVidbnxlfzuBJu7G2YMRdIdLPcAXhvmRZjs40uzDuBeApK+p547kODz2ug==",
+      "dependencies": {
+        "@trezor/utils": "9.5.0",
+        "ws": "^8.18.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4883,6 +9622,14 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/d3-array": {
@@ -4963,20 +9710,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/fs-extra": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
-      "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minimist": {
@@ -5075,12 +9812,6 @@
         "@types/react": "*"
       }
     },
-    "node_modules/@types/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -5093,11 +9824,26 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
+    },
+    "node_modules/@types/w3c-web-usb": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.14.tgz",
+      "integrity": "sha512-Qu3Nn6JFuF4+sHKYl+IcX9vYiI40ogleXzFFSxoE1W94rG98o/kXs8uJ0QSfFzuwBCZWlGfUGpPkgwuuX4PchA=="
+    },
     "node_modules/@types/warning": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.4.tgz",
       "integrity": "sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg==",
       "license": "MIT"
+    },
+    "node_modules/@types/web": {
+      "version": "0.0.197",
+      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.197.tgz",
+      "integrity": "sha512-V4sOroWDADFx9dLodWpKm298NOJ1VJ6zoDVgaP+WBb/utWxqQ6gnMzd9lvVDAr/F3ibiKaxH9i45eS0gQPSTaQ=="
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
@@ -5105,6 +9851,14 @@
       "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -5574,13 +10328,754 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
-      "license": "MIT",
+    "node_modules/@wallet-standard/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ==",
       "engines": {
-        "node": ">=14.6"
+        "node": ">=22"
+      }
+    },
+    "node_modules/@wallet-standard/features": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.1.tgz",
+      "integrity": "sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA==",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@wallet-standard/wallet": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/wallet/-/wallet-1.1.0.tgz",
+      "integrity": "sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@walletconnect/core": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.0.tgz",
+      "integrity": "sha512-W++xuXf+AsMPrBWn1It8GheIbCTp1ynTQP+aoFB86eUwyCtSiK7UQsn/+vJZdwElrn+Ptp2A0RqQx2onTMVHjQ==",
+      "dependencies": {
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.0",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.0",
+        "@walletconnect/utils": "2.23.0",
+        "@walletconnect/window-getters": "1.0.1",
+        "es-toolkit": "1.39.3",
+        "events": "3.3.0",
+        "uint8arrays": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18.20.8"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/@walletconnect/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/@walletconnect/types": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.0.tgz",
+      "integrity": "sha512-9ZEOJyx/kNVCRncDHh3Qr9eH7Ih1dXBFB4k1J8iEudkv3t4GhYpXhqIt2kNdQWluPb1BBB4wEuckAT96yKuA8g==",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.0",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/es-toolkit": {
+      "version": "1.39.3",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.3.tgz",
+      "integrity": "sha512-Qb/TCFCldgOy8lZ5uC7nLGdqJwSabkQiYQShmw4jyiPk1pZzaYWTwaYKYP7EgLccWYgZocMrtItrwh683voaww=="
+    },
+    "node_modules/@walletconnect/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/environment/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@walletconnect/events": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
+      "integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
+      "dependencies": {
+        "keyvaluestorage-interface": "^1.0.0",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/events/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@walletconnect/heartbeat": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.2.tgz",
+      "integrity": "sha512-uASiRmC5MwhuRuf05vq4AT48Pq8RMi876zV8rr8cV969uTOzWdB/k+Lj5yI2PBtB1bGQisGen7MM1GcZlQTBXw==",
+      "dependencies": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-http-connection": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.8.tgz",
+      "integrity": "sha512-+B7cRuaxijLeFDJUq5hAzNyef3e3tBDIxyaCNmFtjwnod5AGis3RToNqzFU33vpVcxFhofkpE7Cx+5MYejbMGw==",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.1",
+        "cross-fetch": "^3.1.4",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-http-connection/node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-http-connection/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-http-connection/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/@walletconnect/jsonrpc-http-connection/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@walletconnect/jsonrpc-http-connection/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-provider": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.14.tgz",
+      "integrity": "sha512-rtsNY1XqHvWj0EtITNeuf8PHMvlCLiS3EjQL+WOkxEOA4KPxsohFnBDeyPYiNm4ZvkQdLnece36opYidmtbmow==",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.4.tgz",
+      "integrity": "sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==",
+      "dependencies": {
+        "events": "^3.3.0",
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-utils": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
+      "dependencies": {
+        "@walletconnect/environment": "^1.0.1",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
+      "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0",
+        "ws": "^7.5.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/keyvaluestorage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.1",
+        "idb-keyval": "^6.2.1",
+        "unstorage": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "1.x"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/logger": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/relay-api": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.11.tgz",
+      "integrity": "sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==",
+      "dependencies": {
+        "@walletconnect/jsonrpc-types": "^1.0.2"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.1.0.tgz",
+      "integrity": "sha512-qFw+a9uRz26jRCDgL7Q5TA9qYIgcNY8jpJzI1zAWNZ8i7mQjaijRnWFKsCHAU9CyGjvt6RKrRXyFtFOpWTVmCQ==",
+      "dependencies": {
+        "@noble/curves": "1.8.0",
+        "@noble/hashes": "1.7.0",
+        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth/node_modules/@noble/curves": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.0.tgz",
+      "integrity": "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==",
+      "dependencies": {
+        "@noble/hashes": "1.7.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth/node_modules/@noble/hashes": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
+      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/safe-json": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/safe-json/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@walletconnect/sign-client": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.0.tgz",
+      "integrity": "sha512-Nzf5x/LnQgC0Yjk0NmkT8kdrIMcScpALiFm9gP0n3CulL+dkf3HumqWzdoTmQSqGPxwHu/TNhGOaRKZLGQXSqw==",
+      "dependencies": {
+        "@walletconnect/core": "2.23.0",
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "3.0.0",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.0",
+        "@walletconnect/utils": "2.23.0",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/@walletconnect/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/@walletconnect/types": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.0.tgz",
+      "integrity": "sha512-9ZEOJyx/kNVCRncDHh3Qr9eH7Ih1dXBFB4k1J8iEudkv3t4GhYpXhqIt2kNdQWluPb1BBB4wEuckAT96yKuA8g==",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.0",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
+      "integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/time/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@walletconnect/types": {
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.9.tgz",
+      "integrity": "sha512-IUl1PpD/Dig8IE2OZ9XtjbPohEyOZJ73xs92EDUzoIyzRtfm36g2D340pY3iu3AAdLv1yFiaZafB8Hf8RFze8A==",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.7.tgz",
+      "integrity": "sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/jsonrpc-http-connection": "1.0.8",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/sign-client": "2.23.7",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "es-toolkit": "1.44.0",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/core": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
+      "integrity": "sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==",
+      "dependencies": {
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "@walletconnect/window-getters": "1.0.1",
+        "es-toolkit": "1.44.0",
+        "events": "3.3.0",
+        "uint8arrays": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18.20.8"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/sign-client": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.7.tgz",
+      "integrity": "sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==",
+      "dependencies": {
+        "@walletconnect/core": "2.23.7",
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/types": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.7.tgz",
+      "integrity": "sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/utils": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.7.tgz",
+      "integrity": "sha512-3p38gNrkVcIiQixVrlsWSa66Gjs5PqHOug2TxDgYUVBW5NcKjwQA08GkC6CKBQUfr5iaCtbfy6uZJW1LKSIvWQ==",
+      "dependencies": {
+        "@msgpack/msgpack": "3.1.3",
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.7",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.6",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/window-getters": "1.0.1",
+        "@walletconnect/window-metadata": "1.0.1",
+        "blakejs": "1.2.1",
+        "detect-browser": "5.3.0",
+        "ox": "0.9.3",
+        "uint8arrays": "3.1.1"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg=="
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/ox": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
+      "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.9",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/utils": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.0.tgz",
+      "integrity": "sha512-bVyv4Hl+/wVGueZ6rEO0eYgDy5deSBA4JjpJHAMOdaNoYs05NTE1HymV2lfPQQHuqc7suYexo9jwuW7i3JLuAA==",
+      "dependencies": {
+        "@msgpack/msgpack": "3.1.2",
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.7",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.6",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.0",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.0",
+        "@walletconnect/window-getters": "1.0.1",
+        "@walletconnect/window-metadata": "1.0.1",
+        "blakejs": "1.2.1",
+        "bs58": "6.0.0",
+        "detect-browser": "5.3.0",
+        "ox": "0.9.3",
+        "uint8arrays": "3.1.1"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@walletconnect/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@walletconnect/types": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.0.tgz",
+      "integrity": "sha512-9ZEOJyx/kNVCRncDHh3Qr9eH7Ih1dXBFB4k1J8iEudkv3t4GhYpXhqIt2kNdQWluPb1BBB4wEuckAT96yKuA8g==",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.0",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/@walletconnect/utils/node_modules/ox": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
+      "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.9",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/window-getters": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/window-getters/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@walletconnect/window-metadata": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+      "dependencies": {
+        "@walletconnect/window-getters": "^1.0.1",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/window-metadata/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@xrplf/isomorphic": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@xrplf/isomorphic/-/isomorphic-1.0.2.tgz",
+      "integrity": "sha512-ncZUdMXr6VlSXtdoiDi0jTH+gBrgGxwVeEidhoegII3PmyErbQsyj6e+j7acmR4LW/lvBkPkzb9QzRfJH0n3rA==",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1",
+        "eventemitter3": "5.0.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@xrplf/isomorphic/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@xrplf/isomorphic/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/@xrplf/secret-numbers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@xrplf/secret-numbers/-/secret-numbers-2.0.0.tgz",
+      "integrity": "sha512-z3AOibRTE9E8MbjgzxqMpG1RNaBhQ1jnfhNCa1cGf2reZUJzPMYs4TggQTc7j8+0WyV3cr7y/U8Oz99SXIkN5Q==",
+      "dependencies": {
+        "@xrplf/isomorphic": "^1.0.1",
+        "ripple-keypairs": "^2.0.0"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.3.0.tgz",
+      "integrity": "sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/acorn": {
@@ -5610,10 +11105,20 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -5754,6 +11259,29 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -5804,6 +11332,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -5827,15 +11370,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/async": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
@@ -5852,13 +11386,12 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
-    "node_modules/at-least-node": {
+    "node_modules/atomic-sleep": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -5887,14 +11420,37 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
-      "license": "MIT",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+      "optional": true,
+      "dependencies": {
+        "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
+      }
+    },
+    "node_modules/axios-retry/node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -5918,6 +11474,55 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-addon-resolve": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.1.tgz",
+      "integrity": "sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-resolve": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.4.tgz",
+      "integrity": "sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-semver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
+      "integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="
     },
     "node_modules/base32.js": {
       "version": "0.1.0",
@@ -5971,6 +11576,11 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
     "node_modules/bfj": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.0.2.tgz",
@@ -5987,13 +11597,16 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
+    "node_modules/big.js": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.2.tgz",
+      "integrity": "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==",
       "engines": {
-        "node": ">=0.6"
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
       }
     },
     "node_modules/bignumber.js": {
@@ -6004,6 +11617,29 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bip32-path": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/bip32-path/-/bip32-path-0.4.2.tgz",
+      "integrity": "sha512-ZBMCELjJfcNMkz5bDuJ1WrYvjlhEF5k6mQ8vUr4N7MbVRsXei7ZOg8VhhwMfNiW68NWmLkgkc6WvTickrLGprQ=="
+    },
+    "node_modules/bip66": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-2.0.0.tgz",
+      "integrity": "sha512-kBG+hSpgvZBrkIm9dt5T1Hd/7xGCPEX2npoxAWZfsK1FvjgaxySEh2WizjyIstWXriKo9K9uJ4u0OnsyLDUPXQ=="
+    },
+    "node_modules/bitcoin-ops": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
+      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -6042,6 +11678,25 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/blake-hash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/blake-hash/-/blake-hash-2.0.0.tgz",
+      "integrity": "sha512-Igj8YowDu1PRkRsxZA7NVkdFNxH5rKv5cpLxQ0CVXSIA77pVYwCPRQJ2sMew/oneUpfuYRyjG6r8SmmmnbZb1w==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -6049,12 +11704,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bn.js": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+      "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg=="
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/borsh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-2.0.0.tgz",
+      "integrity": "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg=="
     },
     "node_modules/boxen": {
       "version": "5.1.2",
@@ -6158,18 +11823,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/bplist-parser": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
-      "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "big-integer": "1.6.x"
-      },
-      "engines": {
-        "node": ">= 5.10.0"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -6193,6 +11846,114 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+      "integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
+      "dependencies": {
+        "bn.js": "^5.2.3",
+        "browserify-rsa": "^4.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.6.1",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.9",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
@@ -6228,6 +11989,23 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/bs58check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -6256,9 +12034,33 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/cac": {
@@ -6377,7 +12179,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6421,6 +12222,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cashaddrjs": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cashaddrjs/-/cashaddrjs-0.4.4.tgz",
+      "integrity": "sha512-xZkuWdNOh0uq/mxJIng6vYWfTowZLd9F4GMAlp2DwFHlcCqCm91NtuAc47RuV4L7r4PYcY5p6Cr2OKNb4hnkWA==",
+      "dependencies": {
+        "big-integer": "1.6.36"
+      }
+    },
+    "node_modules/cashaddrjs/node_modules/big-integer": {
+      "version": "1.6.36",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/cbor": {
+      "version": "10.0.12",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-10.0.12.tgz",
+      "integrity": "sha512-exQDevYd7ZQLP4moMQcZkKCVZsXLAtUSflObr3xTh4xzFIv/xBCdvCd6L259kQOUP2kcTC0jvC6PpZIf/WmRXA==",
+      "dependencies": {
+        "nofilter": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -6467,7 +12295,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
@@ -6534,6 +12361,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -6563,6 +12404,19 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cli-boxes": {
       "version": "2.2.1",
@@ -6832,6 +12686,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cookie-es": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -6857,10 +12721,96 @@
         "node": ">= 6"
       }
     },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/cross-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/cross-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6871,12 +12821,40 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "dev": true,
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      },
       "engines": {
         "node": "*"
       }
@@ -7147,7 +13125,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7274,10 +13251,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="
     },
     "node_modules/degenerator": {
       "version": "5.0.1",
@@ -7294,6 +13277,17 @@
         "node": ">= 14"
       }
     },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -7301,6 +13295,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/dequal": {
@@ -7316,12 +13318,40 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
       "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="
+    },
+    "node_modules/detect-browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
+    },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ]
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -7356,6 +13386,26 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -7500,6 +13550,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.328",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
@@ -7507,17 +13565,24 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/elementtree": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
-      "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
-      "license": "Apache-2.0",
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dependencies": {
-        "sax": "1.1.4"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -7525,6 +13590,11 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encode-utf8": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
@@ -7588,15 +13658,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/envinfo": {
@@ -7682,6 +13743,19 @@
         "docs",
         "benchmarks"
       ]
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "dependencies": {
+        "es6-promise": "^4.0.3"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -8004,6 +14078,14 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/eventsource": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
@@ -8011,6 +14093,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/execa": {
@@ -8080,6 +14171,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "peer": true
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -8127,6 +14224,14 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "engines": {
+        "node": "> 0.1.90"
       }
     },
     "node_modules/fast-check": {
@@ -8193,7 +14298,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -8202,6 +14306,11 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-stable-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -8220,6 +14329,12 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "peer": true
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -8234,6 +14349,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -8315,6 +14431,11 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "node_modules/file-url": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/file-url/-/file-url-4.0.0.tgz",
@@ -8386,16 +14507,15 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -8460,20 +14580,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -8505,6 +14611,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "peer": true,
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
+      "peer": true,
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -8519,7 +14643,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -8792,7 +14915,24 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/h3": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+      "dependencies": {
+        "cookie-es": "^1.2.3",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.6",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.3",
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
@@ -8863,6 +15003,66 @@
         "node": ">=8"
       }
     },
+    "node_modules/hash-base": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/hash-base/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/hash-base/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/hash-base/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/hash-base/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/hash-base/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -8890,6 +15090,16 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -8949,6 +15159,11 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
     },
     "node_modules/html_codesniffer": {
       "version": "2.5.1",
@@ -9029,6 +15244,37 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "peer": true,
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "peer": true
+    },
     "node_modules/http-link-header": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-0.8.0.tgz",
@@ -9072,6 +15318,14 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/i18next": {
@@ -9123,6 +15377,11 @@
       "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
       "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
       "license": "ISC"
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -9271,6 +15530,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/int64-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.1.tgz",
+      "integrity": "sha512-xp/v0/im2q7n7ISFJXcYsr/aVsUdZKPUZS1uYtoM9I9Cfmm5YuAi7SQts2TrEXwAKIE0wyn3KxJbo35goJgvwQ=="
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -9311,10 +15575,17 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
       }
     },
     "node_modules/is": {
@@ -9337,7 +15608,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-callable": {
@@ -9384,6 +15655,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -9454,6 +15726,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-my-ip-valid": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
+      "peer": true
+    },
+    "node_modules/is-my-json-valid": {
+      "version": "2.20.6",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
+      "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
+      "peer": true,
+      "dependencies": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^5.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "node_modules/is-npm": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
@@ -9514,6 +15805,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "peer": true
+    },
     "node_modules/is-retry-allowed": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
@@ -9525,6 +15822,25 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ]
     },
     "node_modules/is-stream": {
       "version": "4.0.1",
@@ -9578,6 +15894,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
@@ -9603,7 +15920,30 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -9675,6 +16015,84 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jayson": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.3.0.tgz",
+      "integrity": "sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==",
+      "dependencies": {
+        "@types/connect": "^3.4.33",
+        "@types/node": "^12.12.54",
+        "@types/ws": "^7.4.4",
+        "commander": "^2.20.3",
+        "delay": "^5.0.0",
+        "es6-promisify": "^5.0.0",
+        "eyes": "^0.1.8",
+        "isomorphic-ws": "^4.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "stream-json": "^1.9.1",
+        "uuid": "^8.3.2",
+        "ws": "^7.5.10"
+      },
+      "bin": {
+        "jayson": "bin/jayson.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jayson/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+    },
+    "node_modules/jayson/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/jayson/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/jayson/node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-axe": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-10.0.0.tgz",
@@ -9743,6 +16161,15 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/jpeg-js": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
@@ -9766,6 +16193,11 @@
       "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-sha256": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
+      "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -9866,6 +16298,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -9879,16 +16316,32 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "license": "MIT",
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -9900,6 +16353,11 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -9915,6 +16373,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10241,6 +16700,21 @@
         "url": "https://github.com/yeoman/update-notifier?sponsor=1"
       }
     },
+    "node_modules/lighthouse/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/lighthouse/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -10268,6 +16742,34 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
+    },
+    "node_modules/lit": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
+      "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -10358,6 +16860,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.5.tgz",
+      "integrity": "sha512-e0r9YBBgNCq1D1o5Dp8FMH0N5hsFtXDBiVa0qoJPHpakvZkmDKPRoGffZJII/XsHvj9An9blm+cRJ01yQqU+Dw=="
+    },
     "node_modules/lookup-closest-locale": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.0.4.tgz",
@@ -10393,6 +16900,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -10494,12 +17007,22 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
       "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "charenc": "0.0.2",
         "crypt": "0.0.2",
         "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "node_modules/memoize-one": {
@@ -10579,6 +17102,23 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -10634,8 +17174,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -10679,21 +17223,10 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/mkdirp": {
@@ -10753,6 +17286,11 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
     "node_modules/mustache": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
@@ -10797,6 +17335,11 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ=="
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -10816,46 +17359,121 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/native-run": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.3.tgz",
-      "integrity": "sha512-U1PllBuzW5d1gfan+88L+Hky2eZx+9gv3Pf6rNBxKbORxi7boHzqiA6QFGSnqMem4j0A9tZ08NMIs5+0m/VS1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@ionic/utils-fs": "^3.1.7",
-        "@ionic/utils-terminal": "^2.3.4",
-        "bplist-parser": "^0.3.2",
-        "debug": "^4.3.4",
-        "elementtree": "^0.1.7",
-        "ini": "^4.1.1",
-        "plist": "^3.1.0",
-        "split2": "^4.2.0",
-        "through2": "^4.0.2",
-        "tslib": "^2.6.2",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "native-run": "bin/native-run"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/native-run/node_modules/ini": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
-      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/near-abi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/near-abi/-/near-abi-0.2.0.tgz",
+      "integrity": "sha512-kCwSf/3fraPU2zENK18sh+kKG4uKbEUEQdyWQkmW8ZofmLarObIz2+zAYjA1teDZLeMvEQew3UysnPDXgjneaA==",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.11"
+      }
+    },
+    "node_modules/near-api-js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/near-api-js/-/near-api-js-5.1.1.tgz",
+      "integrity": "sha512-h23BGSKxNv8ph+zU6snicstsVK1/CTXsQz4LuGGwoRE24Hj424nSe4+/1tzoiC285Ljf60kPAqRCmsfv9etF2g==",
+      "peer": true,
+      "dependencies": {
+        "@near-js/accounts": "1.4.1",
+        "@near-js/crypto": "1.4.2",
+        "@near-js/keystores": "0.2.2",
+        "@near-js/keystores-browser": "0.2.2",
+        "@near-js/keystores-node": "0.1.2",
+        "@near-js/providers": "1.0.3",
+        "@near-js/signers": "0.2.2",
+        "@near-js/transactions": "1.3.3",
+        "@near-js/types": "0.3.1",
+        "@near-js/utils": "1.1.0",
+        "@near-js/wallet-account": "1.3.3",
+        "@noble/curves": "1.8.1",
+        "borsh": "1.0.0",
+        "depd": "2.0.0",
+        "http-errors": "1.7.2",
+        "near-abi": "0.2.0",
+        "node-fetch": "2.6.7"
+      }
+    },
+    "node_modules/near-api-js/node_modules/@noble/curves": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.7.1"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/near-api-js/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "peer": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/near-api-js/node_modules/borsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
+      "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
+      "peer": true
+    },
+    "node_modules/near-api-js/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/near-api-js/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "peer": true
+    },
+    "node_modules/near-api-js/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "peer": true
+    },
+    "node_modules/near-api-js/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/netmask": {
       "version": "2.0.2",
@@ -10866,6 +17484,11 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.13",
@@ -10887,6 +17510,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="
     },
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
@@ -10913,6 +17541,21 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+      "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw=="
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
@@ -10934,6 +17577,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
+      "engines": {
+        "node": ">=12.19"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
@@ -10948,6 +17599,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/normalize-url": {
@@ -11030,6 +17689,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/once": {
@@ -11146,6 +17823,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ox": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.9.tgz",
+      "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "optional": true
+    },
     "node_modules/p-cancelable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
@@ -11202,7 +17914,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11387,6 +18098,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-json/node_modules/semver": {
@@ -11416,6 +18128,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-asn1": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+      "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
+      "dependencies": {
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "pbkdf2": "^3.1.5",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/parse-cache-control": {
@@ -11499,7 +18226,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11519,6 +18245,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11587,10 +18314,27 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pbkdf2": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz",
+      "integrity": "sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==",
+      "dependencies": {
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "^2.0.3",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.12",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -11644,6 +18388,40 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
@@ -11761,18 +18539,12 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/plist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
-      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.9.10",
-        "base64-js": "^1.5.1",
-        "xmlbuilder": "^15.1.1"
-      },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
       "engines": {
-        "node": ">=10.4.0"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -11811,6 +18583,23 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
       }
     },
     "node_modules/prelude-ls": {
@@ -11884,6 +18673,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -11892,28 +18701,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/prompts/node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/prop-types": {
@@ -11932,6 +18719,30 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/protocolify": {
       "version": "3.0.0",
@@ -11967,6 +18778,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/proxy-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
+      "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q=="
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -11988,6 +18804,24 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -12083,6 +18917,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/puppeteer/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/puppeteer/node_modules/ws": {
       "version": "7.5.11",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
@@ -12121,6 +18970,169 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/pushdata-bitcoin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
+      "integrity": "sha512-hw7rcYTJRAl4olM8Owe8x0fBuJJ+WGbMhQuLWOXEMN3PxPCKQHRkhfL+XG0+iXUmSHjkMmb3Ba55Mt21cZc9kQ==",
+      "dependencies": {
+        "bitcoin-ops": "^1.3.0"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "encode-utf8": "^1.0.3",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.2",
@@ -12169,6 +19181,11 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+    },
     "node_modules/quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -12179,12 +19196,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/radix3": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "license": "MIT",
       "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dependencies": {
+        "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
       }
     },
@@ -12609,6 +19640,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/recharts": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
@@ -12707,11 +19758,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/require-addon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "bare-addon-resolve": "^1.3.0"
+      },
+      "engines": {
+        "bare": ">=1.10.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12726,6 +19789,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "node_modules/reselect": {
       "version": "5.2.0",
@@ -12851,6 +19919,69 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "dependencies": {
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ripple-address-codec": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-5.0.1.tgz",
+      "integrity": "sha512-JQHLKuVJV8lv9Qobmn4aUM2Dpv9WRRLKnNWfM8tN02fAbUtG8mUPsu9q9UYX8P76G4qzytEc5ZKMp/3JggNYmw==",
+      "dependencies": {
+        "@scure/base": "^2.0.0",
+        "@xrplf/isomorphic": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ripple-address-codec/node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ripple-binary-codec": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.8.0.tgz",
+      "integrity": "sha512-+NKnOi3hdzjm5dDpoZLUEaYon1jahPlSGnp3YrDoNMSR09ICEqgupN5wpEkPuqJvV75PF/g+W1QUwIXVzbEe7w==",
+      "dependencies": {
+        "@xrplf/isomorphic": "^1.0.2",
+        "bignumber.js": "^10.0.2",
+        "ripple-address-codec": "^5.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ripple-binary-codec/node_modules/bignumber.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+      "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ=="
+    },
+    "node_modules/ripple-keypairs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-2.0.0.tgz",
+      "integrity": "sha512-b5rfL2EZiffmklqZk1W+dvSy97v3V/C7936WxCCgDynaGPp7GE6R2XO7EU9O2LlM/z95rj870IylYnOQs+1Rag==",
+      "dependencies": {
+        "@noble/curves": "^1.0.0",
+        "@xrplf/isomorphic": "^1.0.0",
+        "ripple-address-codec": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/robots-parser": {
@@ -13061,6 +20192,48 @@
         "node": ">=12"
       }
     },
+    "node_modules/rpc-websockets": {
+      "version": "9.3.9",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.9.tgz",
+      "integrity": "sha512-2iQDaTB4g5fDB2ihrTFSJSibCEuxaRi1q7qTW7ZO9/M5/TC+ToHA4D9/ffNLEbAoHNNrcdeP05oATNk44SKZXA==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.2.2",
+        "buffer": "^6.0.3",
+        "eventemitter3": "^5.0.1",
+        "uuid": "^14.0.0",
+        "ws": "^8.5.0"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/kozjak"
+      },
+      "optionalDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^6.0.0"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
@@ -13096,7 +20269,6 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -13122,18 +20294,20 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/sax": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
-      "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
-      "license": "ISC"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -13153,6 +20327,25 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/secp256k1": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-5.0.1.tgz",
+      "integrity": "sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "elliptic": "^6.5.7",
+        "node-addon-api": "^5.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/secp256k1/node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
     "node_modules/semver": {
       "version": "7.7.1",
@@ -13189,6 +20382,11 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
@@ -13212,6 +20410,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "peer": true
+    },
     "node_modules/sha.js": {
       "version": "2.4.12",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
@@ -13230,6 +20434,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sha1": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
+      "integrity": "sha512-dZBS6OrMjtgVkopB1Gmo4RQCDKiZsqcpAQpkV/aaj+FCrCg8r4I4qMkDPQjBgLIxlmu9k4nUbWq6ohXahOneYA==",
+      "dependencies": {
+        "charenc": ">= 0.0.1",
+        "crypt": ">= 0.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/sharp": {
@@ -13294,6 +20510,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -13306,6 +20523,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13422,34 +20640,15 @@
         "node": ">=18"
       }
     },
-    "node_modules/sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "license": "MIT"
-    },
-    "node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
+    "node_modules/slow-redact": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
+      "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw=="
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
@@ -13460,7 +20659,6 @@
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.0.1",
@@ -13475,7 +20673,6 @@
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -13484,6 +20681,24 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/sodium-native": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz",
+      "integrity": "sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "require-addon": "^1.1.0"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/source-map": {
@@ -13582,12 +20797,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA=="
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -13734,11 +20980,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-vendorizer": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/style-vendorizer/-/style-vendorizer-2.2.3.tgz",
+      "integrity": "sha512-/VDRsWvQAgspVy9eATN3z6itKTuyg+jW1q6UoTCQCFRqPDw8bi3E1hXIKnGw5LvXS2AQPuJ7Af4auTLYeBOLEg=="
+    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
       "license": "MIT"
+    },
+    "node_modules/superstruct": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -13799,22 +21058,6 @@
         "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
-    "node_modules/tar": {
-      "version": "7.5.17",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.17.tgz",
-      "integrity": "sha512-wPEBwzapC+2PaTYPH6e2L+cNOEE227S47wUYFqlegcs8zlLLmeb9Fcff1HVZY4Fwku/1Eyv38n7GYwB2aaS71g==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -13843,24 +21086,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tar/node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/term-size": {
@@ -13930,6 +21155,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+    },
     "node_modules/third-party-web": {
       "version": "0.12.7",
       "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.12.7.tgz",
@@ -13937,21 +21167,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/through2": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "3"
-      }
     },
     "node_modules/timed-out": {
       "version": "4.0.1",
@@ -13968,6 +21197,27 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
+    },
+    "node_modules/tiny-secp256k1": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.7.tgz",
+      "integrity": "sha512-eb+F6NabSnjbLwNoC+2o5ItbmP1kg7HliWue71JgLegQt6A5mTN8YbvTLCazdlg6e5SV6A+r8OGvZYskdlmhqQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.13.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/tiny-secp256k1/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -14100,6 +21350,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/toml": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
@@ -14146,6 +21405,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
@@ -14180,6 +21440,11 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -14216,6 +21481,16 @@
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    },
+    "node_modules/tweetnacl-util": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -14294,11 +21569,15 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -14330,6 +21609,76 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ]
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.10.tgz",
+      "integrity": "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="
+    },
+    "node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
       }
     },
     "node_modules/unbzip2-stream": {
@@ -14383,6 +21732,11 @@
         "react": ">=15.0.0"
       }
     },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
+    },
     "node_modules/underscore": {
       "version": "1.13.8",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
@@ -14432,22 +21786,107 @@
         "node": ">=8"
       }
     },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
+    "node_modules/unstorage": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^5.0.0",
+        "destr": "^2.0.5",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1 || ^2 || ^3",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
       }
     },
-    "node_modules/untildify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
-      "license": "MIT",
+    "node_modules/unstorage/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "engines": {
-        "node": ">=8"
+        "node": "20 || >=22"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -14539,6 +21978,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/usb": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.18.0.tgz",
+      "integrity": "sha512-klAJPUTaSxRvTgrIh7om6UTrgRxdzioD+rJc/MaoiN8+OGdqRzai39tR00asnoCesPNikItWB9zBZoo0pJsWaA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@types/w3c-web-usb": "^1.0.6",
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=12.22.0 <13.0 || >=14.17.0"
+      }
+    },
+    "node_modules/usb/node_modules/node-addon-api": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -14546,6 +22007,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utf-8-validate": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -14565,6 +22039,11 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/uuid4": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/uuid4/-/uuid4-2.0.3.tgz",
+      "integrity": "sha512-CTpAkEVXMNJl2ojgtpLXHgz23dh8z81u6/HEPiQFOvBc/c2pde6TVHmH4uwY0d/GLF3tb7+VDAj4+2eJaQSdZQ=="
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -14574,6 +22053,37 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/valtio": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.7.tgz",
+      "integrity": "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==",
+      "dependencies": {
+        "proxy-compare": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/varuint-bitcoin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-2.0.0.tgz",
+      "integrity": "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==",
+      "dependencies": {
+        "uint8array-tools": "^0.0.8"
       }
     },
     "node_modules/victory-vendor": {
@@ -14605,6 +22115,103 @@
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.55.10",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.10.tgz",
+      "integrity": "sha512-Q9Ba+/ma81U2M5o5P2AQ7Ux8rTIwmCZvUcr8rKdQ22bV0IBFHllM2m5gWDP8hFaUN2nH2oW3QG44amRazflYNQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.33",
+        "ws": "8.21.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/viem/node_modules/ox": {
+      "version": "0.14.33",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.33.tgz",
+      "integrity": "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {
@@ -15924,6 +23531,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -15934,6 +23542,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
@@ -16019,6 +23632,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wif": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-5.0.0.tgz",
+      "integrity": "sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA==",
+      "dependencies": {
+        "bs58check": "^4.0.0"
       }
     },
     "node_modules/word-wrap": {
@@ -16167,11 +23788,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
-      "license": "MIT",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -16208,43 +23827,41 @@
         "node": ">=18"
       }
     },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xml2js/node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
-      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xrpl": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.4.3.tgz",
+      "integrity": "sha512-vi2OjuNkiaP8nv1j+nqHp8GZwwEjO6Y8+j/OuVMg6M4LwXEwyHdIj33dlg7cyY1Lw5+jb9HqFOQvABhaywVbTQ==",
+      "dependencies": {
+        "@scure/bip32": "^1.3.1",
+        "@scure/bip39": "^1.2.1",
+        "@xrplf/isomorphic": "^1.0.1",
+        "@xrplf/secret-numbers": "^2.0.0",
+        "bignumber.js": "^9.0.0",
+        "eventemitter3": "^5.0.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "ripple-address-codec": "^5.0.0",
+        "ripple-binary-codec": "^2.5.0",
+        "ripple-keypairs": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -16347,6 +23964,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
@@ -16412,6 +24030,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@capacitor/app": "^8.1.0",
+    "@creit.tech/stellar-wallets-kit": "^2.2.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.9",
@@ -47,9 +48,8 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@axe-core/react": "^4.11.1",
     "@axe-core/playwright": "^4.10.0",
-    "axe-core": "^4.10.0",
+    "@axe-core/react": "^4.11.1",
     "@eslint/js": "^9.39.1",
     "@percy/cli": "^1.31.10",
     "@percy/playwright": "^1.1.0",
@@ -69,6 +69,7 @@
     "@vitejs/plugin-react": "^5.1.1",
     "@vitest/coverage-v8": "^2.1.9",
     "@vitest/ui": "^2.1.8",
+    "axe-core": "^4.10.0",
     "dotenv": "^17.3.1",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/frontend/src/components/ContributeButton.tsx
+++ b/frontend/src/components/ContributeButton.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import type { ContributeButtonProps } from "../types/contribution";
 import { ContributionSuccessModal } from "./ContributionSuccessModal";
 import { useTransaction, explorerUrl } from "../hooks/useTransaction";
 import { useContract } from "../hooks/useContract";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 // ── Confirmation Modal ──────────────────────────────────────────────────────
 
@@ -17,11 +18,38 @@ function ConfirmModal({
   onConfirm: () => void;
   onCancel: () => void;
 }) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Trap Tab/Shift+Tab within the dialog and restore focus to the trigger on close.
+  useFocusTrap(dialogRef, true);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    },
+    [onCancel]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl shadow-xl max-w-sm w-full p-6">
-        <h3 className="text-lg font-bold text-gray-900 text-center mb-1">Confirm Contribution</h3>
-        <p className="text-gray-500 text-sm text-center mb-4">Cycle #{cycleId}</p>
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      onClick={(e) => e.target === e.currentTarget && onCancel()}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-contribution-title"
+        aria-describedby="confirm-contribution-description"
+        className="bg-white rounded-2xl shadow-xl max-w-sm w-full p-6"
+      >
+        <h3 id="confirm-contribution-title" className="text-lg font-bold text-gray-900 text-center mb-1">Confirm Contribution</h3>
+        <p id="confirm-contribution-description" className="text-gray-500 text-sm text-center mb-4">Cycle #{cycleId}</p>
         <div className="bg-gray-50 rounded-xl p-4 mb-5">
           <div className="flex justify-between text-sm">
             <span className="text-gray-500">Amount</span>

--- a/frontend/src/components/ContributionSuccessModal.tsx
+++ b/frontend/src/components/ContributionSuccessModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useLocalStorage } from '../hooks/useLocalStorage';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { getExplorerTxUrl } from '../utils/explorerUrl';
 import './ContributionSuccessModal.css';
 
@@ -150,6 +151,7 @@ export function ContributionSuccessModal({
 }: ContributionSuccessModalProps) {
   const [muted, setMuted] = useLocalStorage('contribution-sound-muted', false);
   const playedRef = useRef(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -157,6 +159,10 @@ export function ContributionSuccessModal({
     },
     [onClose]
   );
+
+  // Trap Tab/Shift+Tab within the dialog while open and restore focus to the
+  // triggering element on close.
+  useFocusTrap(dialogRef, open);
 
   useEffect(() => {
     if (!open) {
@@ -175,9 +181,11 @@ export function ContributionSuccessModal({
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-labelledby="success-modal-title"
+      aria-describedby="success-modal-description"
       style={{
         position: 'fixed',
         inset: 0,
@@ -257,7 +265,7 @@ export function ContributionSuccessModal({
         >
           Contribution Successful!
         </h2>
-        <p style={{ margin: '0 0 16px', color: '#6b7280', fontSize: '14px' }}>
+        <p id="success-modal-description" style={{ margin: '0 0 16px', color: '#6b7280', fontSize: '14px' }}>
           {amount} XLM · Cycle #{cycleId}
         </p>
 

--- a/frontend/src/components/JoinGroupModal.tsx
+++ b/frontend/src/components/JoinGroupModal.tsx
@@ -21,7 +21,7 @@ export const JoinGroupModal: React.FC<Props> = ({ group, onClose, onConfirm }) =
   if (!group) return null;
 
   return (
-    <Dialog open={Boolean(group)} onClose={onClose} maxWidth="xs" fullWidth>
+    <Dialog open={Boolean(group)} onClose={onClose} maxWidth="xs" fullWidth aria-describedby="join-group-description">
       <DialogTitle fontWeight="bold">Join Group</DialogTitle>
       <DialogContent>
         <Stack spacing={2}>
@@ -51,7 +51,7 @@ export const JoinGroupModal: React.FC<Props> = ({ group, onClose, onConfirm }) =
               sx={{ fontWeight: 'bold', fontSize: '0.65rem' }}
             />
           </Stack>
-          <Typography variant="body2" color="text.secondary">
+          <Typography id="join-group-description" variant="body2" color="text.secondary">
             By joining, you commit to contributing <strong>{group.contributionAmount} {group.currency}</strong> each cycle until the group completes.
           </Typography>
         </Stack>

--- a/frontend/src/components/OnboardingTutorial.tsx
+++ b/frontend/src/components/OnboardingTutorial.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import { useLocalStorage } from "../hooks/useLocalStorage";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 import "./OnboardingTutorial.css";
 
 const STORAGE_KEY = "stellar-save-onboarding-complete";
@@ -59,11 +60,17 @@ export function OnboardingTutorial({
   );
   const [step, setStep] = useState(0);
   const [visible, setVisible] = useState(true);
-
-  if ((completed && !forceShow) || !visible) return null;
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   const isLast = step === STEPS.length - 1;
   const current = STEPS[step];
+  const showTutorial = !((completed && !forceShow) || !visible);
+
+  function finish() {
+    setCompleted(true);
+    setVisible(false);
+    onComplete?.();
+  }
 
   const handleNext = () => {
     if (isLast) {
@@ -79,18 +86,34 @@ export function OnboardingTutorial({
     finish();
   };
 
-  function finish() {
-    setCompleted(true);
-    setVisible(false);
-    onComplete?.();
-  }
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") finish();
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  // Trap Tab/Shift+Tab within the dialog while visible and restore focus to
+  // the triggering element once the tutorial is dismissed.
+  useFocusTrap(dialogRef, showTutorial);
+
+  useEffect(() => {
+    if (!showTutorial) return;
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [showTutorial, handleKeyDown]);
+
+  if (!showTutorial) return null;
 
   return (
     <div
+      ref={dialogRef}
       className="onboarding-overlay"
       role="dialog"
       aria-modal="true"
-      aria-label="Onboarding tutorial"
+      aria-labelledby="onboarding-title"
+      aria-describedby="onboarding-description"
       data-testid="onboarding-tutorial"
     >
       <div className="onboarding-modal">
@@ -111,8 +134,8 @@ export function OnboardingTutorial({
           <div className="onboarding-icon" aria-hidden="true">
             {current.icon}
           </div>
-          <h2 className="onboarding-title">{current.title}</h2>
-          <p className="onboarding-description">{current.description}</p>
+          <h2 id="onboarding-title" className="onboarding-title">{current.title}</h2>
+          <p id="onboarding-description" className="onboarding-description">{current.description}</p>
         </div>
 
         <div className="onboarding-dots" aria-label="Tutorial progress">

--- a/frontend/src/components/WalletSelectModal.tsx
+++ b/frontend/src/components/WalletSelectModal.tsx
@@ -8,7 +8,9 @@ import {
   ListItemAvatar,
   Avatar,
   Typography,
+  IconButton,
 } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
 import { useWallet } from '../hooks/useWallet';
 
 const WALLET_ICONS: Record<string, string> = {
@@ -32,7 +34,12 @@ export function WalletSelectModal({ open, onClose }: WalletSelectModalProps) {
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
-      <DialogTitle>Connect Wallet</DialogTitle>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        Connect Wallet
+        <IconButton onClick={onClose} size="small" aria-label="Close dialog" edge="end">
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
       <DialogContent sx={{ p: 0 }}>
         <List>
           {wallets.map((wallet) => (

--- a/frontend/src/components/templates/TemplatePreviewModal.tsx
+++ b/frontend/src/components/templates/TemplatePreviewModal.tsx
@@ -18,10 +18,10 @@ export function TemplatePreviewModal({ template, onClose, onUse }: TemplatePrevi
   ];
 
   return (
-    <Dialog open={!!template} onClose={onClose} maxWidth="xs" fullWidth>
+    <Dialog open={!!template} onClose={onClose} maxWidth="xs" fullWidth aria-describedby="template-preview-description">
       <DialogTitle>{template.name}</DialogTitle>
       <DialogContent>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        <Typography id="template-preview-description" variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           {template.description}
         </Typography>
         <Divider sx={{ mb: 2 }} />

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -79,6 +79,14 @@ export function useFocusTrap(
     document.addEventListener('keydown', handleKeyDown);
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
+      // Also restore focus when the component unmounts while still active
+      // (e.g. a parent conditionally renders the dialog rather than keeping
+      // it mounted and toggling `active`) — otherwise focus would be lost
+      // to <body> instead of returning to the triggering element.
+      if (previousFocusRef.current instanceof HTMLElement) {
+        previousFocusRef.current.focus();
+      }
+      previousFocusRef.current = null;
     };
   }, [active, containerRef]);
 }

--- a/frontend/src/test/ContributionSuccessModal.test.tsx
+++ b/frontend/src/test/ContributionSuccessModal.test.tsx
@@ -1,6 +1,11 @@
+import { useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import { ContributionSuccessModal } from '../components/ContributionSuccessModal';
+
+expect.extend(toHaveNoViolations);
 
 // AudioContext is not available in jsdom — mock it
 beforeEach(() => {
@@ -123,5 +128,78 @@ describe('ContributionSuccessModal', () => {
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-modal', 'true');
     expect(dialog).toHaveAttribute('aria-labelledby', 'success-modal-title');
+  });
+
+  it('has an aria-describedby pointing to the amount/cycle summary', () => {
+    render(<ContributionSuccessModal {...baseProps} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-describedby', 'success-modal-description');
+    expect(document.getElementById('success-modal-description')).toHaveTextContent(/50 XLM/);
+  });
+
+  it('has no axe violations', async () => {
+    const { container } = render(<ContributionSuccessModal {...baseProps} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no axe violations with milestone and explorer link shown', async () => {
+    const { container } = render(
+      <ContributionSuccessModal {...baseProps} milestoneLabel="5th Contribution!" txHash="abc123" />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('moves focus into the dialog when opened', () => {
+    render(<ContributionSuccessModal {...baseProps} />);
+    expect(screen.getByRole('dialog')).toContainElement(document.activeElement as HTMLElement);
+  });
+
+  it('Tab cycles focus within the dialog and wraps around', async () => {
+    const user = userEvent.setup();
+    render(<ContributionSuccessModal {...baseProps} txHash="abc123" />);
+
+    const focusable = [
+      screen.getByRole('button', { name: /mute sound/i }),
+      screen.getByRole('button', { name: /close/i }),
+      screen.getByRole('link', { name: /share/i }),
+      screen.getByRole('link', { name: /view on stellar explorer/i }),
+      screen.getByRole('button', { name: /^done$/i }),
+    ];
+
+    // Focus should start on the first focusable element.
+    expect(document.activeElement).toBe(focusable[0]);
+
+    // Tab from the last element wraps back to the first.
+    focusable[focusable.length - 1].focus();
+    await user.tab();
+    expect(document.activeElement).toBe(focusable[0]);
+
+    // Shift+Tab from the first element wraps back to the last.
+    await user.tab({ shift: true });
+    expect(document.activeElement).toBe(focusable[focusable.length - 1]);
+  });
+
+  it('restores focus to the triggering element when closed', () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <div>
+          <button onClick={() => setOpen(true)}>Open</button>
+          <ContributionSuccessModal
+            open={open}
+            amount={50}
+            cycleId={3}
+            onClose={() => setOpen(false)}
+          />
+        </div>
+      );
+    }
+    render(<Harness />);
+    const trigger = screen.getByRole('button', { name: /open/i });
+    trigger.focus();
+    fireEvent.click(trigger);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^done$/i }));
+    expect(document.activeElement).toBe(trigger);
   });
 });

--- a/frontend/src/test/OnboardingTutorial.test.tsx
+++ b/frontend/src/test/OnboardingTutorial.test.tsx
@@ -1,7 +1,12 @@
+import { useState } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
 import { OnboardingTutorial, useOnboardingTutorial } from "../components/OnboardingTutorial";
 import { renderHook, act } from "@testing-library/react";
+
+expect.extend(toHaveNoViolations);
 
 beforeEach(() => {
   localStorage.clear();
@@ -102,6 +107,78 @@ describe("OnboardingTutorial", () => {
     render(<OnboardingTutorial />);
     const firstDot = screen.getByLabelText("Go to step 1");
     expect(firstDot).toHaveAttribute("aria-current", "step");
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(<OnboardingTutorial />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("dialog has role=dialog, aria-modal, aria-labelledby and aria-describedby", () => {
+    render(<OnboardingTutorial />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby", "onboarding-title");
+    expect(dialog).toHaveAttribute("aria-describedby", "onboarding-description");
+    expect(document.getElementById("onboarding-title")).toHaveTextContent("Welcome to Stellar-Save");
+  });
+
+  it("moves focus into the dialog when opened", () => {
+    render(<OnboardingTutorial />);
+    expect(screen.getByRole("dialog")).toContainElement(document.activeElement as HTMLElement);
+  });
+
+  it("Tab cycles focus within the dialog and wraps around", async () => {
+    const user = userEvent.setup();
+    render(<OnboardingTutorial />);
+
+    const skip = screen.getByLabelText("Skip tutorial");
+    const back = screen.getByLabelText("Previous step");
+    const next = screen.getByLabelText("Next step");
+
+    // Skip is the first focusable element in the dialog.
+    expect(document.activeElement).toBe(skip);
+
+    // Shift+Tab from the first element wraps to the last (Next).
+    await user.tab({ shift: true });
+    expect(document.activeElement).toBe(next);
+
+    // Tab from the last element wraps back to the first (Skip).
+    await user.tab();
+    expect(document.activeElement).toBe(skip);
+
+    expect(back).toBeDisabled();
+  });
+
+  it("closes the tutorial on Escape and saves completion", () => {
+    render(<OnboardingTutorial />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByTestId("onboarding-tutorial")).not.toBeInTheDocument();
+    expect(localStorage.getItem("stellar-save-onboarding-complete")).toBe("true");
+  });
+
+  it("restores focus to the triggering element when dismissed via Skip", () => {
+    localStorage.setItem("stellar-save-onboarding-complete", "true");
+
+    function Harness() {
+      const [show, setShow] = useState(false);
+      return (
+        <div>
+          <button onClick={() => setShow(true)}>Replay tutorial</button>
+          <OnboardingTutorial forceShow={show} />
+        </div>
+      );
+    }
+    render(<Harness />);
+    const trigger = screen.getByRole("button", { name: /replay tutorial/i });
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    expect(screen.getByTestId("onboarding-tutorial")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Skip tutorial"));
+
+    expect(screen.queryByTestId("onboarding-tutorial")).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(trigger);
   });
 });
 

--- a/frontend/src/test/modal-a11y.test.tsx
+++ b/frontend/src/test/modal-a11y.test.tsx
@@ -1,0 +1,382 @@
+/**
+ * Accessibility tests for modal/dialog components (issue #1264).
+ *
+ * Covers the modal dialogs across the app: MUI-based dialogs (which get
+ * focus-trap, aria-modal and Escape-to-close for free from @mui/material),
+ * and the ConfirmModal used by the "contribute" flow (a hand-rolled dialog
+ * wired up with the shared `useFocusTrap` hook).
+ *
+ * Uses jest-axe (axe-core) to assert zero WCAG 2.1 AA violations, plus
+ * Testing Library interactions to verify keyboard-only focus-trap
+ * (Tab/Shift+Tab cycling) and Escape-to-close behavior — axe alone cannot
+ * catch focus-trap regressions.
+ *
+ * Note: ContributionSuccessModal and OnboardingTutorial (also custom,
+ * non-MUI dialogs) have their own dedicated a11y coverage in
+ * ContributionSuccessModal.test.tsx and OnboardingTutorial.test.tsx.
+ *
+ * `useWallet`/`useContract` are mocked here so these tests are isolated
+ * from the wallet integration layer, which is unrelated to modal a11y.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+import { JoinGroupModal } from '../components/JoinGroupModal';
+import { TemplatePreviewModal } from '../components/templates/TemplatePreviewModal';
+import { SaveTemplateModal } from '../components/TransactionBuilder/SaveTemplateModal';
+import TransactionDetailModal from '../components/TransactionDetailModal';
+import { WalletSelectModal } from '../components/WalletSelectModal';
+import { ContributeButton } from '../components/ContributeButton';
+import { GroupSettings } from '../components/GroupSettings';
+import { useWallet } from '../hooks/useWallet';
+import { useContract } from '../hooks/useContract';
+import type { PublicGroup, GroupDetail } from '../types/group';
+import type { GroupTemplate } from '../types/template';
+import type { Transaction } from '../types/transaction';
+
+expect.extend(toHaveNoViolations);
+
+// `useWallet`/`useContract` pull in the wallet SDK integration layer, which is
+// unrelated to modal accessibility — mock them at the hook boundary so these
+// tests exercise only the dialog markup/behavior.
+vi.mock('../hooks/useWallet', () => ({ useWallet: vi.fn() }));
+vi.mock('../hooks/useContract', () => ({ useContract: vi.fn() }));
+
+// ── Shared fixtures ───────────────────────────────────────────────────────────
+
+const group: PublicGroup = {
+  id: 'group-1',
+  name: 'Family Circle',
+  description: 'A rotating savings group for the family.',
+  memberCount: 5,
+  contributionAmount: 25,
+  currency: 'XLM',
+  status: 'active',
+  createdAt: new Date('2026-01-01'),
+};
+
+const template: GroupTemplate = {
+  id: 1,
+  name: 'Weekly Saver',
+  description: 'Frequent payouts for tight-knit groups with short commitment windows.',
+  cycleDuration: 7,
+  maxMembers: 10,
+  totalDuration: '~10 weeks',
+  category: 'short',
+};
+
+const transaction: Transaction = {
+  id: 'tx-1',
+  hash: 'abcdef1234567890',
+  createdAt: new Date('2026-01-01').toISOString(),
+  type: 'payment',
+  amount: '25',
+  assetCode: 'XLM',
+  from: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQRSTU',
+  status: 'success',
+  fee: '0.00001',
+};
+
+const groupDetail: GroupDetail = {
+  ...group,
+  creator: 'GCREATOR1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789',
+  cycleDuration: 604800,
+  maxMembers: 10,
+  minMembers: 3,
+  currentCycle: 1,
+  isActive: true,
+  started: true,
+  startedAt: new Date('2026-01-02'),
+};
+
+// ── 1. JoinGroupModal ──────────────────────────────────────────────────────────
+
+describe('JoinGroupModal – accessibility', () => {
+  it('has no axe violations', async () => {
+    const { container } = render(
+      <JoinGroupModal group={group} onClose={vi.fn()} onConfirm={vi.fn()} />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has aria-describedby pointing to the commitment description', () => {
+    render(<JoinGroupModal group={group} onClose={vi.fn()} onConfirm={vi.fn()} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-describedby', 'join-group-description');
+    expect(document.getElementById('join-group-description')).toHaveTextContent(/By joining/i);
+  });
+
+  it('has an accessible name from the visible title (aria-labelledby wired by MUI)', () => {
+    render(<JoinGroupModal group={group} onClose={vi.fn()} onConfirm={vi.fn()} />);
+    expect(screen.getByRole('dialog', { name: /join group/i })).toBeInTheDocument();
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(<JoinGroupModal group={group} onClose={onClose} onConfirm={vi.fn()} />);
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Cancel button is keyboard reachable', () => {
+    render(<JoinGroupModal group={group} onClose={vi.fn()} onConfirm={vi.fn()} />);
+    const cancel = screen.getByRole('button', { name: /cancel/i });
+    cancel.focus();
+    expect(document.activeElement).toBe(cancel);
+  });
+});
+
+// ── 2. TemplatePreviewModal ────────────────────────────────────────────────────
+
+describe('TemplatePreviewModal – accessibility', () => {
+  it('has no axe violations', async () => {
+    const { container } = render(
+      <TemplatePreviewModal template={template} onClose={vi.fn()} onUse={vi.fn()} />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has aria-describedby pointing to the template description', () => {
+    render(<TemplatePreviewModal template={template} onClose={vi.fn()} onUse={vi.fn()} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-describedby', 'template-preview-description');
+    expect(document.getElementById('template-preview-description')).toHaveTextContent(
+      template.description
+    );
+  });
+
+  it('has an accessible name from the visible title', () => {
+    render(<TemplatePreviewModal template={template} onClose={vi.fn()} onUse={vi.fn()} />);
+    expect(screen.getByRole('dialog', { name: template.name })).toBeInTheDocument();
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(<TemplatePreviewModal template={template} onClose={onClose} onUse={vi.fn()} />);
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
+// ── 3. SaveTemplateModal ───────────────────────────────────────────────────────
+
+describe('SaveTemplateModal – accessibility', () => {
+  const steps = [
+    { id: '1', type: 'payment' as const, label: 'Send payment', params: {}, enabled: true },
+  ];
+
+  it('has no axe violations', async () => {
+    const { container } = render(<SaveTemplateModal open onClose={vi.fn()} steps={steps} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has an accessible name from the visible title', () => {
+    render(<SaveTemplateModal open onClose={vi.fn()} steps={steps} />);
+    expect(
+      screen.getByRole('dialog', { name: /save transaction template/i })
+    ).toBeInTheDocument();
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(<SaveTemplateModal open onClose={onClose} steps={steps} />);
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Cancel button is keyboard reachable', () => {
+    render(<SaveTemplateModal open onClose={vi.fn()} steps={steps} />);
+    const cancel = screen.getByRole('button', { name: /cancel/i });
+    cancel.focus();
+    expect(document.activeElement).toBe(cancel);
+  });
+});
+
+// ── 4. TransactionDetailModal ──────────────────────────────────────────────────
+
+describe('TransactionDetailModal – accessibility', () => {
+  it('has no axe violations', async () => {
+    const { container } = render(
+      <TransactionDetailModal transaction={transaction} isOpen onClose={vi.fn()} />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has an accessible name from the visible title', () => {
+    render(<TransactionDetailModal transaction={transaction} isOpen onClose={vi.fn()} />);
+    expect(screen.getByRole('dialog', { name: /transaction details/i })).toBeInTheDocument();
+  });
+
+  it('has a visible, keyboard-reachable close control', () => {
+    render(<TransactionDetailModal transaction={transaction} isOpen onClose={vi.fn()} />);
+    const closeIcon = screen.getByRole('button', { name: /close dialog/i });
+    closeIcon.focus();
+    expect(document.activeElement).toBe(closeIcon);
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(<TransactionDetailModal transaction={transaction} isOpen onClose={onClose} />);
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
+// ── 5. WalletSelectModal (useWallet mocked) ────────────────────────────────────
+
+describe('WalletSelectModal – accessibility', () => {
+  beforeEach(() => {
+    vi.mocked(useWallet).mockReturnValue({
+      wallets: [
+        { id: 'freighter', name: 'Freighter', installed: true },
+        { id: 'albedo', name: 'Albedo', installed: false },
+      ],
+      switchWallet: vi.fn(),
+    } as unknown as ReturnType<typeof useWallet>);
+  });
+
+  it('has no axe violations', async () => {
+    const { container } = render(<WalletSelectModal open onClose={vi.fn()} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has a visible, keyboard-reachable close control', () => {
+    render(<WalletSelectModal open onClose={vi.fn()} />);
+    const closeBtn = screen.getByRole('button', { name: /close dialog/i });
+    closeBtn.focus();
+    expect(document.activeElement).toBe(closeBtn);
+  });
+
+  it('close button calls onClose', () => {
+    const onClose = vi.fn();
+    render(<WalletSelectModal open onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /close dialog/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(<WalletSelectModal open onClose={onClose} />);
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
+// ── 6. ContributeButton's ConfirmModal (useContract mocked) ────────────────────
+
+describe('ContributeButton confirmation dialog – accessibility', () => {
+  beforeEach(() => {
+    vi.mocked(useContract).mockReturnValue({
+      contribute: vi.fn().mockResolvedValue({ txHash: 'tx_mock', error: null }),
+    } as unknown as ReturnType<typeof useContract>);
+  });
+
+  it('has no axe violations when open', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <ContributeButton amount={25} cycleId={2} walletAddress="GABC" />
+    );
+    await user.click(screen.getByRole('button', { name: /contribute/i }));
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('dialog has role, aria-modal, aria-labelledby and aria-describedby', async () => {
+    const user = userEvent.setup();
+    render(<ContributeButton amount={25} cycleId={2} walletAddress="GABC" />);
+    await user.click(screen.getByRole('button', { name: /contribute/i }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'confirm-contribution-title');
+    expect(dialog).toHaveAttribute('aria-describedby', 'confirm-contribution-description');
+    expect(screen.getByRole('dialog', { name: /confirm contribution/i })).toBeInTheDocument();
+  });
+
+  it('moves focus into the dialog when opened', async () => {
+    const user = userEvent.setup();
+    render(<ContributeButton amount={25} cycleId={2} walletAddress="GABC" />);
+    await user.click(screen.getByRole('button', { name: /contribute/i }));
+    expect(screen.getByRole('dialog')).toContainElement(document.activeElement as HTMLElement);
+  });
+
+  it('Tab cycles focus within the dialog and wraps around', async () => {
+    const user = userEvent.setup();
+    render(<ContributeButton amount={25} cycleId={2} walletAddress="GABC" />);
+    await user.click(screen.getByRole('button', { name: /contribute/i }));
+
+    const cancel = screen.getByRole('button', { name: /cancel/i });
+    const confirm = screen.getByRole('button', { name: /^confirm$/i });
+
+    expect(document.activeElement).toBe(cancel);
+
+    confirm.focus();
+    await user.tab();
+    expect(document.activeElement).toBe(cancel);
+
+    await user.tab({ shift: true });
+    expect(document.activeElement).toBe(confirm);
+  });
+
+  it('closes on Escape and restores focus to the Contribute button', async () => {
+    const user = userEvent.setup();
+    render(<ContributeButton amount={25} cycleId={2} walletAddress="GABC" />);
+    const trigger = screen.getByRole('button', { name: /contribute/i });
+    await user.click(trigger);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('closes when clicking the backdrop', async () => {
+    const user = userEvent.setup();
+    render(<ContributeButton amount={25} cycleId={2} walletAddress="GABC" />);
+    await user.click(screen.getByRole('button', { name: /contribute/i }));
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(dialog.parentElement as HTMLElement);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+
+// ── 7. GroupSettings confirm dialog (useWallet mocked) ─────────────────────────
+
+describe('GroupSettings confirm dialog – accessibility', () => {
+  beforeEach(() => {
+    vi.mocked(useWallet).mockReturnValue({
+      activeAddress: groupDetail.creator,
+    } as unknown as ReturnType<typeof useWallet>);
+  });
+
+  async function openConfirmDialog() {
+    const user = userEvent.setup();
+    const utils = render(<GroupSettings group={groupDetail} />);
+    await user.clear(screen.getByLabelText(/group name/i));
+    await user.type(screen.getByLabelText(/group name/i), 'New Name');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+    return utils;
+  }
+
+  it('has no axe violations when the confirm dialog is open', async () => {
+    const { container } = await openConfirmDialog();
+    expect(screen.getByRole('dialog', { name: /confirm changes/i })).toBeInTheDocument();
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('confirm dialog closes on Escape', async () => {
+    await openConfirmDialog();
+    const dialog = screen.getByRole('dialog');
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  it('Cancel button is keyboard reachable', async () => {
+    await openConfirmDialog();
+    const cancel = screen.getByRole('button', { name: /cancel/i });
+    cancel.focus();
+    expect(document.activeElement).toBe(cancel);
+  });
+});


### PR DESCRIPTION
Closes #1264

## Summary

Manually audited every modal dialog in the frontend (JoinGroupModal, InviteModal, TransactionConfirmModal, TransactionDetailModal, WalletSelectModal, SaveTemplateModal, TemplatePreviewModal, ContributionSuccessModal, the ContributeButton confirmation dialog, GroupSettings' confirm dialog, and OnboardingTutorial) for correct `role`/`aria-modal`/`aria-labelledby`/`aria-describedby`, focus-trap behavior, and keyboard-only Escape/close support, and fixed what was missing.

### Key findings

- **Three hand-rolled (non-MUI) dialogs had no focus trap at all** — Tab could escape into the page behind them, and focus wasn't restored to the triggering element on close: `ContributionSuccessModal`, `ContributeButton`'s inline `ConfirmModal` (the "contribute" flow's confirmation dialog), and `OnboardingTutorial`. A `useFocusTrap` hook already existed in the codebase (and was unit-tested in isolation) but was never actually wired into any component. Wired it into all three.
- **`ContributeButton`'s `ConfirmModal` had zero ARIA semantics** and no Escape handling at all. Added `role="dialog"`, `aria-modal`, `aria-labelledby`/`aria-describedby`, Escape-to-close, and backdrop-click-to-close.
- **`useFocusTrap` had a bug**: it only restored focus when a consumer kept the dialog mounted and toggled an `active` flag. It silently failed to restore focus when a consumer conditionally unmounted the dialog instead (which is exactly what `ContributeButton` does). Fixed by also restoring focus from the effect's cleanup path, so it works for both consumption patterns.
- **`WalletSelectModal` had no visible close control** (only Escape/backdrop-click) — added a visible, keyboard-reachable close `IconButton`.
- Added `aria-describedby` wiring for `JoinGroupModal` and `TemplatePreviewModal`, whose single descriptive paragraph wasn't associated with the dialog for screen readers.
- `OnboardingTutorial` used a static `aria-label` instead of `aria-labelledby`/`aria-describedby` pointing at its actual visible (per-step) heading/body text.

The other MUI `Dialog`-based modals already get focus-trap, `aria-modal`, Escape-to-close, and (via MUI's internal `DialogTitle`/`titleId` context) `aria-labelledby` for free — verified this by reading MUI's source rather than assuming it, so I didn't duplicate work MUI already does correctly.

### Testing

- Added `frontend/src/test/modal-a11y.test.tsx` covering `JoinGroupModal`, `TemplatePreviewModal`, `SaveTemplateModal`, `TransactionDetailModal`, `WalletSelectModal`, `ContributeButton`'s dialog, and `GroupSettings`' confirm dialog: jest-axe zero-violation checks, ARIA attribute assertions, Tab/Shift+Tab focus-trap cycling, and Escape/backdrop-close behavior verified via Testing Library (not just static axe scans).
- Extended `ContributionSuccessModal.test.tsx` and `OnboardingTutorial.test.tsx` with axe checks, focus-trap Tab-cycling tests, and focus-restoration tests.
- `useWallet`/`useContract` are mocked at the hook boundary in the new tests so they exercise only dialog markup/behavior, independent of the wallet integration layer.
- All 99 tests across the 6 affected/added test files pass; zero axe violations on every modal touched.
- `npm run lint`: identical problem count (184) before/after my changes — zero new lint issues introduced.

### Pre-existing, unrelated issues found and left out of scope

While verifying, I found the frontend test/build pipeline has several pre-existing, unrelated breakages (confirmed via `git stash` that each reproduces identically on `main` before my changes):

- `@creit.tech/stellar-wallets-kit` had been dropped from `frontend/package.json` at some point in prior merge history, even though `src/wallet/WalletProvider.tsx` and `vite.config.ts` still reference it. This broke every test that touches `WalletProvider`, **including the `a11y.test.tsx` suite this issue asks to run**. I restored this one dependency (`frontend/package.json`/`package-lock.json`) since it was necessary just to get the test suite running at all — everything else below I left untouched as genuinely out of scope for a modal-accessibility fix:
  - A missing `@stellar-save/sdk` internal workspace package (blocks `TransactionConfirmModal.test.tsx`, `GroupDetails.test.tsx`, etc.)
  - A `@stellar/freighter-api` ESM/CJS interop error inside `WalletProvider.tsx` (still blocks `a11y.test.tsx`, `page-a11y.test.tsx`, and the wallet-dependent integration tests even after the above fix)
  - A duplicate-destructured-parameter syntax error in `GroupCard.tsx` (blocks `BrowseGroupsPage.test.tsx`)
  - A pre-existing `tsc` error in `src/ui/theme/theme.ts` that blocks `npm run build` entirely

## Test plan

- [x] `npx vitest run src/test/modal-a11y.test.tsx src/test/useFocusTrap.test.tsx src/test/ContributionSuccessModal.test.tsx src/test/OnboardingTutorial.test.tsx src/test/InviteModal.test.tsx src/test/TemplateGallery.test.tsx` — 99/99 passing, zero axe violations
- [x] `npm run lint` — no new errors/warnings vs. baseline
- [x] Manual DOM/ARIA review of every modal component for what a screen reader would announce on open/close
- [ ] `npm run build` / full `npm test` — pre-existing unrelated failures on `main`, documented above, not touched by this PR