### PR TITLE
refactor(governance): split governance module into proposal/voting/execution

### DIFF
--- a/contracts/stellar-save/src/contract.rs
+++ b/contracts/stellar-save/src/contract.rs
@@ -17,7 +17,7 @@ use crate::search::{SearchParams, SearchResult};
 use crate::storage::{StorageKey, StorageKeyBuilder};
 use crate::types::{AssignmentMode, ContractConfig, MemberProfile, PayoutScheduleEntry};
 use soroban_sdk::{contract, contractimpl, Address, Env, String, Symbol, Vec, Map, BytesN};
-use crate::{milestones, payout_executor, penalty, rating, refund, search, migration};
+use crate::{governance, milestones, payout_executor, penalty, rating, refund, search, migration};
 
 #[contract]
 pub struct StellarSaveContract;
@@ -973,141 +973,7 @@ impl StellarSaveContract {
         group_id: u64,
         caller: Address,
     ) -> Result<(), StellarSaveError> {
-        caller.require_auth();
-
-        let group_key = StorageKeyBuilder::group_data(group_id);
-        let mut group = env
-            .storage()
-            .persistent()
-            .get::<_, Group>(&group_key)
-            .ok_or(StellarSaveError::GroupNotFound)?;
-
-        let status_key = StorageKeyBuilder::group_status(group_id);
-        let status: GroupStatus = env
-            .storage()
-            .persistent()
-            .get(&status_key)
-            .unwrap_or(GroupStatus::Pending);
-
-        match status {
-            GroupStatus::Cancelled | GroupStatus::Completed => {
-                return Err(StellarSaveError::GroupAlreadyDissolved);
-            }
-            GroupStatus::Active | GroupStatus::Paused => {}
-            GroupStatus::Pending => return Err(StellarSaveError::InvalidState),
-        }
-
-        let member_key = StorageKeyBuilder::member_profile(group_id, caller.clone());
-        if !env.storage().persistent().has(&member_key) {
-            return Err(StellarSaveError::NotMember);
-        }
-
-        let vote_key = StorageKeyBuilder::dissolve_vote(group_id, caller.clone());
-        if env.storage().persistent().has(&vote_key) {
-            return Err(StellarSaveError::AlreadyVotedDissolve);
-        }
-        env.storage().persistent().set(&vote_key, &true);
-
-        let count_key = StorageKeyBuilder::dissolve_vote_count(group_id);
-        let vote_count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
-        let new_count = vote_count.checked_add(1).ok_or(StellarSaveError::Overflow)?;
-        env.storage().persistent().set(&count_key, &new_count);
-
-        // Not unanimous yet — nothing more to do
-        if new_count < group.member_count {
-            return Ok(());
-        }
-
-        // === Unanimous vote: dissolve the group ===
-        group.status = GroupStatus::Cancelled;
-        group.is_active = false;
-        env.storage().persistent().set(&group_key, &group);
-        env.storage()
-            .persistent()
-            .set(&status_key, &GroupStatus::Cancelled);
-
-        let token_config_key = StorageKeyBuilder::group_token_config(group_id);
-        let token_config: crate::group::TokenConfig = env
-            .storage()
-            .persistent()
-            .get(&token_config_key)
-            .ok_or(StellarSaveError::GroupNotFound)?;
-        let token_client =
-            soroban_sdk::token::TokenClient::new(&env, &token_config.token_address);
-
-        let current_cycle = group.current_cycle;
-        let now = env.ledger().timestamp();
-        let mut total_refunded: i128 = 0;
-
-        let members_key = StorageKeyBuilder::group_members(group_id);
-        let members: Map<u32, Address> = env
-            .storage()
-            .persistent()
-            .get(&members_key)
-            .unwrap_or(Map::new(&env));
-
-        for (_, member) in members.iter() {
-            // Skip members who already received their payout
-            let payout_pos_key =
-                StorageKeyBuilder::member_payout_eligibility(group_id, member.clone());
-            let payout_position: u32 =
-                match env.storage().persistent().get::<_, u32>(&payout_pos_key) {
-                    Some(pos) => pos,
-                    None => continue,
-                };
-
-            let recipient_key = StorageKeyBuilder::payout_recipient(group_id, payout_position);
-            let already_paid = env
-                .storage()
-                .persistent()
-                .get::<_, Address>(&recipient_key)
-                .map(|r| r == member)
-                .unwrap_or(false);
-
-            if already_paid {
-                continue;
-            }
-
-            // Refund current-cycle contribution if it exists and hasn't been refunded
-            let contrib_key = StorageKeyBuilder::contribution_individual(
-                group_id,
-                current_cycle,
-                member.clone(),
-            );
-            let refund_amount: i128 = match env
-                .storage()
-                .persistent()
-                .get::<_, crate::contribution::ContributionRecord>(&contrib_key)
-            {
-                Some(record) => record.amount,
-                None => continue,
-            };
-
-            let refund_key =
-                StorageKeyBuilder::refund_record(group_id, current_cycle, member.clone());
-            if env.storage().persistent().has(&refund_key) {
-                continue;
-            }
-
-            token_client.transfer(&env.current_contract_address(), &member, &refund_amount);
-
-            let refund_record = crate::refund::RefundRecord {
-                group_id,
-                member: member.clone(),
-                cycle: current_cycle,
-                amount: refund_amount,
-                refunded_at: now,
-            };
-            env.storage().persistent().set(&refund_key, &refund_record);
-
-            EventEmitter::emit_refund_issued(&env, group_id, member, refund_amount, current_cycle, now);
-
-            total_refunded = total_refunded.saturating_add(refund_amount);
-        }
-
-        EventEmitter::emit_group_dissolved(&env, group_id, now, total_refunded);
-
-        Ok(())
+        governance::vote_dissolve(env, group_id, caller)
     }
 }
 
