### PR TITLE
feat(backend): add graceful shutdown for in-flight requests

### DIFF
--- a/backend/src/graceful_shutdown.ts
+++ b/backend/src/graceful_shutdown.ts
@@ -1,0 +1,55 @@
+export interface ShutdownServer {
+  close(callback: (err?: Error) => void): void;
+}
+
+export interface GracefulShutdownOptions {
+  /** Max time to wait for in-flight requests to finish before forcing exit (ms). Default: 10000 */
+  timeoutMs?: number;
+  exit?: (code: number) => void;
+  log?: (msg: string) => void;
+  logError?: (msg: string, err?: unknown) => void;
+}
+
+/**
+ * Builds a signal handler that stops the server from accepting new connections,
+ * lets in-flight requests finish (bounded by a timeout), runs cleanup (e.g.
+ * closing DB connections), then exits.
+ */
+export function createGracefulShutdown(
+  server: ShutdownServer,
+  cleanup: () => Promise<void>,
+  options: GracefulShutdownOptions = {}
+): (signal: string) => void {
+  const timeoutMs = options.timeoutMs ?? 10000;
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  const log = options.log ?? console.log;
+  const logError = options.logError ?? console.error;
+  let isShuttingDown = false;
+
+  return function gracefulShutdown(signal: string): void {
+    if (isShuttingDown) return;
+    isShuttingDown = true;
+    log(`[shutdown] Received ${signal}, draining in-flight requests...`);
+
+    const forceExitTimer = setTimeout(() => {
+      logError(`[shutdown] Timed out after ${timeoutMs}ms; forcing exit.`);
+      exit(1);
+    }, timeoutMs);
+    forceExitTimer.unref?.();
+
+    server.close((err?: Error) => {
+      cleanup()
+        .catch(() => {})
+        .finally(() => {
+          clearTimeout(forceExitTimer);
+          if (err) {
+            logError('[shutdown] Error closing server:', err);
+            exit(1);
+            return;
+          }
+          log('[shutdown] Clean shutdown complete.');
+          exit(0);
+        });
+    });
+  };
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -34,6 +34,7 @@ import { createV2Router } from './routes/v2';
 import { metricsMiddleware, metricsHandler } from './metrics';
 import { requestLogger } from './logger';
 import { disconnectPrisma, prisma } from './prisma_client';
+import { createGracefulShutdown } from './graceful_shutdown';
 import { createRateLimiterMiddleware, createAuthRateLimiterMiddleware } from './rate_limiter';
 import { createTieredRateLimiter, configureTier, setEndpointCost } from './redis_rate_limiter';
 import { createQuotaReporterRouter } from './routes/quota_reporter';
@@ -384,11 +385,14 @@ server.listen(PORT, async () => {
   }
 });
 
-// Graceful shutdown
-process.on('SIGTERM', () => {
+// Graceful shutdown: stop accepting new connections, let in-flight requests
+// finish within a timeout, then close DB connections before exiting.
+const gracefulShutdown = createGracefulShutdown(server, async () => {
   fraudDetectionWorker.stop();
-  server.close();
-  disconnectPrisma().catch(() => {});
-});
+  await disconnectPrisma();
+}, { timeoutMs: parseInt(process.env.SHUTDOWN_TIMEOUT_MS ?? '10000', 10) });
+
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 
 export { app };

--- a/backend/src/tests/graceful_shutdown.test.ts
+++ b/backend/src/tests/graceful_shutdown.test.ts
@@ -1,0 +1,58 @@
+import { createGracefulShutdown } from '../graceful_shutdown';
+
+function makeServer(closeDelayMs: number) {
+  return {
+    close: jest.fn((cb: (err?: Error) => void) => {
+      setTimeout(() => cb(), closeDelayMs);
+    }),
+  };
+}
+
+describe('createGracefulShutdown', () => {
+  it('waits for in-flight requests to finish before running cleanup and exiting', async () => {
+    const server = makeServer(30);
+    const cleanup = jest.fn().mockResolvedValue(undefined);
+    const exit = jest.fn();
+
+    const shutdown = createGracefulShutdown(server, cleanup, { timeoutMs: 1000, exit, log: () => {} });
+    shutdown('SIGTERM');
+
+    expect(server.close).toHaveBeenCalledTimes(1);
+    expect(cleanup).not.toHaveBeenCalled();
+
+    await new Promise(resolve => setTimeout(resolve, 60));
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('forces exit if in-flight requests do not finish within the timeout', async () => {
+    const server = makeServer(10_000); // never resolves within the test window
+    const cleanup = jest.fn().mockResolvedValue(undefined);
+    const exit = jest.fn();
+
+    const shutdown = createGracefulShutdown(server, cleanup, {
+      timeoutMs: 20,
+      exit,
+      log: () => {},
+      logError: () => {},
+    });
+    shutdown('SIGTERM');
+
+    await new Promise(resolve => setTimeout(resolve, 40));
+
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('ignores repeated shutdown signals', () => {
+    const server = makeServer(10);
+    const cleanup = jest.fn().mockResolvedValue(undefined);
+    const exit = jest.fn();
+
+    const shutdown = createGracefulShutdown(server, cleanup, { timeoutMs: 1000, exit, log: () => {} });
+    shutdown('SIGTERM');
+    shutdown('SIGINT');
+
+    expect(server.close).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract shutdown logic into `backend/src/graceful_shutdown.ts` (`createGracefulShutdown`): on signal, stop accepting new connections (`server.close`), let in-flight requests finish within a bounded timeout (`SHUTDOWN_TIMEOUT_MS`, default 10s, forces exit if exceeded), then run cleanup (stop the fraud worker, disconnect Prisma) before exiting.
- Wire it up in `backend/src/index.ts` for both `SIGTERM` and `SIGINT` (previous handler only handled `SIGTERM`, didn't wait for in-flight requests or a timeout, and disconnected Prisma without awaiting it).
- Add tests covering: in-flight requests complete before cleanup/exit, a hung shutdown force-exits after the timeout, and repeated signals are ignored (idempotent).

Closes #1309

## Validation performed
- Manual review of the extracted shutdown module and its wiring into `index.ts`.
- Could not run `npm test`/`tsc` locally — `node_modules` is not installed in this environment (pre-existing, unrelated to this change).