### PR TITLE
Refactor: extract useTabsController hook from Tabs

### DIFF
--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -1,5 +1,5 @@
-import { useState, useRef, useEffect, KeyboardEvent } from 'react';
 import './Tabs.css';
+import { useTabsController } from '../hooks/useTabsController';
 
 export interface Tab {
   id: string;
@@ -28,66 +28,13 @@ export function Tabs({
   orientation = 'horizontal',
   className = '',
 }: TabsProps) {
-  const isControlled = controlledActiveTab !== undefined;
-  const [internalActiveTab, setInternalActiveTab] = useState(
-    defaultTab || tabs[0]?.id || ''
-  );
-  const activeTab = isControlled ? controlledActiveTab : internalActiveTab;
-  const tabRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
-
-  const handleTabClick = (tabId: string, disabled?: boolean) => {
-    if (disabled) return;
-    
-    if (!isControlled) {
-      setInternalActiveTab(tabId);
-    }
-    onChange?.(tabId);
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>, currentIndex: number) => {
-    const enabledTabs = tabs.filter(tab => !tab.disabled);
-    const currentEnabledIndex = enabledTabs.findIndex(tab => tab.id === tabs[currentIndex].id);
-    
-    let nextIndex = currentEnabledIndex;
-    const isHorizontal = orientation === 'horizontal';
-
-    switch (e.key) {
-      case isHorizontal ? 'ArrowRight' : 'ArrowDown':
-        e.preventDefault();
-        nextIndex = (currentEnabledIndex + 1) % enabledTabs.length;
-        break;
-      case isHorizontal ? 'ArrowLeft' : 'ArrowUp':
-        e.preventDefault();
-        nextIndex = (currentEnabledIndex - 1 + enabledTabs.length) % enabledTabs.length;
-        break;
-      case 'Home':
-        e.preventDefault();
-        nextIndex = 0;
-        break;
-      case 'End':
-        e.preventDefault();
-        nextIndex = enabledTabs.length - 1;
-        break;
-      default:
-        return;
-    }
-
-    const nextTab = enabledTabs[nextIndex];
-    if (nextTab) {
-      handleTabClick(nextTab.id, nextTab.disabled);
-      tabRefs.current.get(nextTab.id)?.focus();
-    }
-  };
-
-  useEffect(() => {
-    // Ensure active tab is valid
-    if (activeTab && !tabs.find(tab => tab.id === activeTab)) {
-      const firstEnabledTab = tabs.find(tab => !tab.disabled);
-      if (firstEnabledTab && !isControlled) {
-        setInternalActiveTab(firstEnabledTab.id);
-      }
-    }
-  }, [tabs, activeTab, isControlled]);
+  const { activeTab, registerTabRef, handleTabClick, handleKeyDown } = useTabsController({
+    tabs,
+    defaultTab,
+    activeTab: controlledActiveTab,
+    onChange,
+    orientation,
+  });
 
   const activeTabContent = tabs.find(tab => tab.id === activeTab)?.content;
 
@@ -116,13 +63,7 @@ export function Tabs({
           return (
             <button
               key={tab.id}
-              ref={(el) => {
-                if (el) {
-                  tabRefs.current.set(tab.id, el);
-                } else {
-                  tabRefs.current.delete(tab.id);
-                }
-              }}
+              ref={(el) => registerTabRef(tab.id, el)}
               role="tab"
               aria-selected={isActive}
               aria-controls={`tabpanel-${tab.id}`}

--- a/frontend/src/hooks/__tests__/useTabsController.test.ts
+++ b/frontend/src/hooks/__tests__/useTabsController.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTabsController } from '../useTabsController';
+import type { Tab } from '../../components/Tabs';
+
+const mockTabs: Tab[] = [
+  { id: 'tab1', label: 'Tab 1', content: null },
+  { id: 'tab2', label: 'Tab 2', content: null },
+  { id: 'tab3', label: 'Tab 3', content: null, disabled: true },
+];
+
+describe('useTabsController', () => {
+  it('defaults active tab to the first tab', () => {
+    const { result } = renderHook(() => useTabsController({ tabs: mockTabs }));
+    expect(result.current.activeTab).toBe('tab1');
+  });
+
+  it('respects defaultTab', () => {
+    const { result } = renderHook(() =>
+      useTabsController({ tabs: mockTabs, defaultTab: 'tab2' })
+    );
+    expect(result.current.activeTab).toBe('tab2');
+  });
+
+  it('updates active tab on handleTabClick when uncontrolled', () => {
+    const { result } = renderHook(() => useTabsController({ tabs: mockTabs }));
+
+    act(() => {
+      result.current.handleTabClick('tab2');
+    });
+
+    expect(result.current.activeTab).toBe('tab2');
+  });
+
+  it('does not update active tab when disabled', () => {
+    const { result } = renderHook(() => useTabsController({ tabs: mockTabs }));
+
+    act(() => {
+      result.current.handleTabClick('tab3', true);
+    });
+
+    expect(result.current.activeTab).toBe('tab1');
+  });
+
+  it('calls onChange with the clicked tab id', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useTabsController({ tabs: mockTabs, onChange }));
+
+    act(() => {
+      result.current.handleTabClick('tab2');
+    });
+
+    expect(onChange).toHaveBeenCalledWith('tab2');
+  });
+
+  it('stays on controlled activeTab regardless of handleTabClick', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useTabsController({ tabs: mockTabs, activeTab: 'tab1', onChange })
+    );
+
+    act(() => {
+      result.current.handleTabClick('tab2');
+    });
+
+    expect(result.current.activeTab).toBe('tab1');
+    expect(onChange).toHaveBeenCalledWith('tab2');
+  });
+
+  it('advances to the next enabled tab on ArrowRight, skipping disabled tabs', () => {
+    const { result } = renderHook(() => useTabsController({ tabs: mockTabs }));
+    const preventDefault = vi.fn();
+
+    act(() => {
+      result.current.handleKeyDown(
+        { key: 'ArrowRight', preventDefault } as unknown as React.KeyboardEvent<HTMLButtonElement>,
+        0
+      );
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(result.current.activeTab).toBe('tab2');
+  });
+
+  it('wraps to the first tab on ArrowRight from the last enabled tab', () => {
+    const { result } = renderHook(() => useTabsController({ tabs: mockTabs, defaultTab: 'tab2' }));
+    const preventDefault = vi.fn();
+
+    act(() => {
+      result.current.handleKeyDown(
+        { key: 'ArrowRight', preventDefault } as unknown as React.KeyboardEvent<HTMLButtonElement>,
+        1
+      );
+    });
+
+    expect(result.current.activeTab).toBe('tab1');
+  });
+
+  it('jumps to first/last enabled tab on Home/End', () => {
+    const { result } = renderHook(() => useTabsController({ tabs: mockTabs, defaultTab: 'tab2' }));
+    const preventDefault = vi.fn();
+
+    act(() => {
+      result.current.handleKeyDown(
+        { key: 'Home', preventDefault } as unknown as React.KeyboardEvent<HTMLButtonElement>,
+        1
+      );
+    });
+    expect(result.current.activeTab).toBe('tab1');
+
+    act(() => {
+      result.current.handleKeyDown(
+        { key: 'End', preventDefault } as unknown as React.KeyboardEvent<HTMLButtonElement>,
+        0
+      );
+    });
+    expect(result.current.activeTab).toBe('tab2');
+  });
+
+  it('respects vertical orientation for Arrow keys', () => {
+    const { result } = renderHook(() =>
+      useTabsController({ tabs: mockTabs, orientation: 'vertical' })
+    );
+    const preventDefault = vi.fn();
+
+    act(() => {
+      result.current.handleKeyDown(
+        { key: 'ArrowDown', preventDefault } as unknown as React.KeyboardEvent<HTMLButtonElement>,
+        0
+      );
+    });
+
+    expect(result.current.activeTab).toBe('tab2');
+  });
+});

--- a/frontend/src/hooks/useTabsController.ts
+++ b/frontend/src/hooks/useTabsController.ts
@@ -1,0 +1,94 @@
+import { useRef, useState, useEffect, KeyboardEvent } from 'react';
+import type { Tab } from '../components/Tabs';
+
+export interface UseTabsControllerOptions {
+  tabs: Tab[];
+  defaultTab?: string;
+  activeTab?: string;
+  onChange?: (tabId: string) => void;
+  orientation?: 'horizontal' | 'vertical';
+}
+
+export function useTabsController({
+  tabs,
+  defaultTab,
+  activeTab: controlledActiveTab,
+  onChange,
+  orientation = 'horizontal',
+}: UseTabsControllerOptions) {
+  const isControlled = controlledActiveTab !== undefined;
+  const [internalActiveTab, setInternalActiveTab] = useState(
+    defaultTab || tabs[0]?.id || ''
+  );
+  const activeTab = isControlled ? controlledActiveTab : internalActiveTab;
+  const tabRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  const registerTabRef = (tabId: string, el: HTMLButtonElement | null) => {
+    if (el) {
+      tabRefs.current.set(tabId, el);
+    } else {
+      tabRefs.current.delete(tabId);
+    }
+  };
+
+  const handleTabClick = (tabId: string, disabled?: boolean) => {
+    if (disabled) return;
+
+    if (!isControlled) {
+      setInternalActiveTab(tabId);
+    }
+    onChange?.(tabId);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>, currentIndex: number) => {
+    const enabledTabs = tabs.filter((tab) => !tab.disabled);
+    const currentEnabledIndex = enabledTabs.findIndex((tab) => tab.id === tabs[currentIndex].id);
+
+    let nextIndex = currentEnabledIndex;
+    const isHorizontal = orientation === 'horizontal';
+
+    switch (e.key) {
+      case isHorizontal ? 'ArrowRight' : 'ArrowDown':
+        e.preventDefault();
+        nextIndex = (currentEnabledIndex + 1) % enabledTabs.length;
+        break;
+      case isHorizontal ? 'ArrowLeft' : 'ArrowUp':
+        e.preventDefault();
+        nextIndex = (currentEnabledIndex - 1 + enabledTabs.length) % enabledTabs.length;
+        break;
+      case 'Home':
+        e.preventDefault();
+        nextIndex = 0;
+        break;
+      case 'End':
+        e.preventDefault();
+        nextIndex = enabledTabs.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    const nextTab = enabledTabs[nextIndex];
+    if (nextTab) {
+      handleTabClick(nextTab.id, nextTab.disabled);
+      tabRefs.current.get(nextTab.id)?.focus();
+    }
+  };
+
+  useEffect(() => {
+    // Ensure active tab is valid
+    if (activeTab && !tabs.find((tab) => tab.id === activeTab)) {
+      const firstEnabledTab = tabs.find((tab) => !tab.disabled);
+      if (firstEnabledTab && !isControlled) {
+        setInternalActiveTab(firstEnabledTab.id);
+      }
+    }
+  }, [tabs, activeTab, isControlled]);
+
+  return {
+    activeTab,
+    registerTabRef,
+    handleTabClick,
+    handleKeyDown,
+  };
+}


### PR DESCRIPTION
## Summary
Extracts the ARIA/keyboard-navigation and active-tab-state logic out of `Tabs.tsx` into a new `useTabsController` hook, as called for in `Tabs.README.md`. `Tabs.tsx` is now purely presentational — it only wires the hook's returned state/handlers into JSX.

## Context / behavior
- Before: `Tabs.tsx` owned `useState`/`useRef`/`useEffect` for active-tab tracking, click handling, and full keyboard nav (Arrow keys, Home/End, disabled-tab skipping).
- After: all of that logic lives in `frontend/src/hooks/useTabsController.ts`, reusable by other composite components. `Tabs.tsx` renders based on `{ activeTab, registerTabRef, handleTabClick, handleKeyDown }`.
- No visual or behavioral change — controlled/uncontrolled modes, disabled tabs, and orientation-aware key handling are preserved exactly.

## Testing
- Added `frontend/src/hooks/__tests__/useTabsController.test.ts` covering: default/`defaultTab` selection, click handling (incl. disabled + controlled mode), `onChange` callback, and keyboard nav (Arrow keys with wraparound, Home/End, vertical orientation).
- Existing `frontend/src/test/Tabs.test.tsx` suite requires no changes and continues to cover the same DOM/ARIA behavior.
- Manually traced keyboard navigation logic against the existing test cases to confirm parity with pre-refactor behavior (could not run the suite in this environment since installing dependencies was out of scope for this change).

Closes #1258