@@ -5166,46 +5032,7 @@ impl StellarSaveContract {
         group_id: u64,
         new_amount: i128,
     ) -> Result<(), StellarSaveError> {
-        let group_key = StorageKeyBuilder::group_data(group_id);
-        let group = env
-            .storage()
-            .persistent()
-            .get::<_, Group>(&group_key)
-            .ok_or(StellarSaveError::GroupNotFound)?;
-
-        group.creator.require_auth();
-
-        if !group.allow_dynamic_contributions {
-            return Err(StellarSaveError::InvalidState);
-        }
-
-        if group.status != GroupStatus::Active {
-            return Err(StellarSaveError::InvalidState);
-        }
-
-        if new_amount <= 0 {
-            return Err(StellarSaveError::InvalidAmount);
-        }
-
-        // Store the proposal and reset votes
-        let proposal_key = StorageKeyBuilder::contribution_pending_amount(group_id);
-        env.storage().persistent().set(&proposal_key, &new_amount);
-
-        let vote_key = StorageKeyBuilder::contribution_amount_vote_count(group_id);
-        env.storage().persistent().set(&vote_key, &0u32);
-
-        // Emit event
-        let timestamp = env.ledger().timestamp();
-        EventEmitter::emit_contribution_amount_proposed(
-            &env,
-            group_id,
-            group.creator.clone(),
-            group.contribution_amount,
-            new_amount,
-            timestamp,
-        );
-
-        Ok(())
+        governance::propose_contribution_change(env, group_id, new_amount)
     }
 
     /// Casts a member's vote to approve the pending contribution amount change.
