### PR TITLE
docs: complete local development onboarding guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Follow the step-by-step guide in [demo/demo-script.md](demo/demo-script.md)
 
 ## 📖 Documentation
 
+- [Local Development Setup](docs/local-development-setup.md) — clone-to-running-app guide for backend, frontend, contracts, and mobile
 - [User Guide](docs/user-guide.md)
 - [Architecture Overview](docs/architecture.md)
 - [Public API Reference](docs/api/interactive-api-reference.md) — REST API with code examples

--- a/docs/local-development-setup.md
+++ b/docs/local-development-setup.md
@@ -125,6 +125,43 @@ stellar contract deploy \
 
 4. Save the returned contract ID for subsequent invocations.
 
+## Mobile Setup
+
+The mobile app lives in `mobile/` and is an Expo (React Native) project.
+
+```bash
+# Install dependencies
+cd mobile
+npm ci
+
+# Start the Expo dev server
+npm start
+
+# Or target a specific platform directly
+npm run android
+npm run ios
+```
+
+The mobile app talks to the same backend (`http://localhost:3001` by default) and consumes the shared `@stellar-save/sdk` workspace package, so start the backend (Docker or manual setup above) before running the app. Use the Expo Go app or a simulator/emulator to open the project once `npm start` prints a QR code.
+
+Useful checks:
+
+```bash
+npm run lint
+npm run typecheck
+```
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| `docker compose up` hangs on `seed` | Postgres/Redis not healthy yet | Re-run `docker compose up`; the `seed` container waits on healthchecks, so a slow first pull can look stuck |
+| `cargo build --target wasm32-unknown-unknown` fails with "target not installed" | Missing Rust target | Run `rustup target add wasm32-unknown-unknown` (already declared in `rust-toolchain.toml`, but manual Rust installs may need it added explicitly) |
+| `stellar contract deploy` fails with account/funding errors | Testnet deployer account has no funds | Use `stellar keys fund deployer --network testnet` (or Friendbot) before deploying |
+| `npm ci` fails in `backend/` or `frontend/` | Node/npm version mismatch | Confirm `node --version` matches the Node 20.x / npm 10.x prerequisite above |
+| Mobile app can't reach the backend from a physical device | `localhost` doesn't resolve to your dev machine on-device | Point the app at your machine's LAN IP (or use `adb reverse tcp:3001 tcp:3001` for Android emulators) instead of `localhost` |
+| Port already in use (5173, 3001, 8000, 5432, 6379) | A previous `docker compose up` or local process is still running | Run `docker compose down -v`, or stop the conflicting local process, then retry |
+
 ## Hello World Walkthrough
 
 ### 1. Create a group


### PR DESCRIPTION
## Summary
`docs/local-development-setup.md` already existed but was missing mobile setup instructions, a troubleshooting section, and a link from the root README — so new contributors following the README couldn't find it, and mobile devs had no coverage at all.

- Added a **Mobile Setup** section (Expo/React Native, `npm ci`, `npm start`, platform targets, lint/typecheck) verified against `mobile/package.json`
- Added a **Troubleshooting** section covering the most common setup failures (compose hangs, missing wasm target, unfunded testnet deployer, Node version mismatch, mobile device networking, port conflicts)
- Linked the guide from the root `README.md` documentation list

## Context / Before-After
- Before: guide covered Docker/manual setup, backend/frontend/contracts build+test, and a testnet walkthrough — but no mobile workspace and no discovery path from the README
- After: guide covers all four workspaces end-to-end and is discoverable from the README

## Testing
- Manually walked the mobile section's commands against `mobile/package.json` scripts (`start`, `android`, `ios`, `lint`, `typecheck`)
- Cross-checked existing commands (Rust target, Node/npm versions, `stellar` CLI usage) against `rust-toolchain.toml` and `package.json` — no stale commands found
- Verified the new README link resolves to the correct relative path

Closes #1254