### PR TITLE
Refactor: split GroupCard into subcomponents

### DIFF
--- a/frontend/src/components/GroupCard.tsx
+++ b/frontend/src/components/GroupCard.tsx
@@ -5,10 +5,12 @@ import { fetchGroup } from '../utils/groupApi';
 import type { GroupDetail } from '../types/group';
 import { queryKeys } from '../lib/queryKeys';
 import { STALE_TIME } from '../lib/queryClient';
-import { GroupBadge } from './GroupBadge';
-import { Button } from './Button';
 import { GroupCardSkeleton } from './Skeleton/GroupCardSkeleton';
 import { usePrefetchGroup } from '../hooks/useGroup';
+import { GroupCardHeader } from './GroupCardHeader';
+import { GroupCardStats } from './GroupCardStats';
+import { GroupCardActions } from './GroupCardActions';
+import { formatXlm, computeNextPayout } from '../utils/groupCardUtils';
 
 type Status = 'active' | 'completed' | 'pending' | 'complete';
 
@@ -51,33 +53,6 @@ interface GroupCardFetchProps {
 }
 
 export type GroupCardProps = GroupCardStaticProps | GroupCardFetchProps;
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-const STROOPS_PER_XLM = 10_000_000;
-
-function formatXlm(stroops: number): string {
-  return (stroops / STROOPS_PER_XLM).toLocaleString('en-US', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  });
-}
-
-function computeNextPayout(
-  startedAt: Date | null,
-  currentCycle: number,
-  cycleDurationSecs: number,
-): Date | null {
-  if (!startedAt || cycleDurationSecs <= 0) return null;
-  const nextCycleEnd =
-    startedAt.getTime() + (currentCycle + 1) * cycleDurationSecs * 1000;
-  return new Date(nextCycleEnd);
-}
-
-function formatDate(date: Date | null | undefined): string {
-  if (!date) return '—';
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-}
 
 // ─── Inner UI ─────────────────────────────────────────────────────────────────
 