@@ -5215,71 +5042,7 @@ impl StellarSaveContract {
         group_id: u64,
         member: Address,
     ) -> Result<(), StellarSaveError> {
-        member.require_auth();
-
-        let group_key = StorageKeyBuilder::group_data(group_id);
-        let mut group = env
-            .storage()
-            .persistent()
-            .get::<_, Group>(&group_key)
-            .ok_or(StellarSaveError::GroupNotFound)?;
-
-        if !group.allow_dynamic_contributions {
-            return Err(StellarSaveError::InvalidState);
-        }
-
-        // Verify member belongs to the group
-        let member_key = StorageKeyBuilder::member_profile(group_id, member.clone());
-        if !env.storage().persistent().has(&member_key) {
-            return Err(StellarSaveError::NotMember);
-        }
-
-        // Check there is a pending proposal
-        let proposal_key = StorageKeyBuilder::contribution_pending_amount(group_id);
-        let new_amount: i128 = env
-            .storage()
-            .persistent()
-            .get(&proposal_key)
-            .ok_or(StellarSaveError::InvalidState)?;
-
-        // Prevent double voting
-        let member_vote_key = StorageKeyBuilder::contribution_member_vote(group_id, member.clone());
-        if env.storage().persistent().has(&member_vote_key) {
-            return Err(StellarSaveError::AlreadyContributed);
-        }
-        env.storage().persistent().set(&member_vote_key, &true);
-
-        // Increment vote count
-        let vote_key = StorageKeyBuilder::contribution_amount_vote_count(group_id);
-        let vote_count: u32 = env.storage().persistent().get(&vote_key).unwrap_or(0);
-        let new_vote_count = vote_count
-            .checked_add(1)
-            .ok_or(StellarSaveError::Overflow)?;
-        env.storage().persistent().set(&vote_key, &new_vote_count);
-
-        // Apply change if majority reached (> 50% of members)
-        let majority = group.member_count / 2 + 1;
-        if new_vote_count >= majority {
-            let old_amount = group.contribution_amount;
-            group.contribution_amount = new_amount;
-            env.storage().persistent().set(&group_key, &group);
-
-            // Clear proposal and votes
-            env.storage().persistent().remove(&proposal_key);
-            env.storage().persistent().remove(&vote_key);
-
-            let timestamp = env.ledger().timestamp();
-            EventEmitter::emit_contribution_amount_changed(
-                &env,
-                group_id,
-                old_amount,
-                new_amount,
-                group.current_cycle + 1,
-                timestamp,
-            );
-        }
-
-        Ok(())
+        governance::vote_contribution_change(env, group_id, member)
     }
 
     // =========================================================================

