### PR TITLE
docs: audit and document class-component exceptions (#1265)

### DIFF
--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -19,6 +19,10 @@ export interface ErrorBoundaryState {
   retryCount: number;
 }
 
+// NOTE: Intentional class component exception (see issue #1265).
+// React has no hooks-based equivalent for `getDerivedStateFromError` /
+// `componentDidCatch`, so error boundaries must be class components.
+// Do not convert this to a function component.
 export class ErrorBoundary extends React.Component<
   React.PropsWithChildren<ErrorBoundaryProps>,
   ErrorBoundaryState

--- a/frontend/src/components/RouteErrorBoundary.tsx
+++ b/frontend/src/components/RouteErrorBoundary.tsx
@@ -12,6 +12,10 @@ interface State {
   errorInfo: ErrorInfo | null;
 }
 
+// NOTE: Intentional class component exception (see issue #1265).
+// React has no hooks-based equivalent for `getDerivedStateFromError` /
+// `componentDidCatch`, so error boundaries must be class components.
+// Do not convert this to a function component.
 export class RouteErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);


### PR DESCRIPTION
Closes #1265

## Summary

Per the issue tasks, audited `frontend/src` for:
- Class components (`extends React.Component` / `React.PureComponent`)
- Lifecycle-to-hook shim utilities

## Findings

Only two class components exist in `frontend/src`:
- `frontend/src/components/ErrorBoundary/ErrorBoundary.tsx`
- `frontend/src/components/RouteErrorBoundary.tsx`

Both are React error boundaries. React currently has no hooks-based equivalent for `getDerivedStateFromError`/`componentDidCatch` — error boundaries must be class components. These are legitimate, documented exceptions under the acceptance criteria ("no class components remain **except documented exceptions**"), not conversion candidates.

No lifecycle-to-hook shim utilities were found anywhere in `frontend/src` (grepped broadly, including HOC-style adapters — none exist).

## Changes

Added a short comment on each error boundary class marking it as an intentional, documented exception, so future audits/contributors don't re-flag these as migration candidates.

No behavioral changes — this is a documentation-only fix confirming the codebase already satisfies the issue's acceptance criteria.

## Verification

- Fresh grep across `frontend/src` for `extends.*Component`, `React.PureComponent`, and shim-style utilities confirms no other candidates exist.
- The added comments are non-functional (comment-only diff); no tests, lint, or build behavior affected.