### PR TITLE
fix(pool): eliminate redundant group_data reads in payout path

### DIFF
--- a/contracts/stellar-save/src/contract.rs
+++ b/contracts/stellar-save/src/contract.rs
@@ -801,8 +801,9 @@ impl StellarSaveContract {
             return Ok(false);
         }
 
-        // 3. Get pool information for current cycle
-        let pool_info = PoolCalculator::get_pool_info(&env, group_id, group.current_cycle)?;
+        // 3. Get pool information for current cycle (reuse already-loaded group,
+        // avoiding a redundant SLOAD of the group_data entry)
+        let pool_info = PoolCalculator::get_pool_info_for_group(&env, &group, group.current_cycle)?;
 
         // 4. Check if cycle is complete (all members contributed)
         if !pool_info.is_cycle_complete {

--- a/contracts/stellar-save/src/payout_executor.rs
+++ b/contracts/stellar-save/src/payout_executor.rs
@@ -50,11 +50,12 @@ use soroban_sdk::{Address, Env};
 /// Validates Requirements 1.1, 1.2, 1.3, 1.4, 1.5
 fn validate_cycle_complete(
     env: &Env,
-    group_id: u64,
+    group: &Group,
     current_cycle: u32,
 ) -> Result<crate::pool::PoolInfo, StellarSaveError> {
-    // Call PoolCalculator to retrieve comprehensive cycle data
-    let pool_info = PoolCalculator::get_pool_info(env, group_id, current_cycle)?;
+    // Reuse the already-loaded group instead of re-reading it from storage,
+    // avoiding a redundant SLOAD of the group_data entry within this invocation.
+    let pool_info = PoolCalculator::get_pool_info_for_group(env, group, current_cycle)?;
 
     // Validate that the pool is ready for payout
     // This checks:
@@ -819,7 +820,7 @@ pub fn execute_payout(env: Env, group_id: u64) -> Result<(), StellarSaveError> {
     // All validation checks must pass before any state modifications occur
 
     // Step 4: Validate cycle is complete (all members have contributed)
-    let pool_info = validate_cycle_complete(&env, group_id, current_cycle)?;
+    let pool_info = validate_cycle_complete(&env, &group, current_cycle)?;
 
     // Step 4b: Apply penalties to members who missed contributions this cycle.
     // Penalties are added to the pool total so the payout recipient benefits.

--- a/contracts/stellar-save/src/pool.rs
+++ b/contracts/stellar-save/src/pool.rs
@@ -224,6 +224,30 @@ impl PoolCalculator {
             .get(&group_key)
             .ok_or(StellarSaveError::GroupNotFound)?;
 
+        Self::get_pool_info_for_group(env, &group, cycle)
+    }
+
+    /// Builds complete pool information for a group and cycle, reusing a
+    /// `Group` the caller has already loaded from storage.
+    ///
+    /// Gas opt: avoids re-reading the `group_data` entry when the caller
+    /// already holds the group (e.g. `is_payout_due`, `execute_payout`),
+    /// eliminating a redundant SLOAD within the same invocation.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `group` - Already-loaded group data
+    /// * `cycle` - Current cycle number
+    ///
+    /// # Returns
+    /// * `Ok(PoolInfo)` - Complete pool information
+    /// * `Err(StellarSaveError)` - If pool calculation fails
+    pub fn get_pool_info_for_group(
+        env: &Env,
+        group: &crate::group::Group,
+        cycle: u32,
+    ) -> Result<PoolInfo, StellarSaveError> {
+        let group_id = group.id;
         let member_count = group.member_count;
         let contribution_amount = group.contribution_amount;
 


### PR DESCRIPTION
## Summary
- `is_payout_due` (contract.rs) and `execute_payout` (payout_executor.rs) each already load the `Group` from storage, then re-fetched the same `group_data` entry a second time via `PoolCalculator::get_pool_info`.
- Added `PoolCalculator::get_pool_info_for_group`, which builds `PoolInfo` from an already-loaded `Group` instead of re-reading it from storage. `get_pool_info` now delegates to it after its own read, so existing callers are unaffected.
- Updated `is_payout_due` and `validate_cycle_complete`/`execute_payout` to pass their already-loaded `group`, removing one redundant SLOAD per invocation.
- No functional/behavioral change — same data, same validation, one fewer storage read on the hot payout path.

Closes #1312

## Validation performed
- `cargo check -p stellar-save` — compiles clean (only pre-existing warnings).
- `cargo test --lib pool::` — confirmed the crate's test target has 79 pre-existing compile errors unrelated to this change (identical error set/count on `main` before this diff, verified via `git stash`). These are out of scope for this issue and were not touched.