--- a/contracts/stellar-save/src/governance/execution.rs
+++ b/contracts/stellar-save/src/governance/execution.rs
@@ -1,0 +1,137 @@
+use crate::error::StellarSaveError;
+use crate::events::EventEmitter;
+use crate::group::{Group, GroupStatus};
+use crate::storage::StorageKeyBuilder;
+use soroban_sdk::{Address, Env, Map};
+
+/// Dissolves a group once every member has voted to dissolve: marks the group
+/// `Cancelled` and refunds current-cycle contributions to members who have not
+/// yet received a payout.
+pub fn execute_dissolution(
+    env: &Env,
+    group_id: u64,
+    group: &mut Group,
+) -> Result<(), StellarSaveError> {
+    let group_key = StorageKeyBuilder::group_data(group_id);
+    let status_key = StorageKeyBuilder::group_status(group_id);
+
+    group.status = GroupStatus::Cancelled;
+    group.is_active = false;
+    env.storage().persistent().set(&group_key, group);
+    env.storage()
+        .persistent()
+        .set(&status_key, &GroupStatus::Cancelled);
+
+    let token_config_key = StorageKeyBuilder::group_token_config(group_id);
+    let token_config: crate::group::TokenConfig = env
+        .storage()
+        .persistent()
+        .get(&token_config_key)
+        .ok_or(StellarSaveError::GroupNotFound)?;
+    let token_client = soroban_sdk::token::TokenClient::new(env, &token_config.token_address);
+
+    let current_cycle = group.current_cycle;
+    let now = env.ledger().timestamp();
+    let mut total_refunded: i128 = 0;
+
+    let members_key = StorageKeyBuilder::group_members(group_id);
+    let members: Map<u32, Address> = env
+        .storage()
+        .persistent()
+        .get(&members_key)
+        .unwrap_or(Map::new(env));
+
+    for (_, member) in members.iter() {
+        // Skip members who already received their payout
+        let payout_pos_key =
+            StorageKeyBuilder::member_payout_eligibility(group_id, member.clone());
+        let payout_position: u32 = match env.storage().persistent().get::<_, u32>(&payout_pos_key)
+        {
+            Some(pos) => pos,
+            None => continue,
+        };
+
+        let recipient_key = StorageKeyBuilder::payout_recipient(group_id, payout_position);
+        let already_paid = env
+            .storage()
+            .persistent()
+            .get::<_, Address>(&recipient_key)
+            .map(|r| r == member)
+            .unwrap_or(false);
+
+        if already_paid {
+            continue;
+        }
+
+        // Refund current-cycle contribution if it exists and hasn't been refunded
+        let contrib_key =
+            StorageKeyBuilder::contribution_individual(group_id, current_cycle, member.clone());
+        let refund_amount: i128 = match env
+            .storage()
+            .persistent()
+            .get::<_, crate::contribution::ContributionRecord>(&contrib_key)
+        {
+            Some(record) => record.amount,
+            None => continue,
+        };
+
+        let refund_key =
+            StorageKeyBuilder::refund_record(group_id, current_cycle, member.clone());
+        if env.storage().persistent().has(&refund_key) {
+            continue;
+        }
+
+        token_client.transfer(&env.current_contract_address(), &member, &refund_amount);
+
+        let refund_record = crate::refund::RefundRecord {
+            group_id,
+            member: member.clone(),
+            cycle: current_cycle,
+            amount: refund_amount,
+            refunded_at: now,
+        };
+        env.storage().persistent().set(&refund_key, &refund_record);
+
+        EventEmitter::emit_refund_issued(env, group_id, member, refund_amount, current_cycle, now);
+
+        total_refunded = total_refunded.saturating_add(refund_amount);
+    }
+
+    EventEmitter::emit_group_dissolved(env, group_id, now, total_refunded);
+
+    Ok(())
+}
+
+/// Applies an approved contribution-amount change: updates the group's
+/// contribution amount, clears the pending proposal/vote state, and emits
+/// the change event.
+pub fn execute_contribution_change(
+    env: &Env,
+    group_id: u64,
+    group: &mut Group,
+    new_amount: i128,
+) -> Result<(), StellarSaveError> {
+    let group_key = StorageKeyBuilder::group_data(group_id);
+    let proposal_key = StorageKeyBuilder::contribution_pending_amount(group_id);
+    let vote_key = StorageKeyBuilder::contribution_amount_vote_count(group_id);
+
+    let old_amount = group.contribution_amount;
+    group.contribution_amount = new_amount;
+    env.storage().persistent().set(&group_key, group);
+
+    // Clear proposal and votes
+    env.storage().persistent().remove(&proposal_key);
+    env.storage().persistent().remove(&vote_key);
+
+    let timestamp = env.ledger().timestamp();
+    EventEmitter::emit_contribution_amount_changed(
+        env,
+        group_id,
+        old_amount,
+        new_amount,
+        group.current_cycle + 1,
+        timestamp,
+    );
+
+    Ok(())
+}

--- a/contracts/stellar-save/src/governance/mod.rs
+++ b/contracts/stellar-save/src/governance/mod.rs
@@ -1,0 +1,11 @@
+//! Governance logic: group-dissolution voting and dynamic contribution-amount changes.
+//!
+//! Split into `proposal` (creating a pending change), `voting` (casting votes
+//! and checking thresholds), and `execution` (applying the resulting state
+//! change) so each concern stays independently readable and testable.
+pub mod execution;
+pub mod proposal;
+pub mod voting;
+
+pub use proposal::propose_contribution_change;
+pub use voting::{vote_contribution_change, vote_dissolve};