@@ -138,66 +113,19 @@ function GroupCardUI({
 
   const content = (
     <>
-      {imageUrl && (
-        <div className="group-card-image">
-          <img src={imageUrl} alt={groupName} />
-        </div>
-      )}
-
-      <div className="group-card-header">
-        <h3 className="group-card-title">{groupName}</h3>
-        <GroupBadge status={status} />
-      </div>
-
-      {description && (
-        <div className="group-card-description">
-          <p>{description}</p>
-        </div>
-      )}
-
-      <div className="group-card-body">
-        <div className="group-card-stats">
-          <div className="group-card-stat">
-            <span className="group-card-stat-label">Contribution</span>
-            <span className="group-card-stat-value">{contributionAmount}</span>
-          </div>
-          <div className="group-card-stat">
-            <span className="group-card-stat-label">Members</span>
-            <span className="group-card-stat-value">{memberCount}</span>
-          </div>
-          <div className="group-card-stat">
-            <span className="group-card-stat-label">Cycle</span>
-            <span className="group-card-stat-value">{currentCycle}</span>
-          </div>
-          <div className="group-card-stat">
-            <span className="group-card-stat-label">Next Payout</span>
-            <span className="group-card-stat-value group-card-stat-value--date">
-              {formatDate(nextPayoutDate)}
-            </span>
-          </div>
-        </div>
-      </div>
-
-      <div className="group-card-footer">
-        {onViewDetails && (
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={(e) => { e.stopPropagation(); onViewDetails(); }}
-          >
-            View Details
-          </Button>
-        )}
-        {onJoin && (
-          <Button
-            variant="primary"
-            size="sm"
-            onClick={(e) => { e.stopPropagation(); onJoin(); }}
-          >
-            Join Group
-          </Button>
-        )}
-      </div>
+      <GroupCardHeader
+        groupName={groupName}
+        status={status}
+        description={description}
+        imageUrl={imageUrl}
+      />
+      <GroupCardStats
+        contributionAmount={contributionAmount}
+        memberCount={memberCount}
+        currentCycle={currentCycle}
+        nextPayoutDate={nextPayoutDate}
+      />
+      <GroupCardActions onViewDetails={onViewDetails} onJoin={onJoin} />
     </>
   );
 

--- a/frontend/src/components/GroupCardActions.tsx
+++ b/frontend/src/components/GroupCardActions.tsx
@@ -1,0 +1,31 @@
+import { Button } from './Button';
+
+interface GroupCardActionsProps {
+  onViewDetails?: () => void;
+  onJoin?: () => void;
+}
+
+export function GroupCardActions({ onViewDetails, onJoin }: GroupCardActionsProps) {
+  return (
+    <div className="group-card-footer">
+      {onViewDetails && (
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={(e) => { e.stopPropagation(); onViewDetails(); }}
+        >
+          View Details
+        </Button>
+      )}
+      {onJoin && (
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={(e) => { e.stopPropagation(); onJoin(); }}
+        >
+          Join Group
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/GroupCardHeader.tsx
+++ b/frontend/src/components/GroupCardHeader.tsx
@@ -1,0 +1,31 @@
+import { GroupBadge, type GroupBadgeStatus } from './GroupBadge';
+
+interface GroupCardHeaderProps {
+  groupName: string;
+  status: GroupBadgeStatus;
+  description?: string;
+  imageUrl?: string;
+}
+
+export function GroupCardHeader({ groupName, status, description, imageUrl }: GroupCardHeaderProps) {
+  return (
+    <>
+      {imageUrl && (
+        <div className="group-card-image">
+          <img src={imageUrl} alt={groupName} />
+        </div>
+      )}
+
+      <div className="group-card-header">
+        <h3 className="group-card-title">{groupName}</h3>
+        <GroupBadge status={status} />
+      </div>
+
+      {description && (
+        <div className="group-card-description">
+          <p>{description}</p>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/GroupCardStats.tsx
+++ b/frontend/src/components/GroupCardStats.tsx
@@ -1,0 +1,40 @@
+import { formatDate } from '../utils/groupCardUtils';
+
+interface GroupCardStatsProps {
+  contributionAmount: string;
+  memberCount: number;
+  currentCycle: number;
+  nextPayoutDate: Date | null | undefined;
+}
+
+export function GroupCardStats({
+  contributionAmount,
+  memberCount,
+  currentCycle,
+  nextPayoutDate,
+}: GroupCardStatsProps) {
+  return (
+    <div className="group-card-body">
+      <div className="group-card-stats">
+        <div className="group-card-stat">
+          <span className="group-card-stat-label">Contribution</span>
+          <span className="group-card-stat-value">{contributionAmount}</span>
+        </div>
+        <div className="group-card-stat">
+          <span className="group-card-stat-label">Members</span>
+          <span className="group-card-stat-value">{memberCount}</span>
+        </div>
+        <div className="group-card-stat">
+          <span className="group-card-stat-label">Cycle</span>
+          <span className="group-card-stat-value">{currentCycle}</span>
+        </div>
+        <div className="group-card-stat">
+          <span className="group-card-stat-label">Next Payout</span>
+          <span className="group-card-stat-value group-card-stat-value--date">
+            {formatDate(nextPayoutDate)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/test/GroupCardActions.test.tsx
+++ b/frontend/src/test/GroupCardActions.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { GroupCardActions } from '../components/GroupCardActions';
+
+describe('GroupCardActions', () => {
+  it('renders no buttons when no handlers are provided', () => {
+    render(<GroupCardActions />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders and calls onViewDetails', () => {
+    const onViewDetails = vi.fn();
+    render(<GroupCardActions onViewDetails={onViewDetails} />);
+    fireEvent.click(screen.getByRole('button', { name: 'View Details' }));
+    expect(onViewDetails).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders and calls onJoin', () => {
+    const onJoin = vi.fn();
+    render(<GroupCardActions onJoin={onJoin} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Join Group' }));
+    expect(onJoin).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders both buttons together', () => {
+    render(<GroupCardActions onViewDetails={vi.fn()} onJoin={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'View Details' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Join Group' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/GroupCardHeader.test.tsx
+++ b/frontend/src/test/GroupCardHeader.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GroupCardHeader } from '../components/GroupCardHeader';
+
+describe('GroupCardHeader', () => {
+  it('renders the group name and status badge', () => {
+    render(<GroupCardHeader groupName="Alpha Savers" status="active" />);
+    expect(screen.getByText('Alpha Savers')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  it('renders description when provided', () => {
+    render(<GroupCardHeader groupName="Alpha Savers" status="active" description="A great group" />);
+    expect(screen.getByText('A great group')).toBeInTheDocument();
+  });
+
+  it('does not render a description block when none is provided', () => {
+    const { container } = render(<GroupCardHeader groupName="Alpha Savers" status="active" />);
+    expect(container.querySelector('.group-card-description')).toBeNull();
+  });
+
+  it('renders the image when imageUrl is provided', () => {
+    render(<GroupCardHeader groupName="Alpha Savers" status="active" imageUrl="https://example.com/a.png" />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('src', 'https://example.com/a.png');
+    expect(img).toHaveAttribute('alt', 'Alpha Savers');
+  });
+
+  it('does not render an image when imageUrl is not provided', () => {
+    render(<GroupCardHeader groupName="Alpha Savers" status="active" />);
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/GroupCardStats.test.tsx
+++ b/frontend/src/test/GroupCardStats.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GroupCardStats } from '../components/GroupCardStats';
+
+describe('GroupCardStats', () => {
+  it('renders contribution amount, member count, and cycle', () => {
+    render(
+      <GroupCardStats
+        contributionAmount="100 XLM"
+        memberCount={8}
+        currentCycle={3}
+        nextPayoutDate={undefined}
+      />
+    );
+    expect(screen.getByText('100 XLM')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('formats the next payout date when provided', () => {
+    render(
+      <GroupCardStats
+        contributionAmount="100 XLM"
+        memberCount={8}
+        currentCycle={3}
+        nextPayoutDate={new Date('2026-08-01')}
+      />
+    );
+    expect(screen.getByText('Aug 1, 2026')).toBeInTheDocument();
+  });
+
+  it('shows an em dash when no next payout date is provided', () => {
+    render(
+      <GroupCardStats
+        contributionAmount="100 XLM"
+        memberCount={8}
+        currentCycle={3}
+        nextPayoutDate={null}
+      />
+    );
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/utils/groupCardUtils.test.ts
+++ b/frontend/src/utils/groupCardUtils.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { formatXlm, computeNextPayout, formatDate } from './groupCardUtils';
+
+describe('formatXlm', () => {
+  it('converts stroops to XLM', () => {
+    expect(formatXlm(10_000_000)).toBe('1');
+  });
+
+  it('formats fractional XLM with up to 2 decimal places', () => {
+    expect(formatXlm(1_234_567)).toBe('0.12');
+  });
+
+  it('formats zero', () => {
+    expect(formatXlm(0)).toBe('0');
+  });
+});
+
+describe('computeNextPayout', () => {
+  it('returns null when startedAt is null', () => {
+    expect(computeNextPayout(null, 0, 86400)).toBeNull();
+  });
+
+  it('returns null when cycleDurationSecs is not positive', () => {
+    expect(computeNextPayout(new Date('2026-01-01'), 0, 0)).toBeNull();
+  });
+
+  it('computes the next payout date from cycle duration', () => {
+    const started = new Date('2026-01-01T00:00:00Z');
+    const result = computeNextPayout(started, 0, 86400);
+    expect(result).toEqual(new Date('2026-01-02T00:00:00Z'));
+  });
+
+  it('accounts for the current cycle offset', () => {
+    const started = new Date('2026-01-01T00:00:00Z');
+    const result = computeNextPayout(started, 2, 86400);
+    expect(result).toEqual(new Date('2026-01-04T00:00:00Z'));
+  });
+});
+
+describe('formatDate', () => {
+  it('returns an em dash for null', () => {
+    expect(formatDate(null)).toBe('—');
+  });
+
+  it('returns an em dash for undefined', () => {
+    expect(formatDate(undefined)).toBe('—');
+  });
+
+  it('formats a date as "Mon D, YYYY"', () => {
+    expect(formatDate(new Date('2026-08-01'))).toBe('Aug 1, 2026');
+  });
+});

--- a/frontend/src/utils/groupCardUtils.ts
+++ b/frontend/src/utils/groupCardUtils.ts
@@ -1,0 +1,24 @@
+const STROOPS_PER_XLM = 10_000_000;
+
+export function formatXlm(stroops: number): string {
+  return (stroops / STROOPS_PER_XLM).toLocaleString('en-US', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  });
+}
+
+export function computeNextPayout(
+  startedAt: Date | null,
+  currentCycle: number,
+  cycleDurationSecs: number,
+): Date | null {
+  if (!startedAt || cycleDurationSecs <= 0) return null;
+  const nextCycleEnd =
+    startedAt.getTime() + (currentCycle + 1) * cycleDurationSecs * 1000;
+  return new Date(nextCycleEnd);
+}
+
+export function formatDate(date: Date | null | undefined): string {
+  if (!date) return '—';
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}


### PR DESCRIPTION
## Summary
Splits `GroupCard.tsx`'s presentation into three focused subcomponents — `GroupCardHeader`, `GroupCardStats`, `GroupCardActions` — and moves formatting/date-math helpers into `frontend/src/utils/groupCardUtils.ts`, per the component's own README call to make it easier to test in isolation.

Note: the plain names `GroupHeader`/`GroupStats` were already taken by an unrelated existing component (`frontend/src/components/GroupStats.tsx`, a totals/progress card), so the new subcomponents are named `GroupCardHeader`, `GroupCardStats`, `GroupCardActions` to avoid a collision.

## Context / behavior
- Before: `GroupCardUI` (the internal presentational component used by both static and fetch modes of `GroupCard`) inlined the image/title/badge/description markup, the four-stat grid, and the footer buttons, plus three free-standing helper functions (`formatXlm`, `computeNextPayout`, `formatDate`).
- After: `GroupCardUI` composes `<GroupCardHeader>`, `<GroupCardStats>`, `<GroupCardActions>`; the helpers live in `groupCardUtils.ts` and are imported by `GroupCard.tsx` and `GroupCardStats.tsx`.
- `GroupCard`'s public export and props are unchanged, so no other call sites (`BrowseGroupsPage.tsx`, etc.) needed import updates — they only ever imported `GroupCard`/`GroupCardSkeleton`, not the internal `GroupCardUI`.
- Rendered DOM/classNames are identical to before (same wrapper divs/classes), so no visual change.

## Testing
- Added unit tests: `groupCardUtils.test.ts` (formatXlm, computeNextPayout, formatDate), `GroupCardHeader.test.tsx`, `GroupCardStats.test.tsx`, `GroupCardActions.test.tsx`.
- Manually traced the existing `frontend/src/test/GroupCard.test.tsx` suite (static + fetch mode, buttons, badges, image/description rendering) against the refactored composition to confirm no regressions — could not execute the suite directly in this environment since installing dependencies was out of scope for this change.

Closes #1256
