### PR TITLE
refactor(backend): add DTO mapper for contract-event responses

### DIFF
--- a/backend/src/dto.ts
+++ b/backend/src/dto.ts
@@ -1,0 +1,35 @@
+/** Serialization layer mapping internal DB models to API-facing response shapes. */
+
+export interface ContractEventDTO {
+  contractId: string;
+  eventType: string;
+  topics: unknown;
+  data: unknown;
+  txHash: string;
+  ledgerSeq: number;
+  timestamp: string;
+}
+
+/**
+ * Maps a raw `ContractEvent` DB row to its public response shape, omitting
+ * internal-only fields (`id`, `createdAt`, `blockTime`) that consumers don't need.
+ */
+export function toContractEventDTO(event: {
+  contractId: string;
+  eventType: string;
+  topics: unknown;
+  data: unknown;
+  txHash: string;
+  ledgerSeq: number;
+  timestamp: Date;
+}): ContractEventDTO {
+  return {
+    contractId: event.contractId,
+    eventType: event.eventType,
+    topics: event.topics,
+    data: event.data,
+    txHash: event.txHash,
+    ledgerSeq: event.ledgerSeq,
+    timestamp: event.timestamp.toISOString(),
+  };
+}

--- a/backend/src/routes/v1.ts
+++ b/backend/src/routes/v1.ts
@@ -15,6 +15,7 @@ import { AnalyticsService } from '../analytics_service';
 import { FeedbackService } from '../feedback_service';
 import { createAnalyticsMiddlewareStack, createAnalyticsCacheMiddleware } from '../analytics_middleware';
 import { Group, UserInteraction, UserPreference } from '../models';
+import { toContractEventDTO } from '../dto';
 import { createNotificationRouter } from './notifications';
 import { createSseRouter } from './sse';
 import { createInsuranceRouter } from './insurance';
@@ -272,7 +273,7 @@ export function createV1Router(services: V1Services): Router {
       const total: number = Array.isArray(result)
         ? items.length
         : (result as any).total ?? items.length;
-      res.json(paginate(items, total, pageParams));
+      res.json(paginate(items.map(toContractEventDTO), total, pageParams));
     } catch (error) {
       console.error('Error fetching events:', error);
       res.status(500).json({ error: 'Failed to fetch events' });
@@ -739,7 +740,7 @@ export function createV1Router(services: V1Services): Router {
       });
 
       await recordApiUsage(req, res);
-      res.json({ count: groups.length, limit, offset, groups });
+      res.json({ count: groups.length, limit, offset, groups: groups.map(toContractEventDTO) });
     } catch (error) {
       res.status(500).json({ error: 'Failed to fetch groups' });
     }

--- a/backend/src/tests/dto.test.ts
+++ b/backend/src/tests/dto.test.ts
@@ -1,0 +1,35 @@
+import { toContractEventDTO } from '../dto';
+
+describe('toContractEventDTO', () => {
+  const dbRow = {
+    id: 'internal-cuid-1',
+    contractId: 'CONTRACT1',
+    eventType: 'GroupCreated',
+    topics: ['group_created'],
+    data: { groupId: 'g1' },
+    txHash: 'tx1',
+    ledgerSeq: 42,
+    timestamp: new Date('2026-01-01T00:00:00.000Z'),
+    blockTime: new Date('2026-01-01T00:00:01.000Z'),
+    createdAt: new Date('2026-01-01T00:00:02.000Z'),
+  };
+
+  it('maps public-facing fields', () => {
+    expect(toContractEventDTO(dbRow)).toEqual({
+      contractId: 'CONTRACT1',
+      eventType: 'GroupCreated',
+      topics: ['group_created'],
+      data: { groupId: 'g1' },
+      txHash: 'tx1',
+      ledgerSeq: 42,
+      timestamp: '2026-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('does not leak internal-only DB fields', () => {
+    const dto = toContractEventDTO(dbRow) as Record<string, unknown>;
+    expect(dto).not.toHaveProperty('id');
+    expect(dto).not.toHaveProperty('createdAt');
+    expect(dto).not.toHaveProperty('blockTime');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `backend/src/dto.ts` with `toContractEventDTO`, a single serialization mapper for `ContractEvent` DB rows, that strips internal-only fields (`id`, `createdAt`, `blockTime`).
- Replace inline response construction in `GET /api/v1/events` and `GET /api/v1/public/groups` (the latter is an external, API-key-authenticated endpoint) with the mapper, so raw DB rows are no longer returned to API consumers.
- Add tests asserting the DTO maps expected fields and does not leak internal-only fields.

Scope note: this codebase manages groups/members via the Soroban contract and indexes activity as `ContractEvent` rows rather than owning separate Group/Member/Transaction DB models, so the mapper targets the one place raw DB rows were being serialized directly to clients. No other route currently returns raw `IndexedTransaction`/member rows.

Closes #1308

## Validation performed
- Manual review of the two affected route handlers and the new mapper/tests.
- Could not run `npm test`/`tsc` locally — `node_modules` is not installed in this environment (pre-existing, unrelated to this change).