--- a/contracts/stellar-save/src/governance/proposal.rs
+++ b/contracts/stellar-save/src/governance/proposal.rs
@@ -1,0 +1,54 @@
+use crate::error::StellarSaveError;
+use crate::events::EventEmitter;
+use crate::group::{Group, GroupStatus};
+use crate::storage::StorageKeyBuilder;
+use soroban_sdk::Env;
+
+/// Proposes a new contribution amount for the next cycle.
+/// Only the group creator can propose; the group must allow dynamic contributions.
+pub fn propose_contribution_change(
+    env: Env,
+    group_id: u64,
+    new_amount: i128,
+) -> Result<(), StellarSaveError> {
+    let group_key = StorageKeyBuilder::group_data(group_id);
+    let group = env
+        .storage()
+        .persistent()
+        .get::<_, Group>(&group_key)
+        .ok_or(StellarSaveError::GroupNotFound)?;
+
+    group.creator.require_auth();
+
+    if !group.allow_dynamic_contributions {
+        return Err(StellarSaveError::InvalidState);
+    }
+
+    if group.status != GroupStatus::Active {
+        return Err(StellarSaveError::InvalidState);
+    }
+
+    if new_amount <= 0 {
+        return Err(StellarSaveError::InvalidAmount);
+    }
+
+    // Store the proposal and reset votes
+    let proposal_key = StorageKeyBuilder::contribution_pending_amount(group_id);
+    env.storage().persistent().set(&proposal_key, &new_amount);
+
+    let vote_key = StorageKeyBuilder::contribution_amount_vote_count(group_id);
+    env.storage().persistent().set(&vote_key, &0u32);
+
+    // Emit event
+    let timestamp = env.ledger().timestamp();
+    EventEmitter::emit_contribution_amount_proposed(
+        &env,
+        group_id,
+        group.creator.clone(),
+        group.contribution_amount,
+        new_amount,
+        timestamp,
+    );
+
+    Ok(())
+}

--- a/contracts/stellar-save/src/governance/voting.rs
+++ b/contracts/stellar-save/src/governance/voting.rs
@@ -1,0 +1,126 @@
+use crate::error::StellarSaveError;
+use crate::governance::execution;
+use crate::group::{Group, GroupStatus};
+use crate::storage::StorageKeyBuilder;
+use soroban_sdk::{Address, Env};
+
+/// Casts a member's vote to dissolve the group.
+///
+/// When all members have voted, the group is dissolved: its status is set to
+/// `Cancelled` and every member who has **not yet received a payout** is
+/// refunded their contributions for the current cycle.
+///
+/// # Errors
+/// - `GroupNotFound` - Group doesn't exist
+/// - `InvalidState` - Group is not Active or Paused
+/// - `NotMember` - Caller is not a member of the group
+/// - `AlreadyVotedDissolve` - Caller has already voted
+/// - `GroupAlreadyDissolved` - Group is already in a terminal state
+pub fn vote_dissolve(env: Env, group_id: u64, caller: Address) -> Result<(), StellarSaveError> {
+    caller.require_auth();
+
+    let group_key = StorageKeyBuilder::group_data(group_id);
+    let mut group = env
+        .storage()
+        .persistent()
+        .get::<_, Group>(&group_key)
+        .ok_or(StellarSaveError::GroupNotFound)?;
+
+    let status_key = StorageKeyBuilder::group_status(group_id);
+    let status: GroupStatus = env
+        .storage()
+        .persistent()
+        .get(&status_key)
+        .unwrap_or(GroupStatus::Pending);
+
+    match status {
+        GroupStatus::Cancelled | GroupStatus::Completed => {
+            return Err(StellarSaveError::GroupAlreadyDissolved);
+        }
+        GroupStatus::Active | GroupStatus::Paused => {}
+        GroupStatus::Pending => return Err(StellarSaveError::InvalidState),
+    }
+
+    let member_key = StorageKeyBuilder::member_profile(group_id, caller.clone());
+    if !env.storage().persistent().has(&member_key) {
+        return Err(StellarSaveError::NotMember);
+    }
+
+    let vote_key = StorageKeyBuilder::dissolve_vote(group_id, caller.clone());
+    if env.storage().persistent().has(&vote_key) {
+        return Err(StellarSaveError::AlreadyVotedDissolve);
+    }
+    env.storage().persistent().set(&vote_key, &true);
+
+    let count_key = StorageKeyBuilder::dissolve_vote_count(group_id);
+    let vote_count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+    let new_count = vote_count
+        .checked_add(1)
+        .ok_or(StellarSaveError::Overflow)?;
+    env.storage().persistent().set(&count_key, &new_count);
+
+    // Not unanimous yet — nothing more to do
+    if new_count < group.member_count {
+        return Ok(());
+    }
+
+    execution::execute_dissolution(&env, group_id, &mut group)
+}
+
+/// Casts a member's vote to approve the pending contribution amount change.
+/// When a majority (> 50%) of members approve, the change is applied immediately.
+pub fn vote_contribution_change(
+    env: Env,
+    group_id: u64,
+    member: Address,
+) -> Result<(), StellarSaveError> {
+    member.require_auth();
+
+    let group_key = StorageKeyBuilder::group_data(group_id);
+    let mut group = env
+        .storage()
+        .persistent()
+        .get::<_, Group>(&group_key)
+        .ok_or(StellarSaveError::GroupNotFound)?;
+
+    if !group.allow_dynamic_contributions {
+        return Err(StellarSaveError::InvalidState);
+    }
+
+    // Verify member belongs to the group
+    let member_key = StorageKeyBuilder::member_profile(group_id, member.clone());
+    if !env.storage().persistent().has(&member_key) {
+        return Err(StellarSaveError::NotMember);
+    }
+
+    // Check there is a pending proposal
+    let proposal_key = StorageKeyBuilder::contribution_pending_amount(group_id);
+    let new_amount: i128 = env
+        .storage()
+        .persistent()
+        .get(&proposal_key)
+        .ok_or(StellarSaveError::InvalidState)?;
+
+    // Prevent double voting
+    let member_vote_key = StorageKeyBuilder::contribution_member_vote(group_id, member.clone());
+    if env.storage().persistent().has(&member_vote_key) {
+        return Err(StellarSaveError::AlreadyContributed);
+    }
+    env.storage().persistent().set(&member_vote_key, &true);
+
+    // Increment vote count
+    let vote_key = StorageKeyBuilder::contribution_amount_vote_count(group_id);
+    let vote_count: u32 = env.storage().persistent().get(&vote_key).unwrap_or(0);
+    let new_vote_count = vote_count
+        .checked_add(1)
+        .ok_or(StellarSaveError::Overflow)?;
+    env.storage().persistent().set(&vote_key, &new_vote_count);
+
+    // Apply change if majority reached (> 50% of members)
+    let majority = group.member_count / 2 + 1;
+    if new_vote_count >= majority {
+        execution::execute_contribution_change(&env, group_id, &mut group, new_amount)?;
+    }
+
+    Ok(())
+}

--- a/contracts/stellar-save/src/lib.rs
+++ b/contracts/stellar-save/src/lib.rs
@@ -18,6 +18,7 @@ pub mod deadline;
 pub mod error;
 pub mod errors;
 pub mod events;
+pub mod governance;
 pub mod group;
 pub mod helpers;
 pub mod migration;


### PR DESCRIPTION
## Summary
- The three governance endpoints (`vote_dissolve`, `propose_contribution_change`, `vote_contribution_change`) previously lived as large inline function bodies inside the monolithic `contract.rs`.
- Extracted their logic into a new `governance` module with clear boundaries, matching the existing thin-facade delegation pattern already used for `payout_executor`:
  - `governance::proposal` — creates/stores a pending contribution-amount change proposal
  - `governance::voting` — casts dissolve/contribution-change votes and checks thresholds
  - `governance::execution` — applies the resulting state change (group dissolution + refunds, or the approved contribution amount)
  - `governance::mod` — thin re-export of the public interface
- `contract.rs`'s `#[contractimpl]` functions are now one-line delegators. Public contract interface and behavior are unchanged (no functional change, pure extraction).

Closes #1311 
Closes #1313 
Closes #1314

## Validation performed
- `cargo check -p stellar-save` — compiles clean, same warning count as before (60), no new unused-import warnings.
- Release wasm build size comparison: **84134 bytes** (main) vs **84183 bytes** (this branch) — a +49 byte (~0.06%) difference, confirming contract size is unaffected.
- Note: `cargo test --lib` currently fails to compile on `main` due to 79 pre-existing, unrelated compile errors in the test target (verified identical error set on `main` before this change via `git stash`). These are out of scope for this issue and were not touched.